### PR TITLE
Support Matic and Binance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,16 @@ As mentioned above, Sourcify has several components:
 + a "monitoring & verifier service" which watches public Ethereum networks for contract deployments
 and tries to associate them with sources and metadata published to Swarm or IPFS. It currently
 watches:
-  + mainnet
-  + ropsten
-  + rinkeby
-  + kovan
-  + goerli
+  + Ethereum Mainnet
+  + Ropsten
+  + Rinkeby
+  + Kovan
+  + Goerli
   + xDai
+  + Matic Mainnet
+  + Mumbai Testnet
+  + Binance Smart Chain Mainnet
+  + Binance Smart Chain Testnet
 
 + a website which allows you to submit sources and metadata for a specific contract address manually
   + https://sourcify.dev (Stable)

--- a/services/core/src/chains.json
+++ b/services/core/src/chains.json
@@ -669,5 +669,57 @@
       "web3": ["https://core.poa.network"],
       "faucets": [],
       "infoURL": "https://poa.network"
+    },
+    {
+      "name": "Binance Smart Chain Mainnet",
+      "chainId": 56,
+      "shortName": "bsc mainnet",
+      "chain": "Binance Smart Chain Mainnet",
+      "network": "binance smart chain mainnet",
+      "networkId": 56,
+      "nativeCurrency": {"name":"BNB","symbol":"BNB","decimals":18},
+      "web3": ["https://bsc-dataseed.binance.org/"],
+      "faucets": [],
+      "infoURL": "https://www.binance.org/",
+      "supported": true
+    },
+    {
+      "name": "Binance Smart Chain Testnet",
+      "chainId": 97,
+      "shortName": "bsc testnet",
+      "chain": "Binance Smart Chain Testnet",
+      "network": "binance smart chain testnet",
+      "networkId": 97,
+      "nativeCurrency": {"name":"BNB","symbol":"BNB","decimals":18},
+      "web3": ["https://data-seed-prebsc-1-s1.binance.org:8545/"],
+      "faucets": ["https://testnet.binance.org/faucet-smart"],
+      "infoURL": "https://www.binance.org/",
+      "supported": true
+    },
+    {
+      "name": "Matic Mainnet",
+      "chainId": 137,
+      "shortName": "matic mainnet",
+      "chain": "Matic Mainnet",
+      "network": "matic mainnet",
+      "networkId": 137,
+      "nativeCurrency": {"name":"MATIC","symbol":"MATIC","decimals":18},
+      "web3": ["https://rpc-mainnet.maticvigil.com/"],
+      "faucets": [],
+      "infoURL": "https://matic.network/",
+      "supported": true
+    },
+    {
+      "name": "Mumbai Testnet",
+      "chainId": 80001,
+      "shortName": "mumbai",
+      "chain": "Mumbai Testnet",
+      "network": "mumbai testnet",
+      "networkId": 80001,
+      "nativeCurrency": {"name":"MATIC","symbol":"MATIC","decimals":18},
+      "web3": ["https://rpc-mumbai.maticvigil.com/"],
+      "faucets": ["https://faucet.matic.network/"],
+      "infoURL": "https://matic.network/",
+      "supported": true
     }
   ]

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -4,7 +4,11 @@ export const CHAIN_OPTIONS = [
     {value: "rinkeby", label: "Rinkeby", id: 4},
     {value: "kovan", label: "Kovan", id: 42},
     {value: "goerli", label: "Görli", id: 5},
-    {value: "xdai", label: "xDai", id: 100}
+    {value: "xdai", label: "xDai", id: 100},
+    {value: "binance smart chain mainnet", label: "Binance Smart Chain Mainnet", id: 56},
+    {value: "binance smart chain testnet", label: "Binance Smart Chain Testnet", id: 97},
+    {value: "matic mainnet", label: "Matic Mainnet", id: 137},
+    {value: "mumbai testnet", label: "Mumbai Testnet", id: 80001}
 ];
 
 export const REPOSITORY_URL = process.env.REPOSITORY_URL;


### PR DESCRIPTION
Now supporting:
- Matic Mainnet
- Mumbai Testnet
- Binance Smart Chain Mainnet
- Binance Smart Chain Testnet

Updates are reflected in the documentation and the UI (it doesn't look as appealing as before because there are 10 options in the dropdown; however this UI will soon be history)