### PR TITLE
Simplify monitor nightly script / add longer timeout

### DIFF
--- a/scripts/monitor_ci.sh
+++ b/scripts/monitor_ci.sh
@@ -5,22 +5,15 @@
 # Install E2E test
 git clone https://github.com/cgewecke/metacoin-source-verify.git
 cd metacoin-source-verify
-cp ../environments/.env .env
-npm install
+yarn
 
 # Publishes sources to IPFS (via Infura) and deploys contracts to Goerli
 # Account key and Infura project ID are Circle CI env variable settings.
 npm run deploy:goerli
 
+# Give monitor a chance to detect and save.
+sleep 300
+
+# Script which verifies repository write
 cd ..
-for i in `seq 1 10`
-do
-    # Give monitor a chance to detect and save.
-    sleep 30
-    # Script which verifies repository write
-    result=$(./scripts/monitor_ci.js)
-    if [[ $result != *"Error"* ]]; then
-        echo $result
-        break
-    fi
-done
+./scripts/monitor_ci.js


### PR DESCRIPTION
Monitor E2E CI has [been failing][1] during its contract deployment step in a way that suggests it's not able to read the `INFURA_ID` env variable. The logic that checked the repo in a loop has been swallowing the error.

Reverting a bit here to the original version to see if we can get it working again...

I've restored `INFURA_ID` to the CI settings for the moment.

[1]: https://app.circleci.com/pipelines/github/ethereum/sourcify/469/workflows/28a97ebb-1da3-4a29-abfa-9587ac98ffd7/jobs/1862