### PR TITLE
Hotfix for latest solc-bin executables

### DIFF
--- a/src/Dockerfile.monitor
+++ b/src/Dockerfile.monitor
@@ -1,4 +1,4 @@
-FROM node:10 as builder
+FROM node:12
 WORKDIR /home/app
 
 COPY environments/.env ./environments/

--- a/src/Dockerfile.server
+++ b/src/Dockerfile.server
@@ -1,7 +1,6 @@
-FROM node:10-alpine as builder
+FROM node:12
 WORKDIR /home/app
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh python make g++ curl
+
 COPY environments/.env ./environments/
 COPY services/core ./services/core
 COPY services/validation ./services/validation


### PR DESCRIPTION
- alpine images were not able to run any solc from 0.7.6