### PR TITLE
Add Solidity syntax highlight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 environments/.env.secrets filter=git-crypt diff=git-crypt
 .gitattributes !filter !diff
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Update `.gitattributes` to enable Solidity syntax highlight on GitHub.