### PR TITLE
Fetch partial matches if full not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ You can find examples in our Postman collection in the root of this project `Sou
 
 * [Verify](docs/api/server/verify.md) : `POST /`
 * [Check by address](docs/api/server/checkByAddress.md) : `GET /checkByAddresses?addresses={address}&chainIds={chainIds}`
-* [Get file tree](docs/api/server/getTreeByChainAndAddress.md) : `GET /files/tree/:chain/:address`
-* [Get source files](docs/api/server/getByChainAndAddress.md) : `GET /files/:chain/:address`
+* [Get file tree (full match)](docs/api/server/getTreeByChainAndAddress.md) : `GET /files/tree/:chain/:address`
+* [Get source files (full match)](docs/api/server/getByChainAndAddress.md) : `GET /files/:chain/:address`
+* [Get file tree (full or partial match)](docs/api/server/getAnyTreeByChainAndAddess.md) : `GET /files/tree/any/:chain/:address`
+* [Get source files (full or partial match)](docs/api/server/getAnyByChainAndAddress.md) : `GET /files/any/:chain/:address`
 * [Server health](docs/api/server/health.md) : `GET /health`

--- a/docs/api/server/getAnyByChainAndAddress.md
+++ b/docs/api/server/getAnyByChainAndAddress.md
@@ -1,0 +1,72 @@
+# Get source files for the address
+
+Returns all verified sources from the repository for the desired contract address and chain, including `metadata.json`. Searches for full and partial matches.
+
+**URL** : `/files/any/:chain/:address`
+
+**Method** : `GET`
+
+## Responses
+
+**Condition** : Contract is available as a full match in the repository.
+
+**Code** : `200 OK`
+
+**Content** : 
+
+```json
+{
+    "status": "full",
+    "files": [
+        {
+            "name": "metadata.json",
+            "path": "/home/data/repository/contracts/full_match/3/0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9/metadata.json",
+            "content": "{\"compiler\":{\"version\":\"0.6.6+commit.6c089d02\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"retreive\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"store\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"Store & retreive value in a variable\",\"methods\":{\"retreive()\":{\"details\":\"Return value \",\"returns\":{\"_0\":\"value of 'number'\"}},\"store(uint256)\":{\"details\":\"Store value in variable\",\"params\":{\"num\":\"value to store\"}}},\"title\":\"Storage\"},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"browser/1_Storage.sol\":\"Storage\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"browser/1_Storage.sol\":{\"keccak256\":\"0xaedc7086ad8503907209f50bac1e4dc6c2eca2ed41b15d03740fea748ea3f88e\",\"urls\":[\"bzz-raw://4bc331951c25951321cb29abbd689eb3af669530222c6bb2d45ff45334ee83a7\",\"dweb:/ipfs/QmWb1NQ6Pw8ZLMFX8uDjMyftgcEieT9iP2TvWisPhjN3U2\"]}},\"version\":1}"
+        },
+        {
+            "name": "1_Storage.sol",
+            "path": "/home/data/repository/contracts/full_match/3/0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9/sources/browser/1_Storage.sol",
+            "content": "pragma solidity >=0.4.22 <0.7.0;\n\n/**\n * @title Storage\n * @dev Store & retreive value in a variable\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retreive() public view returns (uint256){\n        return number;\n    }\n}"
+        }
+    ]
+}
+```
+
+### OR
+
+**Condition** : Contract is available as a partial match in the repository.
+
+**Code** : `200 OK`
+
+**Content** : 
+
+```json
+{
+    "status": "partial",
+    "files": [
+        {
+            "name": "metadata.json",
+            "path": "/home/data/repository/contracts/full_match/3/0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9/metadata.json",
+            "content": "{\"compiler\":{\"version\":\"0.6.6+commit.6c089d02\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"retreive\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"store\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"Store & retreive value in a variable\",\"methods\":{\"retreive()\":{\"details\":\"Return value \",\"returns\":{\"_0\":\"value of 'number'\"}},\"store(uint256)\":{\"details\":\"Store value in variable\",\"params\":{\"num\":\"value to store\"}}},\"title\":\"Storage\"},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"browser/1_Storage.sol\":\"Storage\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"browser/1_Storage.sol\":{\"keccak256\":\"0xaedc7086ad8503907209f50bac1e4dc6c2eca2ed41b15d03740fea748ea3f88e\",\"urls\":[\"bzz-raw://4bc331951c25951321cb29abbd689eb3af669530222c6bb2d45ff45334ee83a7\",\"dweb:/ipfs/QmWb1NQ6Pw8ZLMFX8uDjMyftgcEieT9iP2TvWisPhjN3U2\"]}},\"version\":1}"
+        },
+        {
+            "name": "1_Storage.sol",
+            "path": "/home/data/repository/contracts/full_match/3/0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9/sources/browser/1_Storage.sol",
+            "content": "pragma solidity >=0.4.22 <0.7.0;\n\n/**\n * @title Storage\n * @dev Store & retreive value in a variable\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retreive() public view returns (uint256){\n        return number;\n    }\n}"
+        }
+    ]
+}
+```
+
+### OR
+
+**Condition** : Contract is not available in the repository.
+
+**Code** : `404 Not Found`
+
+**Content** : 
+```json
+{
+    "error": "Files have not been found!"
+}
+```

--- a/docs/api/server/getAnyTreeByChainAndAddress.md
+++ b/docs/api/server/getAnyTreeByChainAndAddress.md
@@ -1,0 +1,70 @@
+# Get file tree
+
+Returns repository URLs for every file in the source tree for the desired chain and address. Searches for full and partial matches.
+
+**URL** : `/files/tree/any/:chain/:address`
+
+**Method** : `GET`
+
+## Responses
+
+**Condition** : Contract is available as a full match in the repository.
+
+**Code** : `200 OK`
+
+**Content** : 
+
+```json
+{
+    "status": "full",
+    "files": [
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/metadata.json",
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/sources/_openzeppelin/contracts/GSN/Context.sol",
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/sources/_openzeppelin/contracts/access/AccessControl.sol",
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/sources/_openzeppelin/contracts/utils/Address.sol",
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/sources/_openzeppelin/contracts/utils/EnumerableSet.sol",
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/sources/home/fabijan/shardlabs/betting-app/ethereum/contracts/Bet.sol",
+        "https://contractrepostaging.komputing.org/contracts/full_match/5/0x32a5d2240a60dcF7Af8EfAE6d886ec8BeD5f71bA/sources/home/fabijan/shardlabs/betting-app/ethereum/contracts/BetFactory.sol"
+    ]
+}
+```
+
+### OR
+
+**Condition** : Contract is available as a partial match in the repository.
+
+**Code** : `200 OK`
+
+**Content** : 
+
+```json
+{
+    "status": "partial",
+    "files": [
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/metadata.json",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/_openzeppelin/contracts/GSN/Context.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/_openzeppelin/contracts/access/Ownable.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/_openzeppelin/contracts/math/SafeMath.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/_openzeppelin/contracts/token/ERC20/IERC20.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/_openzeppelin/contracts/token/ERC20/SafeERC20.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/_openzeppelin/contracts/utils/Address.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/contracts/SyntheticRebaseToken.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/contracts/interfaces/IERC20Nameable.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/contracts/interfaces/IMinimalUniswap.sol",
+        "https://contractrepostaging.komputing.org/contracts/partial_match/1/0x2C1dcCD1EF8918d57652f0Bea499a12602456A12/sources/contracts/interfaces/IStatisticProvider.sol"
+    ]
+}
+```
+
+### OR
+
+**Condition** : Contract is not available in the repository.
+
+**Code** : `404 Not Found`
+
+**Content** : 
+```json
+{
+    "error": "Files have not been found!"
+}
+```

--- a/docs/api/server/getByChainAndAddress.md
+++ b/docs/api/server/getByChainAndAddress.md
@@ -1,6 +1,6 @@
 # Get source files for the address
 
-Returns all verified sources from the repository for the desired contract address and chain, including `metadata.json`.
+Returns all verified sources from the repository for the desired contract address and chain, including `metadata.json`. Searches only for full matches.
 
 **URL** : `/files/:chain/:address`
 

--- a/docs/api/server/getTreeByChainAndAddress.md
+++ b/docs/api/server/getTreeByChainAndAddress.md
@@ -1,6 +1,6 @@
 # Get file tree
 
-Returns repository URLs for every file in the source tree for the desired chain and address.
+Returns repository URLs for every file in the source tree for the desired chain and address. Searches only for full matches.
 
 **URL** : `/files/tree/:chain/:address`
 

--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -37,6 +37,21 @@ export interface Match {
   status: 'perfect' | 'partial' | null
 }
 
+/**
+ * A type for specfifying the strictness level of querying (only full or any kind of matches)
+ */
+export type MatchLevel = "full_match" | "any_match";
+
+/**
+ * A type for specifying the match quality of files.
+ */
+export type MatchQuality = "full" | "partial";
+
+/**
+ * An array wrapper with info properties.
+ */
+export type FilesInfo<T> = { status: MatchQuality, files: Array<T> };
+
 export interface MonitorConfig {
   ipfsCatRequest? : string,
   ipfsProvider? : any,


### PR DESCRIPTION
Fetch partial if full match not available: https://github.com/ethereum/sourcify/issues/321
- FileController had two endpoints:
  - /tree/:chain/:address
  - /:chain/:address
- Added two more that return partial matches if full not found (the return object contains the property `status` indicating whether it was a full or a partial match):
  - /tree/any/:chain/:address
  - /any/:chain/:address
- Refactored FileController to reduce code duplication.

Possible discussion points:
- url path choice (/any)

Solves:
* https://github.com/sourcifyeth/remix-sourcify/issues/27