### PR TITLE
Use sourcify URL instead of komputing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ watches:
   + xDai
 
 + a website which allows you to submit sources and metadata for a specific contract address manually
-  + https://verification.komputing.org/ (Stable)
-  + https://verificationstaging.shardlabs.io/ (Unstable)
+  + https://sourcify.dev (Stable)
+  + https://verificationstaging.shardlabs.io (Unstable)
 
 + a public metadata repository that contains uploaded (or discovered) metadata and their sources:
-  + https://contractrepo.komputing.org/ (Stable)
-  + https://contractrepo.verificationstaging.shardlabs.io/ (Unstable)
+  + https://contractrepo.komputing.org (Stable)
+  + https://contractrepo.verificationstaging.shardlabs.io (Unstable)
 
 ### Getting Metadata
 


### PR DESCRIPTION
also removed the wasteful slashes from the URLs

PS: we should also make the contractrepo a sourcify.dev subdomain for consistency  