### PR TITLE
Make fetching the default behavior

### DIFF
--- a/Sourcify.postman_collection.json
+++ b/Sourcify.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a7406b3d-b299-45ff-9e64-ed8523f26f2d",
+		"_postman_id": "1ccf8bed-6f1c-468f-842e-e1edf1346003",
 		"name": "Sourcify",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -97,11 +97,6 @@
 											"key": "files",
 											"type": "file",
 											"src": "test/testcontracts/1_Storage/metadata.json"
-										},
-										{
-											"key": "fetch",
-											"value": "true",
-											"type": "text"
 										}
 									]
 								},
@@ -135,11 +130,6 @@
 													"key": "files",
 													"type": "file",
 													"src": "test/testcontracts/1_Storage/metadata.json"
-												},
-												{
-													"key": "fetch",
-													"value": "true",
-													"type": "text"
 												}
 											]
 										},
@@ -189,113 +179,6 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"result\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"status\": \"perfect\"\n        }\n    ]\n}"
-								}
-							]
-						},
-						{
-							"name": "verify - missing - do not fetch",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "formdata",
-									"formdata": [
-										{
-											"key": "address",
-											"value": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
-											"type": "text"
-										},
-										{
-											"key": "chain",
-											"value": "100",
-											"type": "text"
-										},
-										{
-											"key": "files",
-											"type": "file",
-											"src": "test/testcontracts/1_Storage/metadata.json"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{host}}",
-									"host": [
-										"{{host}}"
-									]
-								}
-							},
-							"response": [
-								{
-									"name": "verify - missing - do not fetch",
-									"originalRequest": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "formdata",
-											"formdata": [
-												{
-													"key": "address",
-													"value": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
-													"type": "text"
-												},
-												{
-													"key": "chain",
-													"value": "100",
-													"type": "text"
-												},
-												{
-													"key": "files",
-													"type": "file",
-													"src": "test/testcontracts/1_Storage/metadata.json"
-												}
-											]
-										},
-										"url": {
-											"raw": "{{host}}",
-											"host": [
-												"{{host}}"
-											]
-										}
-									},
-									"status": "Bad Request",
-									"code": 400,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "75"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"4b-91ydo9mIuZsJIBw/zbFBZMMd6nk\""
-										},
-										{
-											"key": "Set-Cookie",
-											"value": "sourcify_vid=s%3A1MUnH1uhcDyJytHrXoYrnU3pnYpHwg4k.ESJevK%2BKUpvwiC9MxqT%2FJTXaU%2BGKSIv3yYqJlJ4W6MA; Path=/; Expires=Wed, 20 Jan 2021 23:50:15 GMT; HttpOnly"
-										},
-										{
-											"key": "Date",
-											"value": "Wed, 20 Jan 2021 11:50:15 GMT"
-										},
-										{
-											"key": "Connection",
-											"value": "keep-alive"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"error\": \"Invalid or missing sources in:\\nStorage (browser/1_Storage.sol)\"\n}"
 								}
 							]
 						}
