### PR TITLE
server can use dappnode instead of infura

### DIFF
--- a/src/Dockerfile.server
+++ b/src/Dockerfile.server
@@ -1,5 +1,7 @@
-FROM node:10 as builder
+FROM node:10-alpine as builder
 WORKDIR /home/app
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh python make g++
 COPY package*.json ./
 RUN npm ci
 COPY . .

--- a/src/chains.json
+++ b/src/chains.json
@@ -20,6 +20,7 @@
       "networkId": 1,
       "nativeCurrency": {"name":"Ether","symbol":"ETH","decimals":18},
       "web3": ["https://mainnet.infura.io/v3/${INFURA_ID}"],
+      "fullnode": {"dappnode": "http://geth.dappnode:8545"},
       "faucets": [],
       "infoURL": "https://ethereum.org"
     },
@@ -320,6 +321,7 @@
       "networkId": 3,
       "nativeCurrency": {"name":"Ropsten Ether","symbol":"ROP","decimals":18},
       "web3": ["https://ropsten.infura.io/v3/${INFURA_ID}"],
+      "fullnode": {"dappnode": "http://ropsten.dappnode:8545"},
       "faucets": ["https://faucet.ropsten.be?${ADDRESS}"],
       "infoURL": "https://github.com/ethereum/ropsten"
     },
@@ -404,6 +406,7 @@
       "networkId": 4,
       "nativeCurrency": {"name":"Rinkeby Ether","symbol":"RIN","decimals":18},
       "web3": ["https://rinkeby.infura.io/v3/${INFURA_ID}"],
+      "fullnode": {"dappnode": "http://rinkeby.dappnode:8545"},
       "faucets": ["https://faucet.rinkeby.io"],
       "infoURL": "https://www.rinkeby.io"
     },
@@ -416,6 +419,7 @@
       "networkId": 42,
       "nativeCurrency": {"name":"Kovan Ether","symbol":"KOV","decimals":18},
       "web3": ["https://kovan.infura.io/v3/${INFURA_ID}"],
+      "fullnode": {"dappnode": "http://kovan.dappnode:8545"},
       "faucets": ["https://faucet.kovan.network","https://gitter.im/kovan-testnet/faucet"],
       "infoURL": "https://kovan-testnet.github.io/website"
     },
@@ -452,6 +456,7 @@
       "networkId": 5,
       "nativeCurrency": {"name":"Görli Ether","symbol":"GOR","decimals":18},
       "web3": ["https://goerli.infura.io/v3/${INFURA_ID}"],
+      "fullnode": {"dappnode": "http://goerli-geth.dappnode:8545"},
       "faucets": ["https://goerli-faucet.slock.it/?address=${ADDRESS}","https://faucet.goerli.mudit.blog"],
       "infoURL": "https://goerli.net/#about"
     },

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -76,8 +76,13 @@ export default class Injector {
     for (const chain of ['mainnet', 'ropsten', 'rinkeby', 'kovan', 'goerli']){
       const chainOption = getChainByName(chain);
       this.chains[chainOption.chainId] = {};
-      const web3 = chainOption.web3[0].replace('${INFURA_ID}', this.infuraPID);
-      this.chains[chainOption.chainId].web3 = new Web3(web3);
+      if (this.infuraPID === "changeinfuraid") {
+        const web3 = chainOption.fullnode.dappnode;
+        this.chains[chainOption.chainId].web3 = new Web3(web3);
+      } else {
+        const web3 = chainOption.web3[0].replace('${INFURA_ID}', this.infuraPID);
+        this.chains[chainOption.chainId].web3 = new Web3(web3);
+      }
     }
 
     // For unit testing with testrpc...


### PR DESCRIPTION
Added dappnode endpoints to chains.json that are used if infuraID is not provided.
Docker image for server is now node-alpine which reduced it size for 1/3.