### PR TITLE
Improve fetching

### DIFF
--- a/Sourcify.postman_collection.json
+++ b/Sourcify.postman_collection.json
@@ -74,6 +74,230 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "verify - missing - fetch",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "address",
+											"value": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
+											"type": "text"
+										},
+										{
+											"key": "chain",
+											"value": "100",
+											"type": "text"
+										},
+										{
+											"key": "files",
+											"type": "file",
+											"src": "test/testcontracts/1_Storage/metadata.json"
+										},
+										{
+											"key": "fetch",
+											"value": "true",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{host}}",
+									"host": [
+										"{{host}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "verify - missing - fetch",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "address",
+													"value": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
+													"type": "text"
+												},
+												{
+													"key": "chain",
+													"value": "100",
+													"type": "text"
+												},
+												{
+													"key": "files",
+													"type": "file",
+													"src": "test/testcontracts/1_Storage/metadata.json"
+												},
+												{
+													"key": "fetch",
+													"value": "true",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{host}}",
+											"host": [
+												"{{host}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "88"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"58-J/J2ShSm6vDzcetM7QhLTil+co8\""
+										},
+										{
+											"key": "Set-Cookie",
+											"value": "sourcify_vid=s%3A1MUnH1uhcDyJytHrXoYrnU3pnYpHwg4k.ESJevK%2BKUpvwiC9MxqT%2FJTXaU%2BGKSIv3yYqJlJ4W6MA; Path=/; Expires=Wed, 20 Jan 2021 23:50:51 GMT; HttpOnly"
+										},
+										{
+											"key": "Date",
+											"value": "Wed, 20 Jan 2021 11:50:51 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"result\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"status\": \"perfect\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "verify - missing - do not fetch",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "address",
+											"value": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
+											"type": "text"
+										},
+										{
+											"key": "chain",
+											"value": "100",
+											"type": "text"
+										},
+										{
+											"key": "files",
+											"type": "file",
+											"src": "test/testcontracts/1_Storage/metadata.json"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{host}}",
+									"host": [
+										"{{host}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "verify - missing - do not fetch",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "address",
+													"value": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
+													"type": "text"
+												},
+												{
+													"key": "chain",
+													"value": "100",
+													"type": "text"
+												},
+												{
+													"key": "files",
+													"type": "file",
+													"src": "test/testcontracts/1_Storage/metadata.json"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{host}}",
+											"host": [
+												"{{host}}"
+											]
+										}
+									},
+									"status": "Bad Request",
+									"code": 400,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "75"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"4b-91ydo9mIuZsJIBw/zbFBZMMd6nk\""
+										},
+										{
+											"key": "Set-Cookie",
+											"value": "sourcify_vid=s%3A1MUnH1uhcDyJytHrXoYrnU3pnYpHwg4k.ESJevK%2BKUpvwiC9MxqT%2FJTXaU%2BGKSIv3yYqJlJ4W6MA; Path=/; Expires=Wed, 20 Jan 2021 23:50:15 GMT; HttpOnly"
+										},
+										{
+											"key": "Date",
+											"value": "Wed, 20 Jan 2021 11:50:15 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"error\": \"Invalid or missing sources in:\\nStorage (browser/1_Storage.sol)\"\n}"
+								}
+							]
 						}
 					],
 					"event": [
@@ -200,7 +424,7 @@
 							]
 						},
 						{
-							"name": "Add input files - without metadata",
+							"name": "Add input files - source only",
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -224,73 +448,34 @@
 									]
 								}
 							},
