### PR TITLE
verification statistics

### DIFF
--- a/services/ipfs/publish.sh
+++ b/services/ipfs/publish.sh
@@ -3,6 +3,27 @@
 export PATH=~$PATH:/usr/local/bin:/usr/local/openjdk-11/bin:/usr/bin
 export JAVA_HOME=/usr/local/openjdk-11/
 
+REPOSITORY_PATH=/app/repository
+CHAINS=$(find $REPOSITORY_PATH/contracts/full_match/ -mindepth 1 -maxdepth 1 -type d | rev | cut --delimiter=/ -f1 | rev)
+
+OUTPUT="{ "
+for chainId in ${CHAINS}; do
+   OUTPUT+="  \"$chainId\": {"
+   OUTPUT+="    \"full_match\": $(find $REPOSITORY_PATH/contracts/full_match/$chainId/ -mindepth 1 -maxdepth 1 -type d | wc -l),"
+   OUTPUT+="    \"partial_match\": $(find $REPOSITORY_PATH/contracts/partial_match/$chainId/ -mindepth 1 -maxdepth 1 -type d | wc -l)"
+   
+   if [[ $chainId == $(echo $CHAINS | rev | cut --delimiter=" " -f1 | rev) ]]
+    then
+        OUTPUT+="  }"
+    else
+        OUTPUT+="  },"
+    fi
+        
+done
+OUTPUT+="}"
+
+echo $OUTPUT > $REPOSITORY_PATH/stats.json
+
 hash=$(ipfs add -Q -r /app/repository)
 echo $hash
 curl -X POST "https://ipfs.komputing.org/api/v0/pin/add?arg=$hash&recursive=true"


### PR DESCRIPTION
This will provide statistics on how many contracts are verified on each of supported chains.
It is updated every hour and output is written inside the `stats.json` file which is located inside the root of the repository.
Anyone is able to fetch it by using this URL: https://contractrepo.verificationstaging.shardlabs.io/stats.json