### PR TITLE
Fix fullnode-dappnode usage

### DIFF
--- a/services/core/src/sourcify-chains.json
+++ b/services/core/src/sourcify-chains.json
@@ -1,21 +1,29 @@
 {
     "1": {
-        "dappnode": "http://geth.dappnode:8545",
+        "fullnode": {
+            "dappnode": "http://geth.dappnode:8545"
+        },
         "supported": true,
         "monitored": true
     },
     "3": {
-        "dappnode": "http://ropsten.dappnode:8545",
+        "fullnode": {
+            "dappnode": "http://ropsten.dappnode:8545"
+        },
         "supported": true,
         "monitored": true
     },
     "4": {
-        "dappnode": "http://rinkeby.dappnode:8545",
+        "fullnode": {
+            "dappnode": "http://rinkeby.dappnode:8545"
+        },
         "supported": true,
         "monitored": true
     },
     "5": {
-        "dappnode": "http://kovan.dappnode:8545",
+        "fullnode": {
+            "dappnode": "http://kovan.dappnode:8545"
+        },
         "supported": true,
         "monitored": true
     },


### PR DESCRIPTION
The sourcify-chains.json was left in a state that made it impossible for the current Injector implementation to use the dappnode data.  This is now fixed by correcting the json structure.