### PR TITLE
Adding loki driver to docker logs

### DIFF
--- a/environments/.env.latest
+++ b/environments/.env.latest
@@ -55,7 +55,7 @@ DB_PORT=5432
 EXTERNAL_DB_PORT=5432
 
 # Monitoring config
-LOKI_URL=http://localhost:3100/loki/api/v1/push
+LOKI_URL=http://loki:3100/loki/api/v1/push
 
 # NPM config
 NPM_TOKEN=xxx

--- a/environments/.env.stable
+++ b/environments/.env.stable
@@ -54,7 +54,7 @@ DIALECT=postgres
 DB_PORT=5432
 EXTERNAL_DB_PORT=5432
 
-LOKI_URL=http://localhost:3100/loki/api/v1/push
+LOKI_URL=http://loki:3100/loki/api/v1/push
 
 # NPM config
 NPM_TOKEN=xxx

--- a/environments/.env.testing
+++ b/environments/.env.testing
@@ -52,7 +52,7 @@ DB_PORT=5432
 EXTERNAL_DB_PORT=5432
 
 # Monitoring config
-LOKI_URL=http://localhost:3100/loki/api/v1/push
+LOKI_URL=http://loki:3100/loki/api/v1/push
 
 # NPM config
 NPM_TOKEN=xxx

--- a/environments/ipfs-monitoring.yaml
+++ b/environments/ipfs-monitoring.yaml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  ipfs:
+    logging:
+      driver: loki
+      options:
+        loki-url: $LOKI_URL

--- a/environments/monitor-monitoring.yaml
+++ b/environments/monitor-monitoring.yaml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  monitor:
+    logging:
+      driver: loki
+      options:
+        loki-url: ${LOKI_URL}

--- a/environments/repository-monitoring.yaml
+++ b/environments/repository-monitoring.yaml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  repository:
+    logging:
+      driver: loki
+      options:
+        loki-url: ${LOKI_URL}

--- a/environments/s3-monitoring.yaml
+++ b/environments/s3-monitoring.yaml
@@ -1,0 +1,7 @@
+vversion: "3.7"
+  services:
+    s3:
+      logging:
+        driver: loki
+        options:
+          loki-url: ${LOKI_URL}

--- a/environments/server-monitoring.yaml
+++ b/environments/server-monitoring.yaml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  server:
+    logging:
+      driver: loki
+      options:
+        loki-url: ${LOKI_URL}

--- a/environments/ui-monitoring.yaml
+++ b/environments/ui-monitoring.yaml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  ui:
+    logging:
+      driver: loki
+      options:
+        loki-url: ${LOKI_URL}


### PR DESCRIPTION
Adding loki driver to docker compose so that logs can be redirected to loki and shown in grafana.