### PR TITLE
original metadata name preserved

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -8,7 +8,7 @@ import fs from 'fs'
 // tslint:disable no-commented-code
 // import { findAddresses } from './address-db';
 
-const multihashes : any = require('multihashes');
+const multihashes: any = require('multihashes');
 
 import {
   cborDecode,
@@ -19,7 +19,8 @@ import {
   InputData,
   Match,
   getChainByName,
-  save
+  save,
+  FileObject
 } from './utils';
 
 import {
@@ -31,17 +32,17 @@ declare interface StringMap {
 }
 
 export interface InjectorConfig {
-  infuraPID? : string,
-  localChainUrl? : string,
-  silent? : boolean,
-  log? : Logger,
+  infuraPID?: string,
+  localChainUrl?: string,
+  silent?: boolean,
+  log?: Logger,
   offline?: boolean
 }
 
 export default class Injector {
-  private log : Logger;
-  private chains : any;
-  private infuraPID : string;
+  private log: Logger;
+  private chains: any;
+  private infuraPID: string;
   private localChainUrl: string | undefined;
   private offline: boolean;
 
@@ -49,7 +50,7 @@ export default class Injector {
    * Constructor
    * @param {InjectorConfig = {}} config
    */
-  public constructor(config : InjectorConfig = {}){
+  public constructor(config: InjectorConfig = {}) {
     this.chains = {};
     this.infuraPID = config.infuraPID || "changeinfuraid";
     this.localChainUrl = config.localChainUrl;
@@ -63,7 +64,7 @@ export default class Injector {
       }]
     });
 
-    if (!this.offline){
+    if (!this.offline) {
       this.initChains();
     }
   }
@@ -72,8 +73,8 @@ export default class Injector {
    * Instantiates a web3 provider for all public ethereum networks via Infura.
    * If environment variable TESTING is set to true, localhost:8545 is also available.
    */
-  private initChains(){
-    for (const chain of ['mainnet', 'ropsten', 'rinkeby', 'kovan', 'goerli']){
+  private initChains() {
+    for (const chain of ['mainnet', 'ropsten', 'rinkeby', 'kovan', 'goerli']) {
       const chainOption = getChainByName(chain);
       this.chains[chainOption.chainId] = {};
       const web3 = chainOption.web3[0].replace('${INFURA_ID}', this.infuraPID);
@@ -81,7 +82,7 @@ export default class Injector {
     }
 
     // For unit testing with testrpc...
-    if (this.localChainUrl){
+    if (this.localChainUrl) {
       const chainOption = getChainByName('localhost');
       this.chains[chainOption.chainId] = {
         web3: new Web3(chainOption.web3[0])
@@ -94,25 +95,25 @@ export default class Injector {
    * @param  {string[]} files
    * @return {string[]}         metadata
    */
-  private findMetadataFiles(files: string[]) : any[] {
+  private findMetadataFiles(files: any[]): any[] {
     const metadataFiles = [];
 
     for (const i in files) {
       try {
-        const m = JSON.parse(files[i])
+        const m = JSON.parse(files[i].content)
 
         // TODO: this might need a stronger validation check.
         //       many assumptions are made about structure of
         //       metadata object after this selection step.
         if (m['language'] === 'Solidity') {
-          metadataFiles.push(m);
+          metadataFiles.push({ name: files[i].name, content: m });
         }
       } catch (err) { /* ignore */ }
     }
 
-    if(!metadataFiles.length){
+    if (!metadataFiles.length) {
       const err = new Error("Metadata file not found. Did you include \"metadata.json\"?");
-      this.log.info({loc:'[FIND]', err: err});
+      this.log.info({ loc: '[FIND]', err: err });
       throw err;
     }
 
@@ -124,11 +125,11 @@ export default class Injector {
    * @param  {string[]}  files sources
    * @return {StringMap}
    */
-  private storeByHash(files: string[]) : StringMap {
-    const byHash: StringMap = {};
+  private storeByHash(files: any[]): StringMap {
+    const byHash: any = {};
 
     for (const i in files) {
-      byHash[Web3.utils.keccak256(files[i])] = files[i]
+      byHash[Web3.utils.keccak256(files[i].content)] = files[i]
     }
     return byHash;
   }
@@ -140,19 +141,19 @@ export default class Injector {
    * @param  {string[]}  files    source files
    * @return {StringMap}
    */
-  private rearrangeSources(metadata : any, files: string[]) : StringMap {
+  private rearrangeSources(metadata: any, files: FileObject[]): StringMap {
     const sources: StringMap = {}
     const byHash = this.storeByHash(files);
 
-    for (const fileName in metadata.sources) {
-      let content: string = metadata.sources[fileName].content;
-      const hash: string = metadata.sources[fileName].keccak256;
-      if(content) {
-          if (Web3.utils.keccak256(content) != hash) {
-              const err = new Error(`Invalid content for file ${fileName}`);
-              this.log.info({ loc: '[REARRANGE]', fileName: fileName, err: err});
-              throw err;
-          }
+    for (const fileName in metadata.content.sources) {
+      let content: any = metadata.content.sources[fileName].content;
+      const hash: string = metadata.content.sources[fileName].keccak256;
+      if (content) {
+        if (Web3.utils.keccak256(content) != hash) {
+          const err = new Error(`Invalid content for file ${fileName}`);
+          this.log.info({ loc: '[REARRANGE]', fileName: fileName, err: err });
+          throw err;
+        }
       } else {
         content = byHash[hash];
       }
@@ -162,17 +163,17 @@ export default class Injector {
           `that cannot be found in your upload.\nIts keccak256 hash is ${hash}. ` +
           `Please try to find it and include it in the upload.`
         );
-        this.log.info({loc: '[REARRANGE]', fileName: fileName, err: err});
+        this.log.info({ loc: '[REARRANGE]', fileName: fileName, err: err });
         throw err;
       }
-      sources[fileName] = content;
+      sources[fileName] = content.content || content;
     }
     return sources
   }
 
   private getIdFromChainName(chain: string): number {
-    for(const chainOption in chainOptions) {
-      if(chainOptions[chainOption].network === chain){
+    for (const chainOption in chainOptions) {
+      if (chainOptions[chainOption].network === chain) {
         return chainOptions[chainOption].chainId;
       }
     }
@@ -190,13 +191,14 @@ export default class Injector {
    */
   private storePerfectMatchData(
     repository: string,
-    chain : string,
-    address : string,
-    compilationResult : RecompilationResult,
-    sources: StringMap
-  ) : void {
+    chain: string,
+    address: string,
+    compilationResult: RecompilationResult,
+    sources: StringMap,
+    metadataFileName: string
+  ): void {
 
-    let metadataPath : string;
+    let metadataPath: string;
     const bytes = Web3.utils.hexToBytes(compilationResult.deployedBytecode);
     const cborData = cborDecode(bytes);
 
@@ -212,7 +214,7 @@ export default class Injector {
       );
 
       this.log.info({
-        loc:'[STOREDATA]',
+        loc: '[STOREDATA]',
         address: address,
         chain: chain,
         err: err
@@ -223,12 +225,12 @@ export default class Injector {
 
     const hashPath = path.join(repository, metadataPath);
     const addressPath = path.join(
-        repository,
-        'contracts',
-        'full_match',
-        chain,
-        address,
-        '/metadata.json'
+      repository,
+      'contracts',
+      'full_match',
+      chain,
+      address,
+      metadataFileName
     );
 
     save(hashPath, compilationResult.metadata);
@@ -266,11 +268,12 @@ export default class Injector {
    */
   private storePartialMatchData(
     repository: string,
-    chain : string,
-    address : string,
-    compilationResult : RecompilationResult,
-    sources: StringMap
-  ) : void {
+    chain: string,
+    address: string,
+    compilationResult: RecompilationResult,
+    sources: StringMap,
+    metadataFileName: string
+  ): void {
 
     const addressPath = path.join(
       repository,
@@ -278,7 +281,7 @@ export default class Injector {
       'partial_matches',
       chain,
       address,
-      '/metadata.json'
+      metadataFileName
     );
 
     save(addressPath, compilationResult.metadata);
@@ -313,13 +316,13 @@ export default class Injector {
     chain: string,
     addresses: string[] = [],
     compiledBytecode: string
-  ) : Promise<Match> {
-    let match : Match = { address: null, status: null };
+  ): Promise<Match> {
+    let match: Match = { address: null, status: null };
 
-    for (let address of addresses){
+    for (let address of addresses) {
       address = Web3.utils.toChecksumAddress(address)
 
-      let deployedBytecode : string | null = null;
+      let deployedBytecode: string | null = null;
       try {
         this.log.info(
           {
@@ -330,11 +333,11 @@ export default class Injector {
           `Retrieving contract bytecode address`
         );
         deployedBytecode = await getBytecode(this.chains[chain].web3, address)
-      } catch(e){ /* ignore */ }
+      } catch (e) { /* ignore */ }
 
       const status = this.compareBytecodes(deployedBytecode, compiledBytecode);
 
-      if (status){
+      if (status) {
         match = { address: address, status: status };
         break;
       }
@@ -353,14 +356,14 @@ export default class Injector {
   private compareBytecodes(
     deployedBytecode: string | null,
     compiledBytecode: string
-  ) : 'perfect' | 'partial' | null {
+  ): 'perfect' | 'partial' | null {
 
-    if (deployedBytecode && deployedBytecode.length > 2){
-      if (deployedBytecode === compiledBytecode){
+    if (deployedBytecode && deployedBytecode.length > 2) {
+      if (deployedBytecode === compiledBytecode) {
         return 'perfect';
       }
 
-      if (trimMetadata(deployedBytecode) === trimMetadata(compiledBytecode)){
+      if (trimMetadata(deployedBytecode) === trimMetadata(compiledBytecode)) {
         return 'partial';
       }
     }
@@ -371,14 +374,14 @@ export default class Injector {
    * Throws if addresses array contains a null value (express) or is length 0
    * @param {string[] = []} addresses param (submitted to injector)
    */
-  private validateAddresses(addresses: string[] = []){
+  private validateAddresses(addresses: string[] = []) {
     const err = new Error("Missing address for submitted sources/metadata");
 
-    if (!addresses.length){
+    if (!addresses.length) {
       throw err;
     }
 
-    for (const address of addresses ){
+    for (const address of addresses) {
       if (address == null) throw err;
     }
   }
@@ -387,10 +390,10 @@ export default class Injector {
    * Throws if `chain` is falsy or wrong type
    * @param {string} chain param (submitted to injector)
    */
-  private validateChain(chain: string){
+  private validateChain(chain: string) {
     const err = new Error("Missing chain name for submitted sources/metadata");
 
-    if (!chain || typeof chain !== 'string'){
+    if (!chain || typeof chain !== 'string') {
       throw err;
     }
   }
@@ -407,7 +410,7 @@ export default class Injector {
    */
   public async inject(
     inputData: InputData
-  ) : Promise<Match> {
+  ): Promise<Match> {
     const { repository, chain, addresses, files } = inputData;
     this.validateAddresses(addresses);
     this.validateChain(chain);
@@ -419,24 +422,24 @@ export default class Injector {
       status: null
     };
 
-    for (const metadata of metadataFiles){
+    for (const metadata of metadataFiles) {
       const sources = this.rearrangeSources(metadata, files)
 
       // Starting from here, we cannot trust the metadata object anymore,
       // because it is modified inside recompile.
-      const target = Object.assign({}, metadata.settings.compilationTarget);
+      const target = Object.assign({}, metadata.content.settings.compilationTarget);
 
-      let compilationResult : RecompilationResult;
+      let compilationResult: RecompilationResult;
       try {
-        compilationResult = await recompile(metadata, sources, this.log)
-      } catch(err) {
-        this.log.info({loc: `[RECOMPILE]`, err: err});
+        compilationResult = await recompile(metadata.content, sources, this.log)
+      } catch (err) {
+        this.log.info({ loc: `[RECOMPILE]`, err: err });
         throw err;
       }
 
       // When injector is called by monitor, the bytecode has already been
       // obtained for address and we only need to compare w/ compilation result.
-      if (inputData.bytecode){
+      if (inputData.bytecode) {
 
         const status = this.compareBytecodes(
           inputData.bytecode,
@@ -448,8 +451,8 @@ export default class Injector {
           status: status
         }
 
-      // For other cases, we need to retrieve the code for specified address
-      // from the chain.
+        // For other cases, we need to retrieve the code for specified address
+        // from the chain.
       } else {
         match = await this.matchBytecodeToAddress(
           chain,
@@ -464,11 +467,11 @@ export default class Injector {
       // and the sources.
       if (match.address && match.status === 'perfect') {
 
-        this.storePerfectMatchData(repository, chain, match.address, compilationResult, sources)
+        this.storePerfectMatchData(repository, chain, match.address, compilationResult, sources, metadataFiles[0].name)
 
-      } else if (match.address && match.status === 'partial'){
+      } else if (match.address && match.status === 'partial') {
 
-        this.storePartialMatchData(repository, chain, match.address, compilationResult, sources)
+        this.storePartialMatchData(repository, chain, match.address, compilationResult, sources, metadataFiles[0].name)
 
       } else {
         const err = new Error(

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -668,6 +668,15 @@ export default class Monitor {
     // Also save ipfs and swarm hashes.
     if (Object.keys(queueItem.sources).length == 0) {
 
+      for (const i in queueItem.found.files) {
+        try {
+          JSON.parse(queueItem.found.files[i]);
+          queueItem.found.files[i] = {name: "metadata.json", content: queueItem.found.files[i]}
+        } catch (error) {
+          queueItem.found.files[i] = {name: "Source.sol", content: queueItem.found.files[i]}
+        }
+      }
+
       const data: InputData = {
         repository: this.repository,
         chain: getChainByName(chain).chainId.toString(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,13 +90,13 @@ app.post('/', (req, res, next) => {
   }
 
   try {
-    const files = findInputFiles(req.files);
-    if(files !== undefined) inputData.files = files;
-  } catch(err){
+    const files: FileObject[] = findInputFiles(req.files);
+    if (files !== undefined) inputData.files = files;
+  } catch (err) {
     // Just ignore error if no files have been found
   }
 
-  try{
+  try {
     Promise.all(verify(inputData, injector)).then((result) => {
       res.status(200).send({
         result
@@ -114,13 +114,13 @@ app.get('/checkByAddresses', (req: any, res) => {
   let resultArray: Array<Object> = [];
   const map: Map<string, Object> = new Map();
   req.query.addresses.split(',').forEach((address: string) => {
-    for(const chainId of req.query.chainIds.split(',')) {
+    for (const chainId of req.query.chainIds.split(',')) {
       try {
         const object: any = findByAddress(address, chainId, repository)[0];
         object.chainId = chainId;
         map.set(address, object);
         break;
-      } catch (error) {}
+      } catch (error) { }
     };
     if (!map.has(address)) {
       map.set(address, {

--- a/src/sourcify.ts
+++ b/src/sourcify.ts
@@ -19,10 +19,10 @@ dotenv.config({ path: path.resolve(__dirname, "..", "environments/.env") });
 clear();
 console.log(
   chalk.red(
-    figlet.textSync('sourcify cli', { 
-        horizontalLayout: 'default',
-        font: 'Banner',
-     }),
+    figlet.textSync('sourcify cli', {
+      horizontalLayout: 'default',
+      font: 'Banner',
+    }),
   ),
 );
 console.log("Use this for local verification only!")
@@ -49,25 +49,26 @@ interface Arguments {
 }
 
 const argv: Arguments = yargs.options({
-  files: {type: 'array', alias: 'f', description: 'Paths to the files or folders with files you want to verify'},
-  chain: {type: 'string', alias: 'c', demand: true},
-  address: {type: 'string', alias: 'a', demand: true},
-  repository: {type: 'string', alias: 'r', description: 'Path to the directory with verified contracts'},
-  infura: {type: 'string', alias: 'id', description: 'Provide your own Infura project ID'}
+  files: { type: 'array', alias: 'f', description: 'Paths to the files or folders with files you want to verify' },
+  chain: { type: 'string', alias: 'c', demand: true },
+  address: { type: 'string', alias: 'a', demand: true },
+  repository: { type: 'string', alias: 'r', description: 'Path to the directory with verified contracts' },
+  infura: { type: 'string', alias: 'id', description: 'Provide your own Infura project ID' }
 }).argv;
 
-if (argv.chain){
-  inputData.chain = argv.chain;    
+if (argv.chain) {
+  inputData.chain = argv.chain;
 }
 
-if (argv.address){
+if (argv.address) {
   inputData.addresses.push(argv.address);
 }
 
 if (argv.files) {
-  for(const file in argv.files){
-      const readFile = fs.readFileSync(path.resolve(argv.files[file].toString()));
-      inputData.files.push(readFile);
+  for (const file in argv.files) {
+    const filePath: string = path.resolve(argv.files[file].toString());
+    const readFile: Buffer = fs.readFileSync(filePath);
+    inputData.files.push({ name: filePath.substring(filePath.lastIndexOf("/") + 1), content: readFile.toString() });
   }
 }
 
@@ -80,25 +81,25 @@ if (!argv.infura && !process.env.INFURA_ID) {
 }
 
 export const log = Logger.createLogger({
-    name: "CLI",
-    streams: [{
-      stream: process.stdout,
-      level: 30
-    }]
-  });
+  name: "CLI",
+  streams: [{
+    stream: process.stdout,
+    level: 30
+  }]
+});
 
 const injector = new Injector({
-    localChainUrl: localChainUrl,
-    log: log,
-    infuraPID: argv.infura || process.env.INFURA_ID
+  localChainUrl: localChainUrl,
+  log: log,
+  infuraPID: argv.infura || process.env.INFURA_ID
 });
-  try{
-    Promise.all(verify(inputData, injector)).then((result) => {
-      console.log("Contract successfully verified!")
-      console.log(result);
-    }).catch(err => {
-      console.log(err.message)
-    });
-  } catch (err) {
-   console.log(err.message);
+try {
+  Promise.all(verify(inputData, injector)).then((result) => {
+    console.log("Contract successfully verified!")
+    console.log(result);
+  }).catch(err => {
+    console.log(err.message)
+  });
+} catch (err) {
+  console.log(err.message);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ export const log = Logger.createLogger({
     level: 30
   }]
 });
- 
+
 declare interface StringMap {
   [key: string]: string;
 }
@@ -111,13 +111,13 @@ function reformatMetadata(
 
   if (contractName == '') {
     const err = new Error("Could not determine compilation target from metadata.");
-    log.info({loc: '[REFORMAT]', err: err});
+    log.info({ loc: '[REFORMAT]', err: err });
     throw err;
   }
 
   input['sources'] = {}
   for (const source in sources) {
-    input.sources[source] = {'content': sources[source]}
+    input.sources[source] = { 'content': sources[source] }
   }
 
   input.language = metadata.language
@@ -189,7 +189,7 @@ export type InputData = {
   repository: string
   chain: string,
   addresses: string[],
-  files?: any[],
+  files?: FileObject[],
   bytecode?: string
 }
 
@@ -200,47 +200,47 @@ export function findInputFiles(files: any): any {
 
     // Case: <UploadedFile[]>
     if (Array.isArray(files.files)) {
-      files.files.forEach((file: { data: any; }) => {
-        inputs.push(file.data)
+      files.files.forEach((file: any) => {
+        inputs.push({ name: file.name, content: file.data })
       })
       return inputs;
 
       // Case: <UploadedFile>
     } else if (files.files["data"]) {
-      inputs.push(files.files["data"]);
+      inputs.push({ name: files.files.name, content: files.files["data"] });
       return inputs;
     }
 
     // Case: default
     const msg = `Invalid file(s) detected: ${util.inspect(files.files)}`;
-    log.info({loc: '[POST:INVALID_FILE]'}, msg);
+    log.info({ loc: '[POST:INVALID_FILE]' }, msg);
     throw new BadRequest(msg);
   }
 
 }
 
-export function sanitizeInputFiles(inputs: any): string[] {
-  const files = [];
+export function sanitizeInputFiles(inputs: any): FileObject[] {
+  const files: FileObject[] = [];
   if (!inputs.length) {
     const msg = 'Unable to extract any files. Your request may be misformatted ' +
-                'or missing some contents.';
+      'or missing some contents.';
 
     const err = new Error(msg);
-    log.info({loc: '[POST:NO_FILES]', err: err})
+    log.info({ loc: '[POST:NO_FILES]', err: err })
     throw new BadRequest(msg)
   }
 
-  for (const data of inputs) {
+  for (const file of inputs) {
     try {
-      const val = JSON.parse(data.toString());
+      const val = JSON.parse(file.content.toString());
       const type = Object.prototype.toString.call(val);
 
       (type === '[object Object]')
-        ? files.push(JSON.stringify(val))  // JSON formatted metadata
-        : files.push(val);                 // Stringified metadata
+        ? files.push({ name: file.name, content: JSON.stringify(val) })  // JSON formatted metadata
+        : files.push({ name: file.name, content: val });                 // Stringified metadata
 
     } catch (err) {
-      files.push(data.toString())          // Solidity files
+      files.push({ name: file.name, content: file.content.toString() })          // Solidity files
     }
 
   }
@@ -254,12 +254,16 @@ export function sanitizeInputFiles(inputs: any): string[] {
  * @param repository
  */
 export function findByAddress(address: string, chain: string, repository: string): Match[] {
-  const addressPath = `${repository}/contracts/full_match/${chain}/${address}/metadata.json`;
+  const addressPath = `${repository}/contracts/full_match/${chain}/${address}/`;
   const normalizedPath = path.join('./', addressPath);
 
   try {
-    fs.readFileSync(normalizedPath);
-  } catch(e){
+    const contractDirectory = fs.readdirSync(normalizedPath);
+    const jsonFile = contractDirectory
+      .filter(file => file.endsWith('.json'))
+      .map(file => path.resolve(__dirname, file))
+    fs.readFileSync(path.join('./', normalizedPath, jsonFile[0].substring(jsonFile[0].lastIndexOf("/") + 1)));
+  } catch (e) {
     throw new Error("Address not found in repository");
   }
 
@@ -271,7 +275,7 @@ export function findByAddress(address: string, chain: string, repository: string
 
 export type FileObject = {
   name: string,
-  path: string
+  path?: string
   content?: string
 }
 
@@ -285,41 +289,41 @@ export function fetchAllFileUrls(chain: string, address: string): Array<string> 
   return urls;
 }
 
-export function fetchAllFilePaths(chain: string, address: string): Array<FileObject>{
+export function fetchAllFilePaths(chain: string, address: string): Array<FileObject> {
   const fullPath: string = path.resolve(__dirname, `../repository/contract/${chain}/${address}/`);
   const files: Array<FileObject> = [];
   dirTree(fullPath, {}, (item) => {
-    files.push({"name": item.name, "path": item.path});
+    files.push({ "name": item.name, "path": item.path });
   });
   return files;
 }
 
-export function fetchAllFileContents(chain: string, address: string): Array<FileObject>{
+export function fetchAllFileContents(chain: string, address: string): Array<FileObject> {
   const files = fetchAllFilePaths(chain, address);
-    for(const file in files){
-      const loadedFile = fs.readFileSync(files[file].path)
-      files[file].content = loadedFile.toString();
-    }
+  for (const file in files) {
+    const loadedFile = fs.readFileSync(files[file].path)
+    files[file].content = loadedFile.toString();
+  }
 
-    return files;
+  return files;
 }
 
 export function getChainId(chain: string): string {
-  for(const chainOption in chainOptions){
-      const network = chainOptions[chainOption].network;
-      const chainId = chainOptions[chainOption].chainId;
-      if( (network && network.toLowerCase() === chain) || String(chainId) === chain){
-        return String(chainOptions[chainOption].chainId);
-      }
+  for (const chainOption in chainOptions) {
+    const network = chainOptions[chainOption].network;
+    const chainId = chainOptions[chainOption].chainId;
+    if ((network && network.toLowerCase() === chain) || String(chainId) === chain) {
+      return String(chainOptions[chainOption].chainId);
     }
+  }
 
   throw new NotFound(`Chain ${chain} not supported!`);
 }
 
 export function getChainByName(name: string): any {
-  for(const chainOption in chainOptions) {
+  for (const chainOption in chainOptions) {
     const network = chainOptions[chainOption].network;
-    if(network && network.toLowerCase() === name){
+    if (network && network.toLowerCase() === name) {
       return chainOptions[chainOption];
     }
   }
@@ -350,7 +354,7 @@ type Tag = {
  * Update repository tag
  */
 export function updateRepositoryTag(repositoryPath?: string) {
-  if(repositoryPath !== undefined) {
+  if (repositoryPath !== undefined) {
     repository = repositoryPath;
   }
   const filePath: string = path.join(repository, 'manifest.json')
@@ -365,27 +369,27 @@ export function updateRepositoryTag(repositoryPath?: string) {
 
 //------------------------------------------------------------------------------------------------------
 
-export function verify(inputData: InputData, injector: Injector): any{
+export function verify(inputData: InputData, injector: Injector): any {
   console.log(process.cwd());
   // Try to find by address, return on success.
   try {
     return findByAddress(inputData.addresses[0], inputData.chain, inputData.repository);
-  } catch(err) {
+  } catch (err) {
     const msg = "Could not find file in repository, proceeding to recompilation"
-    log.info({loc:'[POST:VERIFICATION_BY_ADDRESS_FAILED]'}, msg);
+    log.info({ loc: '[POST:VERIFICATION_BY_ADDRESS_FAILED]' }, msg);
   }
 
-  if(inputData.files.length === 0){
+  if (inputData.files.length === 0) {
     // If we reach this point, an address has been submitted and searched for
     // but there are no files associated with the request.
     const msg = 'Address for specified chain not found in repository';
-    log.info({loc: '[POST:ADDRESS_NOT_FOUND]', err: msg})
+    log.info({ loc: '[POST:ADDRESS_NOT_FOUND]', err: msg })
     throw new NotFound(msg);
   }
 
   // Try to organize files for submission, exit on error.
   inputData.files = sanitizeInputFiles(inputData.files);
-  
+
   // Injection
   const promises: Promise<Match>[] = [];
   promises.push(injector.inject(inputData));

--- a/test/injector.js
+++ b/test/injector.js
@@ -1,4 +1,4 @@
-process.env.MOCK_REPOSITORY='./mockRepository';
+process.env.MOCK_REPOSITORY = './mockRepository';
 
 const assert = require('assert');
 const ganache = require('ganache-cli');
@@ -25,8 +25,8 @@ const {
 const Injector = require('../src/injector').default;
 const getChainId = require('../src/utils').getChainId;
 
-describe('injector', function(){
-  describe('inject', function(){
+describe('injector', function () {
+  describe('inject', function () {
     this.timeout(25000);
 
     let server;
@@ -47,44 +47,44 @@ describe('injector', function(){
     const simpleWithImportMetadata = SimpleWithImport.compilerOutput.metadata;
     const literalMetadata = Literal.compilerOutput.metadata;
 
-    before(async function(){
-      server = ganache.server({chainId: chainId});
+    before(async function () {
+      server = ganache.server({ chainId: chainId });
       await pify(server.listen)(port);
       web3 = new Web3(`http://${chain}:${port}`);
     })
 
-    beforeEach(async function(){
+    beforeEach(async function () {
       simpleInstance = await deployFromArtifact(web3, Simple);
       simpleWithImportInstance = await deployFromArtifact(web3, SimpleWithImport);
       literalInstance = await deployFromArtifact(web3, Literal);
-      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
+      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true });
     })
 
-    beforeEach(async function(){
+    beforeEach(async function () {
       simpleInstance = await deployFromArtifact(web3, Simple);
       simpleWithImportInstance = await deployFromArtifact(web3, SimpleWithImport);
       literalInstance = await deployFromArtifact(web3, Literal);
-      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
+      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true });
     })
 
-    beforeEach(async function(){
+    beforeEach(async function () {
       simpleInstance = await deployFromArtifact(web3, Simple);
       simpleWithImportInstance = await deployFromArtifact(web3, SimpleWithImport);
       literalInstance = await deployFromArtifact(web3, Literal);
-      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
+      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true });
     })
 
     // Clean up repository
-    afterEach(function(){
-      try { exec(`rm -rf ${mockRepo}`) } catch(err) { /*ignore*/ }
+    afterEach(function () {
+      try { exec(`rm -rf ${mockRepo}`) } catch (err) { /*ignore*/ }
     })
 
     // Clean up server
-    after(async function(){
+    after(async function () {
       await pify(server.close)();
     });
 
-    it('verifies sources from multiple metadatas, addresses & stores by IPFS hash', async function(){
+    it('verifies sources from multiple metadatas, addresses & stores by IPFS hash', async function () {
       // Inject by address into repository after recompiling
       const inputData = {
         repository: mockRepo,
@@ -94,11 +94,11 @@ describe('injector', function(){
           simpleWithImportInstance.options.address
         ],
         files: [
-          simpleSource,
-          simpleWithImportSource,
-          importSource,
-          simpleMetadata,
-          simpleWithImportMetadata
+          { name: "Simple.sol", content: simpleSource },
+          { name: "SimpleWithImport.sol", content: simpleWithImportSource },
+          { name: "Import.sol", content: importSource },
+          { name: "simple.json", content: simpleMetadata },
+          { name: "simpleWithImport.json", content: simpleWithImportMetadata }
         ]
       };
 
@@ -115,13 +115,13 @@ describe('injector', function(){
       assert.equal(simpleWithImportSavedMetadata, simpleWithImportMetadata);
     });
 
-    it('verfies a metadata with embedded source code (--metadata-literal)', async function(){
+    it('verfies a metadata with embedded source code (--metadata-literal)', async function () {
       // Inject by address into repository after recompiling
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ literalInstance.options.address ],
-        files: [ literalMetadata ]
+        addresses: [literalInstance.options.address],
+        files: [{ name: "literal.json", content: literalMetadata }]
       };
 
       await injector.inject(inputData);
@@ -133,7 +133,7 @@ describe('injector', function(){
       assert.equal(literalSavedMetadata, literalMetadata);
     });
 
-    it('verfies a contract with a bzzr0 hash', async function(){
+    it('verfies a contract with a bzzr0 hash', async function () {
       const instance = await deployFromArtifact(web3, SimpleBzzr0);
       const metadata = SimpleBzzr0.compilerOutput.metadata;
       const source = SimpleBzzr0.sourceCodes["Simple.sol"];
@@ -142,10 +142,10 @@ describe('injector', function(){
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ instance.options.address ],
+        addresses: [instance.options.address],
         files: [
-          metadata,
-          source
+          { name: "metadata.json", content: metadata },
+          { name: "Source.sol", content: source }
         ]
       };
 
@@ -158,7 +158,7 @@ describe('injector', function(){
       assert.equal(savedMetadata, metadata);
     });
 
-    it('verfies a contract with a bzzr1 hash', async function(){
+    it('verfies a contract with a bzzr1 hash', async function () {
       const instance = await deployFromArtifact(web3, SimpleBzzr1);
       const metadata = SimpleBzzr1.compilerOutput.metadata;
       const source = SimpleBzzr1.sourceCodes["Simple.sol"];
@@ -167,10 +167,10 @@ describe('injector', function(){
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ instance.options.address ],
+        addresses: [instance.options.address],
         files: [
-          metadata,
-          source
+          { name: "metadata.json", content: metadata },
+          { name: "source.sol", content: source }
         ]
       };
 
@@ -183,7 +183,7 @@ describe('injector', function(){
       assert.equal(savedMetadata, metadata);
     });
 
-    it('verifies a contract when deployed & compiled metadata hashes do not match', async function(){
+    it('verifies a contract when deployed & compiled metadata hashes do not match', async function () {
       const mismatchedMetadata = MismatchedBytecode.compilerOutput.metadata;
 
       assert.notEqual(
@@ -196,10 +196,10 @@ describe('injector', function(){
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ simpleInstance.options.address ],
+        addresses: [simpleInstance.options.address],
         files: [
-          simpleSource,
-          mismatchedMetadata
+          { name: "Simple.sol", content: simpleSource },
+          { name: "mismatch.json", content: mismatchedMetadata }
         ]
       };
 
@@ -212,7 +212,7 @@ describe('injector', function(){
         'partial_matches',
         getChainId('localhost').toString(),
         simpleInstance.options.address,
-        '/metadata.json'
+        '/mismatch.json'
       );
 
       const savedMetadata = read(expectedPath, 'utf-8');
@@ -230,17 +230,17 @@ describe('injector', function(){
       // assert.equal(outputIdMetadata, mismatchedMetadata);
     })
 
-    it('errors if metadata is missing', async function(){
+    it('errors if metadata is missing', async function () {
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ simpleInstance.options.address],
-        files: [ simpleSource ]
+        addresses: [simpleInstance.options.address],
+        files: [{ name: "Simple.sol", content: simpleSource }]
       }
 
       try {
         await injector.inject(inputData);
-      } catch(err) {
+      } catch (err) {
         assert.equal(
           err.message,
           'Metadata file not found. Did you include "metadata.json"?'
@@ -248,34 +248,35 @@ describe('injector', function(){
       }
     });
 
-    it('errors if sources specified in metadata are missing', async function(){
+    it('errors if sources specified in metadata are missing', async function () {
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ simpleInstance.options.address],
-        files: [ simpleMetadata ]
+        addresses: [simpleInstance.options.address],
+        files: [{ name: "simple.json", content: simpleMetadata }]
       }
 
       try {
         await injector.inject(inputData);
-      } catch(err) {
+      } catch (err) {
         assert(err.message.includes('Simple.sol'));
         assert(err.message.includes('cannot be found'));
       }
     });
 
-    it('errors when recompiled bytecode does not match deployed', async function(){
+    it('errors when recompiled bytecode does not match deployed', async function () {
       const inputData = {
         repository: mockRepo,
         chain: getChainId('localhost'),
-        addresses: [ simpleWithImportInstance.options.address],
-        files: [ simpleMetadata, simpleSource ]
+        addresses: [simpleWithImportInstance.options.address],
+        files: [{ name: "simple.json", content: simpleMetadata },
+        { name: "Simple.sol", content: simpleSource }]
       }
 
       // Try to match Simple sources/metadata to SimpleWithImport's address
       try {
         await injector.inject(inputData);
-      } catch(err) {
+      } catch (err) {
         assert(err.message.includes('Could not match on-chain deployed bytecode'));
         assert(err.message.includes('contracts/Simple.sol'));
       }

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -13,9 +13,9 @@ const SimpleWithImport = require('./sources/pass/simpleWithImport.js');
 const Monitor = require('../src/monitor').default;
 const getChainByName = require('../src/utils').getChainByName;
 
-describe('monitor', function(){
+describe('monitor', function () {
 
-  describe('E2E', function(){
+  describe('E2E', function () {
     let monitor;
     let web3;
     let server;
@@ -27,23 +27,23 @@ describe('monitor', function(){
     let mockRepo = 'mockRepository';
     let chainId = getChainByName(chain).chainId.toString();
 
-    before(async function(){
-      server = ganache.server({blockTime: 1});
+    before(async function () {
+      server = ganache.server({ blockTime: 1 });
       await pify(server.listen)(port);
       web3 = new Web3(`http://${chain}:${port}`);
       accounts = await web3.eth.getAccounts();
     });
 
     // Clean up server
-    after(async function(){
+    after(async function () {
       monitor.stop();
       await pify(server.close)();
       await ipfs.stop();
 
-      try { exec(`rm -rf ${mockRepo}`) } catch(err) { /*ignore*/ }
+      try { exec(`rm -rf ${mockRepo}`) } catch (err) { /*ignore*/ }
     });
 
-    it('SimpleWithImport: matches deployed to IPFS sources', async function(){
+    it('SimpleWithImport: matches deployed to IPFS sources', async function () {
       this.timeout(25000);
 
       const customChain = {

--- a/test/server.js
+++ b/test/server.js
@@ -61,7 +61,7 @@ describe("server", function () {
       'full_match',
       chainId.toString(),
       simpleInstance.options.address,
-      'metadata.json'
+      'simple.meta.json'
     );
 
     const submittedMetadata = read(simpleMetadataPath, 'utf-8');
@@ -95,7 +95,7 @@ describe("server", function () {
       'full_match',
       chainId.toString(),
       simpleInstance.options.address,
-      'metadata.json'
+      'simple.meta.object.json'
     );
 
     // The injector will save a stringified version

--- a/test/sourcify.js
+++ b/test/sourcify.js
@@ -1,4 +1,4 @@
-process.env.MOCK_REPOSITORY='./mockRepository';
+process.env.MOCK_REPOSITORY = './mockRepository';
 
 const chai = require('chai');
 const chaiExec = require("@jsdevtools/chai-exec");


### PR DESCRIPTION
For every metadata file original name is preserved through verification and saved like that in the repository.
This works for every module: UI verification, CLI verification, API requests to server and monitor fetch.
FindByAddress method also recognizes metadata files with different names.