@@ -738,70 +621,6 @@
 							},
 							"response": [
 								{
-									"name": "Verify validated contracts - no pending contracts",
-									"originalRequest": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"contracts\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"status\": \"error\"\n        }\n    ],\n    \"unused\": []\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{host}}/verify-validated",
-											"host": [
-												"{{host}}"
-											],
-											"path": [
-												"verify-validated"
-											]
-										}
-									},
-									"status": "Bad Request",
-									"code": 400,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "53"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"35-C1PLshiV2v4d8cihT1ADwOqiWu8\""
-										},
-										{
-											"key": "Set-Cookie",
-											"value": "sourcify_vid=s%3AIPLSfpM1nXFH5HzRLCxiDBDF8S7DN3BL.rInlSM2GiOhHRm8EVf6%2FN1ykqgoMW0u2YBA7Hgqa9Zw; Path=/; Expires=Thu, 07 Jan 2021 21:38:57 GMT; HttpOnly"
-										},
-										{
-											"key": "Date",
-											"value": "Thu, 07 Jan 2021 09:38:57 GMT"
-										},
-										{
-											"key": "Connection",
-											"value": "keep-alive"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"error\": \"There are currently no pending contracts.\"\n}"
-								},
-								{
 									"name": "Verify validated contracts - timestamp indicates the contract has already been verified",
 									"originalRequest": {
 										"method": "POST",
@@ -864,6 +683,70 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"contracts\": [\n        {\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"status\": \"perfect\",\n            \"storageTimestamp\": \"2021-01-12T15:41:56.502Z\"\n        }\n    ],\n    \"unused\": []\n}"
+								},
+								{
+									"name": "Verify validated contracts - no pending contracts",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"contracts\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"status\": \"error\"\n        }\n    ],\n    \"unused\": []\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{host}}/verify-validated",
+											"host": [
+												"{{host}}"
+											],
+											"path": [
+												"verify-validated"
+											]
+										}
+									},
+									"status": "Bad Request",
+									"code": 400,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "53"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"35-C1PLshiV2v4d8cihT1ADwOqiWu8\""
+										},
+										{
+											"key": "Set-Cookie",
+											"value": "sourcify_vid=s%3AIPLSfpM1nXFH5HzRLCxiDBDF8S7DN3BL.rInlSM2GiOhHRm8EVf6%2FN1ykqgoMW0u2YBA7Hgqa9Zw; Path=/; Expires=Thu, 07 Jan 2021 21:38:57 GMT; HttpOnly"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 07 Jan 2021 09:38:57 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"error\": \"There are currently no pending contracts.\"\n}"
 								},
 								{
 									"name": "Verify validated contracts - perfect match",
@@ -1030,108 +913,6 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"contracts\": [\n        {\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"status\": \"perfect\"\n        }\n    ],\n    \"unused\": []\n}"
-								}
-							]
-						},
-						{
-							"name": "Verify validated contracts - fetch missing source",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"contracts\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\"\n        }\n    ],\n    \"fetch\": true\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{host}}/verify-validated",
-									"host": [
-										"{{host}}"
-									],
-									"path": [
-										"verify-validated"
-									]
-								}
-							},
-							"response": [
-								{
-									"name": "Verify validated contracts - fetch missing source",
-									"originalRequest": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"contracts\": [\n        {\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\"\n        }\n    ],\n    \"fetch\": true\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{host}}/verify-validated",
-											"host": [
-												"{{host}}"
-											],
-											"path": [
-												"verify-validated"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "375"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"177-KLpUVJREY/f+juod/D1HYTPgH0w\""
-										},
-										{
-											"key": "Set-Cookie",
-											"value": "sourcify_vid=s%3AJc8SefWWpuHUIH6OAsjltayogQfAofJ2.DF%2FVQveyCQCjtNpOgza8CJ43Q2qSWCkjgepNb9hARmE; Path=/; Expires=Thu, 21 Jan 2021 00:21:19 GMT; HttpOnly"
-										},
-										{
-											"key": "Date",
-											"value": "Wed, 20 Jan 2021 12:21:19 GMT"
-										},
-										{
-											"key": "Connection",
-											"value": "keep-alive"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"contracts\": [\n        {\n            \"verificationId\": \"0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe\",\n            \"compiledPath\": \"browser/1_Storage.sol\",\n            \"name\": \"Storage\",\n            \"compilerVersion\": \"0.6.6+commit.6c089d02\",\n            \"address\": \"0x656d0062eC89c940213E3F3170EA8b2add1c0143\",\n            \"chainId\": \"100\",\n            \"files\": {\n                \"found\": [\n                    \"browser/1_Storage.sol\"\n                ],\n                \"missing\": []\n            },\n            \"status\": \"perfect\"\n        }\n    ],\n    \"unused\": [],\n    \"fetch\": true\n}"
 								}
 							]
 						},

