### PR TITLE
Monitor improvement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,10 +28,14 @@
       "name": "Monitor",
       "program": "${workspaceFolder}/scripts/run_monitor.js",
       "envFile": "${workspaceFolder}/environments/.env",
-      "preLaunchTask": "tsc: build - tsconfig.json",
+      "preLaunchTask": "npm: build:lerna",
       "outFiles": [
-        "${workspaceFolder}/dist/**/*.js"
+        "${workspaceFolder}/dist/**/*.js",
+        "${workspaceFolder}/services/core/build/**/*.js",
+        "${workspaceFolder}/services/validation/build/**/*.js",
+        "${workspaceFolder}/services/verification/build/**/*.js"
       ],
+      "smartStep": true,
       "console": "integratedTerminal", 
       "outputCapture": "std"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3521,6 +3521,27 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.0.tgz",
       "integrity": "sha512-BfbIHP9IapdupGhq/hc+jT5dyiBVZ2DdeC5WwJWQWDb0GijQlzUFAeIQn/2GtvZcd2HVUU7An8felIICFTC2qg=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -18894,24 +18915,6 @@
         }
       }
     },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -20067,11 +20070,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-each": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ethereum-sourcify/core": "*",
     "@ethereum-sourcify/validation": "*",
     "@ethereum-sourcify/verification": "*",
+    "@types/node-fetch": "^2.5.7",
     "bunyan": "^1.8.12",
     "cors": "^2.8.5",
     "death": "^1.1.0",
@@ -62,7 +63,7 @@
     "http-status-codes": "^2.1.4",
     "it-concat": "^1.0.1",
     "multihashes": "^3.0.1",
-    "request-promise-native": "^1.0.9",
+    "node-fetch": "^2.6.1",
     "serve-index": "^1.9.1",
     "web3": "^1.2.11"
   },

--- a/scripts/run_monitor.js
+++ b/scripts/run_monitor.js
@@ -1,29 +1,9 @@
 #!/usr/bin/env node
-const death = require('death');
 const Monitor = require('../dist/monitor/monitor.js').default;
-let config;
-
-const monitor = new Monitor({
-  ipfsCatRequest: process.env.IPFS_URL,
-  repository: 'repository'
-});
-
-if (process.env.TESTING === "true"){
-  console.log(
-    `Monitor will attach to test client: ${process.env.LOCALCHAIN_URL}`
-  );
-
-  config = {
-    name: 'localhost',
-    url: process.env.LOCALCHAIN_URL
-  }
-}
-
-// Ctrl c
-death(function(){
-  monitor.stop();
-});
 
 console.log("Starting monitor...");
+const monitor = new Monitor({
+    repository: 'repository'
+});
 
-monitor.start(config);
+monitor.start();

--- a/services/core/src/utils/CheckedContract.ts
+++ b/services/core/src/utils/CheckedContract.ts
@@ -55,18 +55,10 @@ export class CheckedContract {
             && isEmpty(contract.invalid);
     }
 