-							"response": [
-								{
-									"name": "Add input files - without metadata",
-									"originalRequest": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "formdata",
-											"formdata": [
-												{
-													"key": "files",
-													"type": "file",
-													"src": "test/testcontracts/1_Storage/1_Storage.sol"
-												}
-											]
-										},
-										"url": {
-											"raw": "{{host}}/input-files",
-											"host": [
-												"{{host}}"
-											],
-											"path": [
-												"input-files"
-											]
+							"response": []
+						},
+						{
+							"name": "Add input files - metadata only",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "files",
+											"type": "file",
+											"src": "test/testcontracts/1_Storage/metadata.json"
 										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "43"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"2b-GRCkRQ7DAtUZ6oOVl+Q+eZi9siI\""
-										},
-										{
-											"key": "Set-Cookie",
-											"value": "sourcify_vid=s%3Ai8fGEBmscCNl4g5Lr-55tEiTPRIFJZI3.i%2Bg%2B9doxHuunTqq5V6nPPsnkc5GIc8RUpuzVm2wFGqo; Path=/; Expires=Wed, 13 Jan 2021 05:40:11 GMT; HttpOnly"
-										},
-										{
-											"key": "Date",
-											"value": "Tue, 12 Jan 2021 17:40:11 GMT"
-										},
-										{
-											"key": "Connection",
-											"value": "keep-alive"
-										}
+									]
+								},
+								"url": {
+									"raw": "{{host}}/input-files",
+									"host": [
+										"{{host}}"
 									],
-									"cookie": [],
-									"body": "{\n    \"contracts\": [],\n    \"unused\": [\n        \"1_Storage.sol\"\n    ]\n}"
+									"path": [
+										"input-files"
+									]
 								}
-							]
+							},
+							"response": []
 						},
 						{
 							"name": "Add input files - under wrong property",
@@ -845,6 +1030,108 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"contracts\": [\n        {\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"networkId\": \"100\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"status\": \"perfect\"\n        }\n    ],\n    \"unused\": []\n}"
+								}
+							]
+						},
+						{
+							"name": "Verify validated contracts - fetch missing source",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contracts\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"networkId\": \"100\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\"\n        }\n    ],\n    \"fetch\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{host}}/verify-validated",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"verify-validated"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Verify validated contracts - fetch missing source",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"contracts\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"networkId\": \"100\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\"\n        }\n    ],\n    \"fetch\": true\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{host}}/verify-validated",
+											"host": [
+												"{{host}}"
+											],
+											"path": [
+												"verify-validated"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "375"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"177-KLpUVJREY/f+juod/D1HYTPgH0w\""
+										},
+										{
+											"key": "Set-Cookie",
+											"value": "sourcify_vid=s%3AJc8SefWWpuHUIH6OAsjltayogQfAofJ2.DF%2FVQveyCQCjtNpOgza8CJ43Q2qSWCkjgepNb9hARmE; Path=/; Expires=Thu, 21 Jan 2021 00:21:19 GMT; HttpOnly"
+										},
+										{
+											"key": "Date",
+											"value": "Wed, 20 Jan 2021 12:21:19 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"contracts\": [\n        {\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"networkId\": \"100\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"status\": \"perfect\"\n        }\n    ],\n    \"unused\": [],\n    \"fetch\": true\n}"
 								}
 							]
 						},

--- a/docs/api/server/verification1/verify.md
+++ b/docs/api/server/verification1/verify.md
@@ -78,7 +78,7 @@ If using `application/json`, the files should be in an object under the key `fil
 
 **Condition** : Failed fetching missing files. OR Contract bytecode does not match deployed bytecode.
 
-**Code** : `500 Internal Server Error`
+**Code** : `400 Bad Request Error`
 
 **Content** : 
 ```json

--- a/docs/api/server/verification2/exchange-object.md
+++ b/docs/api/server/verification2/exchange-object.md
@@ -44,7 +44,8 @@ The object expected by the server from the client is a proper subset of (1) and 
             "networkId": "100",
             "compilerVersion": "0.6.6+commit.6c089d02"
         }