--- a/docs/api/server/verification1/verify.md
+++ b/docs/api/server/verification1/verify.md
@@ -78,7 +78,7 @@ If using `application/json`, the files should be in an object under the key `fil
 
 **Condition** : Failed fetching missing files. OR Contract bytecode does not match deployed bytecode.
 
-**Code** : `400 Bad Request Error`
+**Code** : `500 Internal Server Error`
 
 **Content** : 
 ```json

--- a/docs/api/server/verification2/exchange-object.md
+++ b/docs/api/server/verification2/exchange-object.md
@@ -44,8 +44,7 @@ The object expected by the server from the client is a proper subset of (1) and 
             "chainId": "100",
             "compilerVersion": "0.6.6+commit.6c089d02"
         }
-    ],
-    "fetch": true // if true or "true", then considered true, all other values are treated as false
+    ]
 }
 ```
 - If the client does not know some of the properties yet, they may be omitted.

--- a/docs/api/server/verification2/verify-validated.md
+++ b/docs/api/server/verification2/verify-validated.md
@@ -13,9 +13,9 @@
 
 ## Responses
 
-**Assumptions for all example responses (except the last)** :
-* There is one pending contract with 0 or 1 missing source file, but no `address` or `chainId`.
-* Supplying the following minimum object:
+**Assumptions for all example responses (except the last one)** :
+* There is one pending contract with all source files, but no `address` or `chainId`.
+* Supplying the following minimum object (extra properties would be ignored):
 ```json
 {
     "contracts": [
@@ -29,9 +29,7 @@
 }
 ```
 
-**Conditions** :
-- All the source files have been previously provided.
-- The provided contract `perfect`ly matches the one at the provided `chainId` and `address`.
+**Condition** : The provided contract `perfect`ly matches the one at the provided `chainId` and `address`.
 
 **Code** : `200 OK`
 
@@ -57,41 +55,6 @@
         }
     ],
     "unused": []
-}
-```
-
-### OR
-
-**Conditions** :
-- One source file is missing.
-- Fetching requested by providing `fetch: true`, look [here](exchange-object.md) for more info.
-- The provided contract `perfect`ly matches the one at the provided `chainId` and `address`.
-
-**Code** : `200 OK`
-
-**Content** :
-
-```json
-{
-    "contracts": [
-        {
-            "verificationId": "0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe",
-            "compiledPath": "browser/1_Storage.sol",
-            "name": "Storage",
-            "compilerVersion": "0.6.6+commit.6c089d02",
-            "address": "0x656d0062eC89c940213E3F3170EA8b2add1c0143",
-            "chainId": "100",
-            "files": {
-                "found": [
-                    "browser/1_Storage.sol"
-                ],
-                "missing": []
-            },
-            "status": "perfect"
-        }
-    ],
-    "unused": [],
-    "fetch": true
 }
 ```
 

--- a/environments/.env.latest
+++ b/environments/.env.latest
@@ -4,6 +4,7 @@ FQDN=sourcify.shardlabs.hr
 # Monitor config
 MONITOR_EXTERNAL_PORT=3000
 MONITOR_PORT=80
+MONITOR_FETCH_TIMEOUT=300000
 
 # UI config
 UI_EXTERNAL_PORT=1234
@@ -39,6 +40,10 @@ BUCKET_NAME=s3://sourcify-staging
 IPFS_SECRET=xxx
 IPFS_EXTERNAL_PORT=5050
 IPNS=k51qzi5uqu5dkuzo866rys9qexfvbfdwxjc20njcln808mzjrhnorgu5rh30lb
+IPFS_URL=http://ipfs-latest:8080/ipfs/
+
+# Fetch config
+FETCH_TIMEOUT=500
 
 # ENS config
 ENS_SECRET=xxx

--- a/environments/.env.stable
+++ b/environments/.env.stable
@@ -4,6 +4,7 @@ FQDN=verification.komputing.org
 # Monitor config
 MONITOR_EXTERNAL_PORT=3001
 MONITOR_PORT=80
+MONITOR_FETCH_TIMEOUT=300000
 
 # UI config
 UI_EXTERNAL_PORT=1235
@@ -39,6 +40,10 @@ BUCKET_NAME=s3://sourcify-ethereum
 IPFS_SECRET=xxx
 IPFS_EXTERNAL_PORT=5051
 IPNS=k51qzi5uqu5dll0ocge71eudqnrgnogmbr37gsgl12uubsinphjoknl6bbi41p
+IPFS_URL=http://ipfs-stable:8080/ipfs/
+
+# Fetch config
+FETCH_TIMEOUT=500
 
 # ENS config
 ENS_SECRET=xxx

--- a/scripts/run_monitor.js
+++ b/scripts/run_monitor.js
@@ -4,6 +4,7 @@ const Monitor = require('../dist/monitor/monitor.js').default;
 let config;
 
 const monitor = new Monitor({
+  ipfsCatRequest: process.env.IPFS_URL,
   repository: 'repository'
 });
 

--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -11,8 +11,7 @@ export interface InputData {
     chain: string,
     addresses: string[],
     contract?: CheckedContract,
-    bytecode?: string;
-    fetchMissing?: boolean;
+    bytecode?: string
 }
 
 export interface CompilationSettings {

--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -188,7 +188,7 @@ export class Injector {
      * @return {Promise<object>}              address & status of successfully verified contract
      */
     public async inject(inputData: InputData): Promise<Match> {
-        const { chain, addresses, contract, fetchMissing } = inputData;
+        const { chain, addresses, contract } = inputData;
         this.validateAddresses(addresses);
         this.validateChain(chain);
 
@@ -202,7 +202,7 @@ export class Injector {
 
         if (!CheckedContract.isValid(contract)) {
             // eslint-disable-next-line no-useless-catch
-            if (fetchMissing) try {
+            try {
                 await CheckedContract.fetchMissing(contract, this.log);
             } catch(err) {
                 throw err;

--- a/src/server/controllers/VerificationController-util.ts
+++ b/src/server/controllers/VerificationController-util.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express';
 import { Session } from 'express-session';
-import { PathContent, CheckedContract, isEmpty, PathBuffer } from '@ethereum-sourcify/core';
+import { PathContent, CheckedContract, isEmpty } from '@ethereum-sourcify/core';
 import Web3 from 'web3';
 
 export interface PathContentMap {
@@ -39,8 +39,7 @@ export type SessionMaps = {
 export type MySession = 
     Session &
     SessionMaps & { 
-    unusedSources: string[],
-    fetch?: boolean
+    unusedSources: string[]
 };
 
 export type MyRequest = 
@@ -60,9 +59,9 @@ export type SendableContract =
     verificationId?: string
 }
 
-export function isVerifiable(contractWrapper: ContractWrapper, ignoreMissing?: boolean) {
+export function isVerifiable(contractWrapper: ContractWrapper) {
     const contract = contractWrapper.contract;
-    return (isEmpty(contract.missing) || ignoreMissing)
+    return isEmpty(contract.missing)
         && isEmpty(contract.invalid)
         && Boolean(contractWrapper.compilerVersion)
         && Boolean(contractWrapper.address)
@@ -104,7 +103,7 @@ export function getSessionJSON(session: MySession) {
     }
 
     const unused = session.unusedSources || [];
-    return { contracts, unused, fetch: session.fetch };
+    return { contracts, unused };
 }
 
 export function generateId(obj: any): string {


### PR DESCRIPTION
- Add fetching timeout.
- Use IPFS_URL and FETCH_TIMEOUT env vars.
  - When using local IPFS fetching: `IPFS_URL=http://127.0.0.1:8080/ipfs/`
  - If no IPFS_URL provided: defaults to `https://ipfs.infura.io:5001/api/v0/cat?arg=`
- Make fetching from GitHub and IPFS the default behavior.
- Make monitor use the IPFS_URL variable (after a force-push)

Discussion point: Should IPFS_URL be encapsulated within config.ts or used directly from process.env?