-    private sourceMapToStringMap(input: SourceMap) {
-        const ret: StringMap = {};
-        for (const key in input) {
-            ret[key] = input[key].content;
-        }
-        return ret;
-    }
-
-    public constructor(metadata: any, solidity: SourceMap, missing: any, invalid: StringMap) {
+    public constructor(metadata: any, solidity: StringMap, missing: any = {}, invalid: StringMap = {}) {
         this.metadataRaw = JSON.stringify(metadata);
         this.metadata = JSON.parse(JSON.stringify(metadata));
-        this.solidity = this.sourceMapToStringMap(solidity);
+        this.solidity = solidity;
         this.missing = missing;
         this.invalid = invalid;
 
@@ -75,7 +67,7 @@ export class CheckedContract {
             const metadataSource = sources[compiledPath];
             const foundSource = solidity[compiledPath];
             if (!metadataSource.content && foundSource) {
-                metadataSource.content = foundSource.content;
+                metadataSource.content = foundSource;
             }
             delete metadataSource.license;
         }

--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -70,43 +70,8 @@ export type MatchQuality = "full" | "partial";
 export type FilesInfo<T> = { status: MatchQuality, files: Array<T> };
 
 export interface MonitorConfig {
-  ipfsCatRequest? : string,
-  ipfsProvider? : any,
-  swarmGateway? : string,
   repository? : string,
-  blockTime? : number,
-  silent?: boolean
-}
-
-export interface CustomChainConfig {
-  name: string,
-  url: string
-}
-
-export declare interface ChainSet {
-  [key: string]: ChainData
-}
-
-export declare interface ChainData {
-  web3 : Web3,
-  metadataQueue: Queue,
-  sourceQueue: Queue,
-  latestBlock : number,
-  chainId: string
-}
-
-export declare interface Queue {
-  [key: string]: QueueItem;
-}
-
-export declare interface QueueItem {
-  bzzr1? : string,
-  ipfs? : string,
-  timestamp? : number,
-  metadataRaw? : string,
-  sources?: any,
-  found?: any,
-  bytecode?: string
+  testing?: boolean
 }
 
 export declare interface StringToBooleanMap {

--- a/services/core/src/utils/utils.ts
+++ b/services/core/src/utils/utils.ts
@@ -24,7 +24,7 @@ export type Chain = {
     web3: string[],
     faucets: string[],
     infoURL: string,
-    fullnode: { dappnode: string }
+    fullnode?: { dappnode: string }
 };
 
 type ChainMap = {
@@ -66,20 +66,32 @@ const supportedChains = filter(chainMap, c => c.supported);
 const monitoredChains = filter(chainMap, c => c.monitored);
 const fullnodeChains = filter(chainMap, c => c.fullnode);
 
+const TEST_CHAINS: Chain[] = [{
+    name: "Localhost",
+    shortName: "Localhost",
+    chainId: 0,
+    faucets: [],
+    infoURL: null,
+    nativeCurrency: null,
+    network: "testnet",
+    networkId: 0,
+    web3: [ `http://localhost:${process.env.LOCALCHAIN_PORT || 8545}` ]
+}];
+
 /**
  * Returns the chains currently supported by Sourcify server.
  * @returns array of chains currently supported by Sourcify server
  */
-export function getSupportedChains(): Chain[] {
-    return supportedChains;
+export function getSupportedChains(testing = false): Chain[] {
+    return testing ? TEST_CHAINS : supportedChains;
 }
 
 /**
  * Returns the chains currently monitored by Sourcify.
  * @returns array of chains currently monitored by Sourcify
  */
-export function getMonitoredChains(): Chain[] {
-    return monitoredChains;
+export function getMonitoredChains(testing = false): Chain[] {
+    return testing ? TEST_CHAINS : monitoredChains;
 }
 
 /**

--- a/services/validation/src/ValidationService.ts
+++ b/services/validation/src/ValidationService.ts
@@ -218,7 +218,7 @@ export class ValidationService implements IValidationService {
      * @return foundSources, missingSources, invalidSources
      */
     private rearrangeSources(metadata: any, byHash: Map<string, PathContent>) {
-        const foundSources: SourceMap = {};
+        const foundSources: StringMap = {};
         const missingSources: any = {};
         const invalidSources: StringMap = {};
         const metadata2provided: StringMap = {}; // maps fileName as in metadata to the fileName of the provided file
@@ -243,7 +243,7 @@ export class ValidationService implements IValidationService {
             }
 
             if (file && file.content) {
-                foundSources[fileName] = file;
+                foundSources[fileName] = file.content;
             } else {
                 missingSources[fileName] = { keccak256: hash, urls: sourceInfo.urls };
             }

--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -53,6 +53,14 @@ export class Injector {
     }
 
     /**
+     * Creates an instance of Injector. Does not initialize chains.
+     * @param config 
+     */
+    public static createOffline(config: InjectorConfig = {}): Injector {
+        return new Injector(config);
+    }
+
+    /**
      * Instantiates a web3 provider for all public ethereum networks via Infura or regular node.
      * If environment variable TESTING is set to true, localhost:8545 is also available.
      */

--- a/src/monitor/gateway.ts
+++ b/src/monitor/gateway.ts
@@ -1,0 +1,24 @@
+import { SourceOrigin } from "./util";
+
+export declare interface IGateway {
+    worksWith: (origin: SourceOrigin) => boolean;
+    createUrl: (fetchId: string) => string;
+}
+
+export class SimpleGateway implements IGateway {
+    private origins: SourceOrigin[];
+    private baseUrl: string;
+
+    constructor(origins: SourceOrigin | SourceOrigin[], baseUrl: string) {
+        this.origins = [].concat(origins);
+        this.baseUrl = baseUrl;
+    }
+
+    worksWith(origin: SourceOrigin): boolean {
+        return this.origins.includes(origin);
+    }
+
+    createUrl(fetchId: string): string {
+        return this.baseUrl + fetchId;
+    }
+}

--- a/src/monitor/monitor.ts
+++ b/src/monitor/monitor.ts
@@ -1,683 +1,176 @@
-/* eslint-disable */
-import Web3 from 'web3';
-import { ethers } from 'ethers';
-import request from 'request-promise-native';
-import concat from 'it-concat';
-import { outputFileSync } from 'fs-extra';
-import * as bunyan from 'bunyan';
-import { Injector } from '@ethereum-sourcify/verification';
-import config from '../config';
-import { BlockTransactionObject } from 'web3-eth';
-import {
-  MonitorConfig,
-  ChainSet,
-  CustomChainConfig,
-  Queue,
-  QueueItem,
-  StringToBooleanMap,
-  InputData,
-  cborDecode,
-  Logger,
-  getMonitoredChains,
-  PathBuffer,
-  CheckedContract
-} from '@ethereum-sourcify/core';
-import { ValidationService } from '@ethereum-sourcify/validation';
+import { cborDecode, getMonitoredChains, MonitorConfig } from "@ethereum-sourcify/core";
+import { Injector } from "@ethereum-sourcify/verification";
+import Logger from "bunyan";
+import Web3 from "web3";
+import { Transaction } from "web3-core";
+import { SourceAddress } from "./util";
+import { ethers } from "ethers";
+import dotenv from 'dotenv';
+import path from 'path';
+import SourceFetcher from "./source-fetcher";
+dotenv.config({ path: path.resolve(__dirname, "..", "..", "environments/.env") });
 
-const multihashes = require('multihashes');
-const save = outputFileSync;
-const FETCH_TIMEOUT = parseInt(process.env.MONITOR_FETCH_TIMEOUT) || (5 * 60 * 1000);
-const timedRequest = (url: string) => request(url, { timeout: FETCH_TIMEOUT });
+const BLOCK_PAUSE_FACTOR = parseInt(process.env.BLOCK_PAUSE_FACTOR) || 1.1;
+const BLOCK_PAUSE_UPPER_LIMIT = parseInt(process.env.BLOCK_PAUSE_UPPER_LIMIT) || (30 * 1000); // default: 30 seconds
+const BLOCK_PAUSE_LOWER_LIMIT = parseInt(process.env.BLOCK_PAUSE_LOWER_LIMIT) || (0.5 * 1000); // default: 0.5 seconds
 
-export default class Monitor {
-  private log: bunyan;
-  private chains: ChainSet;
-  private ipfsCatRequest: string;
-  private ipfsProvider: any;
-  private swarmGateway: string;
-  private repository: string;
-  private blockTime: number;
-  private blockInterval: any;
-  private sourceInterval: any;
-  private metadataInterval: any;
-  private injector: Injector;
-  private validationService: ValidationService;
+function createsContract(tx: Transaction): boolean {
+    return !tx.to;
+}
 
-  /**
-   * Constructor
-   *
-   * @param {MonitorConfig = {}} monitorConfig [description]
-   */
-  constructor(monitorConfig: MonitorConfig = {}) {
-    this.chains = {};
+/**
+ * A monitor that periodically checks for new contracts on a single chain.
+ */
+class ChainMonitor {
+    private chainId: string;
+    private web3Provider: Web3;
+    private sourceFetcher: SourceFetcher;
+    private logger: Logger;
+    private injector: Injector;
+    private running: boolean;
 
-    this.ipfsCatRequest = monitorConfig.ipfsCatRequest || 'https://ipfs.infura.io:5001/api/v0/cat?arg=';
-    this.ipfsProvider = monitorConfig.ipfsProvider || null;
-    this.swarmGateway = 'https://swarm-gateways.net/';
-    this.repository = monitorConfig.repository || 'repository';
-    this.blockTime = monitorConfig.blockTime || 15 // seconds;
+    private getBytecodeRetryPause: number;
+    private getBlockPause: number;
+    private initialGetBytecodeTries: number;
 
-    this.blockInterval = null;
-    this.sourceInterval = null;
-    this.metadataInterval = null;
+    constructor(name: string, chainId: string, web3Url: string, sourceFetcher: SourceFetcher, injector: Injector) {
+        this.chainId = chainId;
+        this.web3Provider = new Web3(web3Url);
+        this.sourceFetcher = sourceFetcher;
+        this.logger = new Logger({ name });
+        this.injector = injector;
 
-    this.log = Logger("Monitor");
-    this.validationService = new ValidationService(this.log);
-
-    Injector.createAsync({
-      offline: true,
-      log: this.log,
-      infuraPID: config.endpoint.infuraId || "changeinfuraid",
-      repositoryPath: config.repository.path
-    }).then((injector: Injector) => this.injector = injector); // TODO temporary solution to enable compilation; await not allowed inside a constructor
-  }
-
-  /**
-   * Starts running the monitor, listening to public eth chains via Infura for new contract
-   * deployments and inserting them in a queue that periodically queries decentralized storage
-   * providers like IPFS to retrieve metadata stored at the hash embedded in a contract's deployed
-   * bytecode. Can be configured to listen to a single custom network (like localhost) for testing.
-   *
-   * @param  {CustomChainConfig} customChain
-   * @return {Promise<void>}
-   */
-  public async start(customChain?: CustomChainConfig): Promise<void> {
-    for (const chain of getMonitoredChains()) {
-      const url: string = customChain
-        ? customChain.url
-        : chain.web3[0].replace("${INFURA_API_KEY}", process.env.INFURA_ID);
-      
-      this.chains[chain.name] = {
-        web3: new Web3(url),
-        metadataQueue: {},
-        sourceQueue: {},
-        latestBlock: 0,
-        chainId: chain.chainId.toString()
-      };
-
-      const blockNumber = await this.chains[chain.name].web3.eth.getBlockNumber();
-      this.chains[chain.name].latestBlock = blockNumber;
-
-      this.log.info(
-        {
-          loc: '[START]',
-          chain: chain,
-          block: blockNumber
-        },
-        'Starting monitor for chain'
-      );
+        this.getBytecodeRetryPause = parseInt(process.env.GET_BYTECODE_RETRY_PAUSE) || (5 * 1000);
+        this.getBlockPause = parseInt(process.env.GET_BLOCK_PAUSE) || (10 * 1000);
+        this.initialGetBytecodeTries = parseInt(process.env.INITIAL_GET_BYTECODE_TRIES) || 3;
     }
 
-    this.blockInterval = setInterval(this.retrieveBlocks.bind(this), 1000 * this.blockTime);
-    this.metadataInterval = setInterval(this.retrieveMetadata.bind(this), 1000 * this.blockTime);
-    this.sourceInterval = setInterval(this.retrieveSource.bind(this), 1000 * this.blockTime);
-  }
-
-  /**
-   * Shuts down the monitor
-   */
-  public stop(): void {
-    this.log.info({ loc: '[STOP]' }, 'Stopping monitor')
-    clearInterval(this.blockInterval);
-    clearInterval(this.metadataInterval);
-    clearInterval(this.sourceInterval);
-  }
-
-  /**
-   * Wraps the ipfs.cat command. `cat` can be run with in-memory ipfs
-   * provider or by a gateway url, per monitor config
-   *
-   * @param  {string}          hash [description]
-   * @return {Promise<string>}      [description]
-   */
-  private async ipfsCat(hash: string): Promise<string> {
-    return (this.ipfsProvider)
-      ? (await concat(this.ipfsProvider.cat(`/ipfs/${hash}`))).slice().toString() // TODO the point of slice? copying? return await should be avoided
-      : timedRequest(`${this.ipfsCatRequest}${hash}`);
-  }
-
-  // =======
-  // Queue
-  // =======
-
-  /**
-   * Adds item to a string indexed set the monitor will periodically iterate over,
-   * seeking to match contract deployments and their associated metadata / source components.
-   * Each item is timestamped so it can be removed when stale.
-   *
-   * @param {StringMap} queue string indexed set
-   * @param {string}    key   index
-   * @param {QueueItem} item
-   */
-  private addToQueue(queue: Queue, key: string, item: QueueItem): void {
-    if (queue[key] !== undefined)
-      return;
-    item.timestamp = new Date().getTime();
-    queue[key] = item;
-  }
-
-  /**
-   * Deletes items from a queue that have gone stale
-   *
-   * @param {StringMap} queue        string indexed set
-   * @param {number}    maxAgeInSecs staleness criterion
-   */
-  private cleanupQueue(queue: Queue, maxAgeInSecs: number): void {
-    const toDelete: StringToBooleanMap = {};
-
-    // getTime
-    for (const key in queue) {
-      // tslint:disable-next-line: no-useless-cast
-      const currentTimeMillis = new Date().getTime();
-      if ((queue[key].timestamp as number + (maxAgeInSecs * 1000)) < currentTimeMillis) {
-        toDelete[key] = true;
-      }
+    start = async (): Promise<void> => {
+        this.running = true;
+        const rawStartBlock = process.env[`MONITOR_START_${this.chainId}`];
+        const startBlock = (rawStartBlock !== undefined) ?
+            parseInt(rawStartBlock) : await this.web3Provider.eth.getBlockNumber();
+        this.processBlock(startBlock);
+        this.logger.info({ loc: "[MONITOR_START]", startBlock }, "Starting monitor");
     }
-    for (const key in toDelete) {
-      delete queue[key]
+
+    /**
+     * Stops the monitor after executing all pending requests.
+     */
+    stop = (): void => {
+        this.running = false;
     }
-  }
 
-  // =======
-  // Blocks
-  // =======
+    private processBlock = (blockNumber: number) => {
+        this.web3Provider.eth.getBlock(blockNumber, true).then(block => {
+            if (!block) {
+                this.getBlockPause *= BLOCK_PAUSE_FACTOR;
+                this.getBlockPause = Math.min(this.getBlockPause, BLOCK_PAUSE_UPPER_LIMIT);
 
-  /**
-   * Retrieves blocks for all chains
-   */
-  private retrieveBlocks(): void {
-    try {
-      for (const chain in this.chains) {
-        this.retrieveBlocksInChain(chain);
-      }
-    } catch (err) {
-      this.log.info(
-        {
-          loc: '[ERROR]',
-          err: err
-        },
-        'Block retreival error'
-      );
-    }
-  }
+                const logObject = { loc: "[PROCESS_BLOCK]", blockNumber, getBlockPause: this.getBlockPause };
+                this.logger.info(logObject, "Waiting for new blocks");
+                return;
 
-  /**
-   * Polls chain for new blocks, detecting contract deployments and
-   * calling `retrieveBytecode` when one is discovered
-   *
-   * @param {string} chain [description]
-   */
-  private retrieveBlocksInChain(chain: string): void {
-    const _this = this;
-    const web3 = this.chains[chain].web3;
-
-    web3.eth.getBlockNumber((err: Error, newBlockNr: number) => {
-      if (err) return;
-      // tslint:disable restrict-plus-operands
-      newBlockNr = Math.min(newBlockNr, _this.chains[chain].latestBlock + 4);
-
-      for (; _this.chains[chain].latestBlock < newBlockNr; _this.chains[chain].latestBlock++) {
-        const latest = _this.chains[chain].latestBlock;
-
-        web3.eth.getBlock(latest, true, (err: Error, block: BlockTransactionObject) => {
-          if (err || !block) {
-            const latest = _this.chains[chain].latestBlock;
-
-            this.log.info(
-              {
-                loc: '[BLOCKS]',
-                chain: chain,
-                block: latest,
-                err: err.message
-              },
-              'Block not available'
-            );
-
-            return;
-          }
-
-          this.log.info(
-            {
-              loc: '[BLOCKS]',
-              chain: chain,
-              block: block.number
-            },
-            'Processing Block'
-          );
-
-          for (const i in block.transactions) {
-            const t = block.transactions[i]
-            if (t.to === null) {
-              const address = ethers.utils.getContractAddress(t);
-
-              this.log.info(
-                {
-                  loc: '[BLOCKS]',
-                  chain: chain,
-                  block: block.number,
-                  address: address
-                },
-                `Retrieving code for address`
-              );
-
-              _this.retrieveCode(chain, address);
+            } else {
+                this.getBlockPause /= BLOCK_PAUSE_FACTOR;
+                this.getBlockPause = Math.max(this.getBlockPause, BLOCK_PAUSE_LOWER_LIMIT);
             }
-          }
-        })
-      }
-    })
-  }
 
-  /**
-   * Fetches on-chain deployed bytecode and extracts its metadata hash. Add the item to
-   * a metadata queue which will periodically query decentralized storage to discover whether
-   * metadata exists at the discovered metadata hash address.
-   *
-   * @param {string} chain   ex: 'ropsten'
-   * @param {string} address contract address
-   */
-  private retrieveCode(chain: string, address: string): void {
-    const _this = this;
-    const web3 = this.chains[chain].web3;
+            for (const tx of block.transactions) {
+                if (createsContract(tx)) {
+                    const address = ethers.utils.getContractAddress(tx);
+                    this.processBytecode(address, this.initialGetBytecodeTries);
+                }
+            }
 
-    this.log.info({loc: "[BLOCKS]", chain, address}, "Retrieving code");
+            blockNumber++;
 
-    web3.eth.getCode(address, (err: Error, bytecode: string) => {
-      if (err) {
-        this.log.error({loc: "[BLOCKS]", chain, address}, "Cannot retrieve code");
-        return;
-      }
+        }).catch(err => {
+            this.logger.error({ loc: "[PROCESS_BLOCK:FAILED]", blockNumber }, err.message);
+        }).finally(() => {
+            this.mySetTimeout(this.processBlock, this.getBlockPause, blockNumber);
+        });
+    }
 
-      try {
-        const cborData = cborDecode(web3.utils.hexToBytes(bytecode))
-
-        if (!cborData) {
-
+    private processBytecode = (address: string, retriesLeft: number): void => {
+        if (retriesLeft-- <= 0) {
+            return;
         }
 
-        let option;
-        let metadata;
+        this.web3Provider.eth.getCode(address).then(bytecode => {
+            if (bytecode === "0x") {
+                this.logger.info({ loc: "[PROCESS_BYTECODE]", address, retriesLeft }, "Empty bytecode");
+                this.mySetTimeout(this.processBytecode, this.getBytecodeRetryPause, address, retriesLeft);
+                return;
+            }
 
-        if ("bzzr1" in cborData) {
-          option = "bzzr1";
-          metadata = web3.utils.bytesToHex(cborData['bzzr1']).slice(2);
-        } else if ("ipfs" in cborData) {
-          option = "ipfs";
-          metadata = multihashes.toB58String(cborData['ipfs']);
-        } else {
-          this.log.warn({loc: "[BLOCKS]", chain, address}, "Could not find a compatible metadata extraction method");
-          return;
+            const numericBytecode = Web3.utils.hexToBytes(bytecode);
+            try {
+                const cborData = cborDecode(numericBytecode);
+                const metadataAddress = SourceAddress.fromCborData(cborData);
+                this.sourceFetcher.assemble(metadataAddress, contract => {
+                    const logObject = { loc: "[PROCESS_BYTECODE]", contract: contract.name, address };
+                    this.injector.inject({
+                        contract,
+                        bytecode,
+                        chain: this.chainId,
+                        addresses: [address]
+                    }).then(() => this.logger.info(logObject, "Successfully injected")
+                    ).catch(err => this.logger.error(logObject, err.message));
+                });
+            } catch(err) {
+                this.logger.error({ loc: "[GET_BYTECODE:METADATA_READING]", address }, err.message);
+            }
+
+        }).catch(err => {
+            this.logger.error({ loc: "[GET_BYTECODE]", address, retriesLeft }, err.message);
+            this.mySetTimeout(this.processBytecode, this.getBytecodeRetryPause, address, retriesLeft);
+        });
+    }
+
+    private mySetTimeout(handler: TimerHandler, timeout: number, ...args: any[]) {
+        if (this.running) {
+            setTimeout(handler, timeout, ...args);
         }
-
-        const infoObject: any = {loc: "[BLOCKS]", chain, address};
-        infoObject[option] = option;
-        this.log.info(infoObject, "Queueing retrieval of metadata");
-
-        const queueItem: any = {bytecode};
-        queueItem[option] = metadata;
-
-        _this.addToQueue(
-          _this.chains[chain].metadataQueue,
-          address,
-          queueItem
-        );
-
-      } catch (error) {
-        this.log.error({loc: "[BLOCKS]", chain, address}, "Error in metadata extraction.");
-      }
-    })
-  }
-
-  // =========
-  // Metadata
-  // =========
-
-  /**
-   * Retrieves metadata by chain. This data may be in decentralized storage - its storage
-   * address has been queued after a contract deployment was detected by the retrieveBlocks
-   * engine.
-   */
-  private retrieveMetadata(): void {
-    try {
-      for (const chain in this.chains) {
-        this.retrieveMetadataInChain(chain);
-      }
-    } catch (err) {
-      this.log.info(
-        {
-          loc: '[ERROR]',
-          err: err
-        },
-        'Metadata retreival error'
-      );
     }
-  }
+}
 
-  /**
-   * Retrieves metadata from decentralized storage provider
-   * for chain after deleting stale metadata queue items.
-   * @param {string} chain ex: 'ropsten'
-   */
-  private retrieveMetadataInChain(chain: string): void {
-    /// Try to retrieve metadata for one hour
-    this.cleanupQueue(this.chains[chain].metadataQueue, 3600)
-    for (const address in this.chains[chain].metadataQueue) {
-      this.log.info(
-        {
-          loc: '[METADATA]',
-          chain: chain,
-          address: address
-        },
-        'Processing metadata queue'
-      );
+/**
+ * A monitor that periodically checks for new contracts on designated chains.
+ */
+export default class Monitor {
+    private chainMonitors: ChainMonitor[];
+    private injector: Injector;
+    private sourceFetcher = new SourceFetcher();
 
-      // tslint:disable-next-line:no-floating-promises
-      this.retrieveMetadataByStorageProvider(
-        chain,
-        address,
-        this.chains[chain].metadataQueue[address].bytecode,
-        this.chains[chain].metadataQueue[address]['bzzr1'],
-        this.chains[chain].metadataQueue[address]['ipfs']
-      );
-    }
-  }
+    constructor(config: MonitorConfig) {
+        this.injector = Injector.createOffline({
+            log: new Logger({ name: "Monitor" }),
+            repositoryPath: config.repository
+        });
 
-  /**
-   * Queries decentralized storage for metadata at the location specified by
-   * hash embedded in the bytecode of a deployed contract. If metadata is discovered,
-   * its sources are added to a source discovery queue. (Supports swarm:bzzr1 and ipfs)
-   *
-   * @param  {string}        chain         ex: 'ropsten'
-   * @param  {string}        address       contract address
-   * @param  {string}        metadataBzzr1 storage hash
-   * @param  {string}        metadataIpfs  storage hash
-   * @return {Promise<void>}
-   */
-  private async retrieveMetadataByStorageProvider(
-    chain: string,
-    address: string,
-    bytecode: string | undefined,
-    metadataBzzr1: string | undefined,
-    metadataIpfs: string | undefined
-  ): Promise<void> {
-    let metadataRaw;
-
-    const found: any = {
-      files: {},
-      bytecode: bytecode
-    };
-
-    if (metadataBzzr1) {
-
-      try {
-        // TODO guard against too large files
-        // TODO only write files after recompilation check?
-        metadataRaw = await timedRequest(`${this.swarmGateway}/bzz-raw:/${metadataBzzr1}`);
-        found.swarm = {
-          metadataPath: `${this.repository}/swarm/bzzr1/${metadataBzzr1}`,
-          file: metadataRaw
-        }
-      } catch (error) { return }
-
-    } else if (metadataIpfs) {
-
-      try {
-        metadataRaw = await this.ipfsCat(metadataIpfs);
-        found.ipfs = {
-          metadataPath: `${this.repository}/ipfs/${metadataIpfs}`,
-          file: metadataRaw.toString()
-        }
-      } catch (error) { return }
+        const chains = getMonitoredChains(config.testing || false);
+        this.chainMonitors = chains.map((chain: any) => new ChainMonitor(
+            chain.name,
+            chain.chainId.toString(),
+            chain.web3[0].replace("${INFURA_API_KEY}", process.env.INFURA_ID),
+            this.sourceFetcher,
+            this.injector
+        ));
     }
 
-    this.log.info(
-      {
-        loc: '[METADATA]',
-        chain: chain,
-        address: address
-      },
-      'Got metadata by address'
-    );
-
-    // found.files.push(metadataRaw.toString()) TODO this shouldn't be in the same array as solidity content
-
-    const metadata = JSON.parse(metadataRaw);
-    delete this.chains[chain].metadataQueue[address];
-
-    try {
-      this.addToQueue(this.chains[chain].sourceQueue, address, {
-        metadataRaw: metadataRaw.toString(),
-        sources: metadata.sources,
-        found: found
-      });
-    } catch (error) {
-
-    }
-  }
-
-
-  // =======
-  // Sources
-  // =======
-
-  /**
-   * Queries decentralized storage for solidity files at the location specified by
-   * a metadata sources manifest.
-   */
-  private retrieveSource(): void {
-    try {
-      for (const chain in this.chains) {
-        this.retrieveSourceInChain(chain);
-      }
-    } catch (err) {
-      this.log.info(
-        {
-          loc: '[ERROR]',
-          err: err
-        },
-        'Source retreival error'
-      );
-    }
-  }
-
-  /**
-   * Retrieves solidity files by address from decentralized storage provider after
-   * deleting stale source queue items.
-   * @param {string} chain ex: 'ropsten'
-   */
-  private retrieveSourceInChain(chain: string): void {
-    /// Try to retrieve source for five days.
-    this.cleanupQueue(this.chains[chain].sourceQueue, 3600 * 24 * 5)
-
-    for (const address in this.chains[chain].sourceQueue) {
-      this.log.info(
-        {
-          loc: '[SOURCE]',
-          chain: chain,
-          address: address
-        },
-        'Processing source queue'
-      );
-
-      this.retrieveSourceByAddress(
-        chain,
-        address,
-        this.chains[chain].sourceQueue[address].sources
-      );
-    }
-  }
-
-  /**
-   * Retrieves solidity files *for* a contract address from decentralized storage provider.
-   *
-   * @param {string} chain ex: 'ropsten'
-   * @param {string} chain   [description]
-   * @param {string} address [description]
-   * @param {any}    sources [description]
-   */
-  private retrieveSourceByAddress(
-    chain: string,
-    address: string,
-    sources: any
-  ): void {
-    for (const sourceKey in sources) {
-      for (const url of sources[sourceKey]['urls']) {
-
-        // tslint:disable-next-line:no-floating-promises
-        this.retrieveSwarmSource(chain, address, sourceKey, url);
-
-        // tslint:disable-next-line:no-floating-promises
-        this.retrieveIpfsSource(chain, address, sourceKey, url);
-      }
-    }
-  }
-
-  /**
-   * Queries swarm for solidity file at metadata specified url and saves if found
-   * @param  {string}        chain     ex: 'ropsten'
-   * @param  {string}        address   contract address
-   * @param  {string}        sourceKey file path or file name
-   * @param  {string}        url       metadata specified swarm url
-   * @return {Promise<void>}
-   */
-  private async retrieveSwarmSource(
-    chain: string,
-    address: string,
-    sourceKey: string,
-    url: string
-  ): Promise<void> {
-    if (!url.startsWith('bzz-raw')) return;
-
-    try {
-      const source = await timedRequest(`${this.swarmGateway}${url}`);
-
-      // tslint:disable-next-line:no-floating-promises
-      this.sourceFound(chain, address, sourceKey, source);
-
-    } catch (error) {
-      // ignore
-    }
-  }
-
-  /**
-   * Queries ipfs for solidity file at metadata specified url and saves if found.
-   * @param  {string}        chain     ex: 'ropsten'
-   * @param  {string}        address   contract address
-   * @param  {string}        sourceKey file path or file name
-   * @param  {string}        url       metadata specified ipfs url
-   * @return {Promise<void>}
-   */
-  private async retrieveIpfsSource(
-    chain: string,
-    address: string,
-    sourceKey: string,
-    url: string
-  ): Promise<void> {
-
-    if (!url.startsWith('dweb')) return;
-
-    try {
-      const source = await this.ipfsCat(url.split('dweb:/ipfs/')[1]);
-
-      // tslint:disable-next-line:no-floating-promises
-      this.sourceFound(chain, address, sourceKey, source.toString());
-
-    } catch (error) {
-      // ignore
-    }
-  }
-
-  /**
-   * Writes discovered sources to repository under chain address and source key
-   * qualified path:
-   *
-   * @example "repository/contract/ropsten/0xabc..defc/sources/Simple.sol"
-
-   * @param {string} chain     ex: 'ropsten'
-   * @param {string} address   contract address
-   * @param {string} sourceKey file path or file name
-   * @param {string} source    solidity file
-   */
-  private async sourceFound(
-    chain: string,
-    address: string,
-    sourceKey: string,
-    source: string
-  ): Promise<void> {
-
-    const queueItem = this.chains[chain].sourceQueue[address];
-    if (queueItem && (sourceKey in queueItem.sources)) {
-      queueItem.found.files[sourceKey] = source;
-      delete queueItem.sources[sourceKey];
-    } else {
-      return;
+    /**
+     * Starts the monitor on all the designated chains.
+     */
+    start = (): void => {
+        this.chainMonitors.forEach(cm => cm.start());
     }
 
-    const remaining = Object.keys(queueItem.sources);
-
-    this.log.info(
-      {
-        loc: '[SOURCES]',
-        chain: chain,
-        address: address,
-        sources: remaining
-      },
-      'Sources left to be retrieved'
-    );
-
-    // Once we've assembled all the sources, inject them.
-    // Also save ipfs and swarm hashes.
-    if (Object.keys(queueItem.sources).length == 0) {
-
-      const inputFiles: PathBuffer[] = [];
-      const metadataPathBuffer = { buffer: Buffer.from(queueItem.metadataRaw) }; // TODO is property metadataRaw really optional?
-      inputFiles.push(metadataPathBuffer);
-      for (const filePath in queueItem.found.files) {
-        const fileContent = queueItem.found.files[filePath];
-        const filePathBuffer = { buffer: Buffer.from(fileContent), path: filePath };
-        inputFiles.push(filePathBuffer);
-      }
-
-      const data: InputData = {
-        chain: this.chains[chain].chainId,
-        addresses: [address],
-        bytecode: queueItem.found.bytecode
-      };
-
-      try {
-        const validatedContracts = this.validationService.checkFiles(inputFiles);
-        const errors = validatedContracts
-                        .filter(contract => !CheckedContract.isValid(contract))
-                        .map(contract => contract.getInfo());
-        if (errors.length) {
-          throw new Error(errors.join("\n"));
-        }
-
-        if (validatedContracts.length !== 1) {
-          const contractNames = validatedContracts.map(c => c.name).join(", ");
-          const msg = `Detected ${validatedContracts.length} contracts (${contractNames}), but can only verify one at a time`;
-          throw new Error(msg);
-        }
-
-        data.contract = validatedContracts[0];
-
-        await this.injector.inject(data);
-
-        if (queueItem.found.swarm) {
-          save(queueItem.found.swarm.metadataPath, queueItem.found.swarm.file)
-        }
-
-        if (queueItem.found.ipfs) {
-          save(queueItem.found.ipfs.metadataPath, queueItem.found.ipfs.file)
-        }
-      } catch (err) {
-        this.log.error({
-          loc: "[SOURCES:INJECTION_FAILED]",
-          chain,
-          address
-        }, err);
-      }
-      delete this.chains[chain].sourceQueue[address];
+    /**
+     * Stops the monitor after executing all the pending requests.
+     */
+    stop = (): void => {
+        this.chainMonitors.forEach(cm => cm.stop());
+        this.sourceFetcher.stop();
     }
-  }
 }

--- a/src/monitor/pending-contract.ts
+++ b/src/monitor/pending-contract.ts
@@ -1,0 +1,78 @@
+import { StringMap } from '@ethereum-sourcify/core';
+import SourceFetcher from './source-fetcher';
+import { SourceAddress } from "./util";
+import Logger from 'bunyan';
+import Web3 from 'web3';
+import { CheckedContract, isEmpty } from '@ethereum-sourcify/core';
+
+type PendingSource = { keccak256: string, urls: string[], name: string };
+interface PendingSourceMap {
+    [keccak256: string]: PendingSource;
+}
+type Metadata = { sources: PendingSourceMap };
+
+export default class PendingContract {
+    private metadata: Metadata;
+    private pendingSources: PendingSourceMap;
+    private fetchedSources: StringMap = {};
+    private sourceFetcher: SourceFetcher;
+    private callback: (contract: CheckedContract) => void;
+    private logger = new Logger({ name: "Pending Contract" });
+
+    constructor(sourceFetcher: SourceFetcher, callback: (checkedContract: CheckedContract) => void) {
+        this.sourceFetcher = sourceFetcher;
+        this.callback = callback;
+    }
+
+    /**
+     * Assembles this contract by first fetching its metadata and then fetching all the sources listed in the metadata.
+     * 
+     * @param metadataAddress an object representing the location of the contract metadata
+     */
+    assemble(metadataAddress: SourceAddress) {
+        this.sourceFetcher.subscribe(metadataAddress, this.addMetadata);
+    }
+
+    private addMetadata = (rawMetadata: string) => {
+        this.metadata = JSON.parse(rawMetadata);
+        this.pendingSources = {};
+
+        const count = Object.keys(this.metadata.sources).length;
+        this.logger.info({ loc: "[PENDING_CONTRACT:ADD_METADATA]", count }, "New pending files");
+
+        for (const name in this.metadata.sources) {
+            const source = this.metadata.sources[name];
+            source.name = name;
+            this.pendingSources[source.keccak256] = source;
+
+            for (const url of source.urls) { // TODO make this more efficient; this might leave unnecessary subscriptions hanging
+                const sourceAddress = SourceAddress.fromUrl(url);
+                if (!sourceAddress) {
+                    this.logger.error(
+                        { loc: "[ADD_METADATA]", url, name },
+                        "Could not determine source file location"
+                    );
+                    continue;
+                }
+                this.sourceFetcher.subscribe(sourceAddress, this.addFetchedSource);
+            }
+        }
+    }
+
+    private addFetchedSource = (sourceContent: string) => {
+        const hash = Web3.utils.keccak256(sourceContent);
+        const source = this.pendingSources[hash];
+
+        if (!source || source.name in this.fetchedSources) {
+            return;
+        }
+
+        delete this.pendingSources[hash];
+        this.fetchedSources[source.name] = sourceContent;
+
+        if (isEmpty(this.pendingSources)) {
+            const contract = new CheckedContract(this.metadata, this.fetchedSources);
+            this.callback(contract);
+        }
+    }
+}

--- a/src/monitor/source-fetcher.ts
+++ b/src/monitor/source-fetcher.ts
@@ -1,0 +1,195 @@
+import { CheckedContract } from "@ethereum-sourcify/core";
+import Logger from "bunyan";
+import { StatusCodes } from "http-status-codes";
+import nodeFetch from 'node-fetch';
+import { IGateway, SimpleGateway } from "./gateway";
+import PendingContract from "./pending-contract";
+import { SourceAddress, FetchedFileCallback } from "./util";
+
+const STARTING_INDEX = 0;
+const NO_PAUSE = 0;
+
+class Subscription {
+    sourceAddress: SourceAddress;
+    fetchUrl: string;
+    beingProcessed = false;
+    subscribers: Array<FetchedFileCallback> = [];
+
+    constructor(sourceAddress: SourceAddress, fetchUrl: string) {
+        this.sourceAddress = sourceAddress;
+        this.fetchUrl = fetchUrl;
+    }
+}
+
+declare interface SubscriptionMap {
+    [hash: string]: Subscription
+}
+
+declare interface TimestampMap {
+    [hash: string]: Date
+}
+
+/**
+ * A fetcher of contract source files (metadata and solidity).
+ * Allows assembling a contract (collecting its sources) from the address of its metadata.
+ * Allows subscribing to individual sources.
+ */
+export default class SourceFetcher {
+    private subscriptions: SubscriptionMap = {};
+    private timestamps: TimestampMap = {};
+    private logger = new Logger({ name: "SourceFetcher" });
+    private fileCounter = 0;
+    private subscriptionCounter = 0;
+    private running = true;
+
+    private fetchTimeout: number; // when to terminate a request
+    private fetchPause: number; // how much time to wait between two requests
+    private cleanupTime: number; // how much time has to pass before a source is forgotten
+
+    private gateways: IGateway[] = [
+        new SimpleGateway("ipfs", process.env.IPFS_URL || "https://ipfs.infura.io:5001/api/v0/cat?arg="),
+        new SimpleGateway(["bzzr0", "bzzr1"], "https://swarm-gateways.net/bzz-raw:/")
+    ];
+
+    constructor() {
+        this.fetchTimeout = parseInt(process.env.MONITOR_FETCH_TIMEOUT) || (5 * 60 * 1000);
+        this.fetchPause = parseInt(process.env.MONITOR_FETCH_PAUSE) || (1 * 1000);
+        this.cleanupTime = parseInt(process.env.MONITOR_CLEANUP_PERIOD) || (30 * 60 * 1000);
+        this.fetch([], STARTING_INDEX);
+    }
+
+    /**
+     * Stops the fetcher after executing all pending requests.
+     */
+    stop(): void {
+        this.running = false;
+    }
+
+    private fetch = (sourceHashes: string[], index: number): void => {
+        if (index >= sourceHashes.length) {
+            const newSourceHashes = Object.keys(this.subscriptions); // make a copy so that subscriptions can be freely cleared if necessary
+            if (this.running) setTimeout(this.fetch, NO_PAUSE, newSourceHashes, STARTING_INDEX);
+            return;
+        }
+
+        const sourceHash = sourceHashes[index];
+        const subscription = this.subscriptions[sourceHash];
+        let nextFast = false;
+
+        if (!(sourceHash in this.subscriptions) || subscription.beingProcessed) {
+            nextFast = true;
+        
+        } else if (this.shouldCleanup(sourceHash)) {
+            this.cleanup(sourceHash);
+            nextFast = true;
+        }
+
+        if (nextFast) {
+            setTimeout(this.fetch, NO_PAUSE, sourceHashes, index + 1);
+            return;
+        }
+
+        subscription.beingProcessed = true;
+        const fetchUrl = subscription.fetchUrl;
+        nodeFetch(fetchUrl, { timeout: this.fetchTimeout }).then(resp => {
+            resp.text().then(text => {
+                if (resp.status === StatusCodes.OK) {
+                    this.notifySubscribers(sourceHash, text);
+
+                } else {
+                    this.logger.error({
+                        loc: "[SOURCE_FETCHER:FETCH_FAILED]",
+                        status: resp.status,
+                        statusText: resp.statusText,
+                        sourceHash
+                    }, text);
+                }
+            });
+
+        }).catch(err => this.logger.error(
+            { loc: "[SOURCE_FETCHER]", fetchUrl }, err.message
+        )).finally(() => {
+            subscription.beingProcessed = false;
+        });
+
+        if (this.running) setTimeout(this.fetch, this.fetchPause, sourceHashes, index + 1);
+    }
+
+    private findGateway(sourceAddress: SourceAddress) {
+        for (const gateway of this.gateways) {
+            if (gateway.worksWith(sourceAddress.origin)) {
+                return gateway;
+            }
+        }
+
+        throw new Error(`Gateway not found for ${sourceAddress.origin}`);
+    }
+
+    private notifySubscribers(id: string, file: string) {
+        if (!(id in this.subscriptions)) {
+            return;
+        }
+
+        const subscription = this.subscriptions[id];
+        this.cleanup(id);
+
+        this.logger.info({
+            loc: "[SOURCE_FETCHER:NOTIFY]",
+            id,
+            subscribers: subscription.subscribers.length
+        }, "Fetching successful");
+
+        subscription.subscribers.forEach(callback => callback(file));
+    }
+
+    /**
+     * Fetches the requested source and executes the callback on the fetched content.
+     * 
+     * @param sourceAddress an object representing the location of the source file
+     * @param callback the callback to be called on the fetched content
+     */
+    subscribe(sourceAddress: SourceAddress, callback: FetchedFileCallback): void {
+        const sourceHash = sourceAddress.getUniqueIdentifier();
+        const gateway = this.findGateway(sourceAddress);
+        const fetchUrl = gateway.createUrl(sourceAddress.id);
+        
+        if (!(sourceHash in this.subscriptions)) {
+            this.subscriptions[sourceHash] = new Subscription(sourceAddress, fetchUrl);
+            this.fileCounter++;
+        }
+        
+        this.timestamps[sourceHash] = new Date();
+        this.subscriptions[sourceHash].subscribers.push(callback);
+
+        this.subscriptionCounter++;
+        this.logger.info({ loc: "[SOURCE_FETCHER:NEW_SUBSCRIPTION]", filesPending: this.fileCounter, subscriptions: this.subscriptionCounter });
+    }
+
+    private cleanup(sourceHash: string) {
+        delete this.timestamps[sourceHash];
+        const subscribers = Object.keys(this.subscriptions[sourceHash].subscribers);
+        const subscriptionsDelta = subscribers.length;
+        delete this.subscriptions[sourceHash];
+
+        this.fileCounter--;
+        this.subscriptionCounter -= subscriptionsDelta;
+        this.logger.info({ loc: "[SOURCE_FETCHER:CLEANUP]", sourceHash, filesPending: this.fileCounter, subscriptions: this.subscriptionCounter });
+    }
+
+    private shouldCleanup(sourceHash: string) {
+        const timestamp = this.timestamps[sourceHash];
+        return timestamp && (timestamp.getTime() + this.cleanupTime < Date.now());
+    }
+
+    /**
+     * Begins the process of assembling a contract's sources. This is done by fetching the metadata from the address provided. 
+     * After assembling the contract, the provided callback is called.
+     * 
+     * @param metadataAddress an object representing the location of the contract metadata
+     * @param callback the callback to be called on the contract once it is assembled
+     */
+    assemble(metadataAddress: SourceAddress, callback: (contract: CheckedContract) => void) {
+        const contract = new PendingContract(this, callback);
+        contract.assemble(metadataAddress);
+    }
+}

--- a/src/monitor/util.ts
+++ b/src/monitor/util.ts
@@ -1,0 +1,66 @@
+import Web3 from "web3";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const multihashes = require("multihashes");
+
+export type SourceOrigin = "ipfs" | "bzzr1" | "bzzr0";
+
+export type FetchedFileCallback= (fetchedFile: string) => any;
+
+interface Prefix {
+    regex: RegExp,
+    origin: SourceOrigin
+}
+
+const PREFIXES: Prefix[] = [
+    { origin: "ipfs", regex: /dweb:\/ipfs\/{1,2}/ },
+    { origin: "bzzr1", regex: /bzz-raw:\/{1,2}/ }
+];
+
+interface CborProcessor {
+    origin: SourceOrigin,
+    process: (bytes: number[]) => string
+}
+
+const CBOR_PROCESSORS: CborProcessor[] = [
+    { origin: "ipfs", process: multihashes.toB58String },
+    { origin: "bzzr0", process: (data) => Web3.utils.bytesToHex(data).slice(2) },
+    { origin: "bzzr1", process: (data) => Web3.utils.bytesToHex(data).slice(2) }
+]
+
+export class SourceAddress {
+    origin: SourceOrigin;
+    id: string;
+
+    constructor(origin: SourceOrigin, id: string) {
+        this.origin = origin;
+        this.id = id;
+    }
+
+    getUniqueIdentifier(): string {
+        return this.origin + "-" + this.id;
+    }
+
+    static fromUrl(url: string): SourceAddress {
+        for (const prefix of PREFIXES) {
+            const attempt = url.replace(prefix.regex, "");
+            if (attempt !== url) {
+                return new SourceAddress(prefix.origin, attempt);
+            }
+        }
+
+        return null;
+    }
+
+    static fromCborData(cborData: any): SourceAddress {
+        for (const cborProcessor of CBOR_PROCESSORS) {
+            const bytes = cborData[cborProcessor.origin];
+            if (bytes) {
+                const metadataId = cborProcessor.process(bytes);
+                return new SourceAddress(cborProcessor.origin, metadataId);
+            }
+        }
+
+        const msg = `Unsupported metadata file format: ${Object.keys(cborData)}`;
+        throw new Error(msg);
+    }
+}

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -2,7 +2,7 @@ const dagPB = require('ipld-dag-pb');
 const UnixFS = require('ipfs-unixfs');
 const multihashes = require('multihashes');
 const Web3 = require('web3');
-const utils = require('./../../src/utils/Utils');
+const utils = require('../../services/core/build/utils/utils');
 
 /**
  * Deploys a contract to testrpc

--- a/test/server.js
+++ b/test/server.js
@@ -2,8 +2,8 @@ process.env.TESTING = true;
 process.env.LOCALCHAIN_URL = "http://localhost:8545";
 process.env.MOCK_REPOSITORY = './dist/data/mock-repository';
 process.env.MOCK_DATABASE = './dist/data/mock-database';
-process.env.SOLC_REPO='./dist/data/solc-repo';
-process.env.SOLJSON_REPO='/dist/data/soljson-repo';
+process.env.SOLC_REPO = './dist/data/solc-repo';
+process.env.SOLJSON_REPO = '/dist/data/soljson-repo';
 
 const chai = require("chai");
 const chaiHttp = require("chai-http");
@@ -18,11 +18,14 @@ chai.use(chaiHttp);
 
 const EXTENDED_TIME = 15000; // 15 seconds
 
-describe("Server", async function() {
+describe("Server", function() {
     const server = new Server();
-    const promisified = util.promisify(server.app.listen);
-    await promisified(server.port);
-    console.log(`Injector listening on port ${server.port}!`);
+
+    before(async () => {
+        const promisified = util.promisify(server.app.listen);
+        await promisified(server.port);
+        console.log(`Injector listening on port ${server.port}!`);
+    })
 
     beforeEach(() => {
         rimraf.sync(process.env.MOCK_REPOSITORY);


### PR DESCRIPTION
- Restructure the Monitor component
- Dynamically adapt the time between two block fetchings
- Enable monitoring old blocks (via env vars)
- Enable monitor mocha testing
- Changes to services/verification/src/services/Injector.ts (add an offline version of the static constructor)
- Pending:
  - Squash to a single commit

- Fix #385
- Fix #387
- Fix #399