-    ]
+    ],
+    "fetch": true // if true or "true", then considered true, all other values are treated as false
 }
 ```
 - If the client does not know some of the properties yet, they may be omitted.

--- a/docs/api/server/verification2/verify-validated.md
+++ b/docs/api/server/verification2/verify-validated.md
@@ -13,9 +13,9 @@
 
 ## Responses
 
-**Assumptions for all example responses (except the last one)** :
-* There is one pending contract with all source files, but no `address` or `networkId`.
-* Supplying the following minimum object (extra properties would be ignored):
+**Assumptions for all example responses (except the last)** :
+* There is one pending contract with 0 or 1 missing source file, but no `address` or `networkId`.
+* Supplying the following minimum object:
 ```json
 {
     "contracts": [
@@ -29,7 +29,9 @@
 }
 ```
 
-**Condition** : The provided contract `perfect`ly matches the one at the provided `networkId` and `address`.
+**Conditions** :
+- All the source files have been previously provided.
+- The provided contract `perfect`ly matches the one at the provided `networkId` and `address`.
 
 **Code** : `200 OK`
 
@@ -55,6 +57,41 @@
         }
     ],
     "unused": []
+}
+```
+
+### OR
+
+**Conditions** :
+- One source file is missing.
+- Fetching requested by providing `fetch: true`, look [here](exchange-object.md) for more info.
+- The provided contract `perfect`ly matches the one at the provided `networkId` and `address`.
+
+**Code** : `200 OK`
+
+**Content** :
+
+```json
+{
+    "contracts": [
+        {
+            "verificationId": "0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe",
+            "compiledPath": "browser/1_Storage.sol",
+            "name": "Storage",
+            "compilerVersion": "0.6.6+commit.6c089d02",
+            "address": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
+            "networkId": "100",
+            "files": {
+                "found": [
+                    "browser/1_Storage.sol"
+                ],
+                "missing": []
+            },
+            "status": "perfect"
+        }
+    ],
+    "unused": [],
+    "fetch": true
 }
 ```
 

--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -12,6 +12,7 @@ export interface InputData {
     addresses: string[],
     contract?: CheckedContract,
     bytecode?: string;
+    fetchMissing?: boolean;
 }
 
 export interface CompilationSettings {

--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -195,7 +195,7 @@ export class Injector {
      * @return {Promise<object>}              address & status of successfully verified contract
      */
     public async inject(inputData: InputData): Promise<Match> {
-        const { chain, addresses, contract } = inputData;
+        const { chain, addresses, contract, fetchMissing } = inputData;
         this.validateAddresses(addresses);
         this.validateChain(chain);
 
@@ -209,8 +209,8 @@ export class Injector {
 
         if (!CheckedContract.isValid(contract)) {
             // eslint-disable-next-line no-useless-catch
-            try {
-                await contract.fetchMissing(this.log);
+            if (fetchMissing) try {
+                await CheckedContract.fetchMissing(contract, this.log);
             } catch(err) {
                 throw err;
             }

--- a/src/server/controllers/VerificationController-util.ts
+++ b/src/server/controllers/VerificationController-util.ts
@@ -39,7 +39,8 @@ export type SessionMaps = {
 export type MySession = 
     Session &
     SessionMaps & { 
-    unusedSources: string[]
+    unusedSources: string[],
+    fetch?: boolean
 };
 
 export type MyRequest = 
@@ -59,9 +60,9 @@ export type SendableContract =
     verificationId?: string
 }
 
-export function isVerifiable(contractWrapper: ContractWrapper) {
+export function isVerifiable(contractWrapper: ContractWrapper, ignoreMissing?: boolean) {
     const contract = contractWrapper.contract;
-    return isEmpty(contract.missing)
+    return (isEmpty(contract.missing) || ignoreMissing)
         && isEmpty(contract.invalid)
         && Boolean(contractWrapper.compilerVersion)
         && Boolean(contractWrapper.address)
@@ -103,7 +104,7 @@ export function getSessionJSON(session: MySession) {
     }
 
     const unused = session.unusedSources || [];
-    return { contracts, unused };
+    return { contracts, unused, fetch: session.fetch };
 }
 
 export function generateId(obj: any): string {


### PR DESCRIPTION
- User may specify to fetch missing sources. This is done by providing a `fetch` property set to `true` or `"true"`. See docs on how exactly this may be achieved in API v1 and API v2.
- If possible, source fetching is first attempted from GitHub, then from IPFS.
- If a solc version is not present, its fetching is first attempted from [the Github repo](https://github.com/ethereum/solc-bin/tree/gh-pages/linux-amd64).