### PR TITLE
Monitor2.2

### DIFF
--- a/src/monitor/gateway.ts
+++ b/src/monitor/gateway.ts
@@ -3,11 +3,12 @@ import { SourceOrigin } from "./util";
 export declare interface IGateway {
     worksWith: (origin: SourceOrigin) => boolean;
     createUrl: (fetchId: string) => string;
+    baseUrl: string;
 }
 
 export class SimpleGateway implements IGateway {
     private origins: SourceOrigin[];
-    private baseUrl: string;
+    baseUrl: string;
 
     constructor(origins: SourceOrigin | SourceOrigin[], baseUrl: string) {
         this.origins = [].concat(origins);

--- a/src/monitor/pending-contract.ts
+++ b/src/monitor/pending-contract.ts
@@ -41,9 +41,10 @@ export default class PendingContract {
     private addMetadata = (rawMetadata: string) => {
         this.metadata = JSON.parse(rawMetadata);
         this.pendingSources = {};
+        const loc = "[PENDING_CONTRACT:ADD_METADATA]";
 
         const count = Object.keys(this.metadata.sources).length;
-        this.logger.info({ loc: "[PENDING_CONTRACT:ADD_METADATA]", count }, "New pending files");
+        this.logger.info({ loc, count }, "New pending files");
 
         for (const name in this.metadata.sources) {
             const source = this.metadata.sources[name];
@@ -54,21 +55,24 @@ export default class PendingContract {
                 continue;
             } else if (!source.keccak256) {
                 const err = "The source provides neither content nor keccak256";
-                this.logger.error({ loc: "[PENDING_CONTRACT:ADD_METADATA]", name, err });
+                this.logger.error({ loc, name, err });
                 break;
             }
             this.pendingSources[source.keccak256] = source;
 
+            const sourceAddresses: SourceAddress[] = [];
             for (const url of source.urls) {
                 const sourceAddress = SourceAddress.fromUrl(url);
                 if (!sourceAddress) {
-                    this.logger.error(
-                        { loc: "[ADD_METADATA]", url, name },
-                        "Could not determine source file location"
-                    );
+                    this.logger.error({ loc, url, name }, "Could not determine source file location");
                     continue;
                 }
-                this.sourceFetcher.subscribe(sourceAddress, this.addFetchedSource);
+                sourceAddresses.push(sourceAddress);
+
+                this.sourceFetcher.subscribe(sourceAddress, (sourceContent: string) => {
+                    this.addFetchedSource(sourceContent);
+                    this.sourceFetcher.unsubscribe(sourceAddresses);
+                });
             }
         }
 

--- a/src/monitor/pending-contract.ts
+++ b/src/monitor/pending-contract.ts
@@ -71,7 +71,10 @@ export default class PendingContract {
 
                 this.sourceFetcher.subscribe(sourceAddress, (sourceContent: string) => {
                     this.addFetchedSource(sourceContent);
-                    this.sourceFetcher.unsubscribe(sourceAddresses);
+                    // once source is resolved from one endpoint, others don't have to be pinged anymore, so delete them
+                    for (const deletableSourceAddress of sourceAddresses) {
+                        this.sourceFetcher.unsubscribe(deletableSourceAddress);
+                    }
                 });
             }
         }

--- a/src/monitor/source-fetcher.ts
+++ b/src/monitor/source-fetcher.ts
@@ -68,7 +68,7 @@ export default class SourceFetcher {
     private fetch = (sourceHashes: string[], index: number): void => {
         if (index >= sourceHashes.length) {
             const newSourceHashes = Object.keys(this.subscriptions); // make a copy so that subscriptions can be freely cleared if necessary
-            if (this.running) setTimeout(this.fetch, NO_PAUSE, newSourceHashes, STARTING_INDEX);
+            this.mySetTimeout(this.fetch, NO_PAUSE, newSourceHashes, STARTING_INDEX);
             return;
         }
 
@@ -85,7 +85,7 @@ export default class SourceFetcher {
         }
 
         if (nextFast) {
-            setTimeout(this.fetch, NO_PAUSE, sourceHashes, index + 1);
+            this.mySetTimeout(this.fetch, NO_PAUSE, sourceHashes, index + 1);
             return;
         }
 
@@ -112,7 +112,13 @@ export default class SourceFetcher {
             subscription.beingProcessed = false;
         });
 
-        if (this.running) setTimeout(this.fetch, this.fetchPause, sourceHashes, index + 1);
+        this.mySetTimeout(this.fetch, this.fetchPause, sourceHashes, index + 1);
+    }
+
+    private mySetTimeout = (handler: TimerHandler, timeout: number, ...args: any[]) => {
+        if (this.running) {
+            setTimeout(handler, timeout, ...args);
+        }
     }
 
     private findGateway(sourceAddress: SourceAddress) {

--- a/src/monitor/util.ts
+++ b/src/monitor/util.ts
@@ -4,7 +4,7 @@ const multihashes = require("multihashes");
 
 export type SourceOrigin = "ipfs" | "bzzr1" | "bzzr0";
 
-export type FetchedFileCallback= (fetchedFile: string) => any;
+export type FetchedFileCallback = (fetchedFile: string) => any;
 
 interface Prefix {
     regex: RegExp,

--- a/src/monitor/util.ts
+++ b/src/monitor/util.ts
@@ -36,7 +36,10 @@ export class SourceAddress {
         this.id = id;
     }
 
-    getUniqueIdentifier(): string {
+    /**
+     * @returns a unique identifier of this source address
+     */
+    getSourceHash(): string {
         return this.origin + "-" + this.id;
     }
 

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -87,7 +87,7 @@ class MonitorWrapper {
         const addressMetadataPath = this.getAddressMetadataPath(address);
         fs.mkdirSync(path.dirname(addressMetadataPath), { recursive: true });
         fs.writeFileSync(addressMetadataPath, metadata);
-        return fs.statSync(addressMetadataPath).birthtime;
+        return fs.statSync(addressMetadataPath).ctime;
     }
 }
 

--- a/test/server.js
+++ b/test/server.js
@@ -52,7 +52,7 @@ describe("Server", function() {
 
     const contractChain = "5"; // goerli
     const contractAddress = "0x000000bCB92160f8B7E094998Af6BCaD7fa537fe";
-    const fakeAddress = "0x000000bCB92160f8B7E094998Af6BCaD7fa537ff"
+    const fakeAddress = "0x000000bCB92160f8B7E094998Af6BCaD7fa537ff";
 
     const assertError = (err, res, field) => {
         chai.expect(err).to.be.null;


### PR DESCRIPTION
Reduce congestion in source fetching by:
- separating fetching to different queues (not really queues, basically arrays iterated over), one per each gateway (ipfs, swarm)
- removing unnecessary scheduled fetchings (e.g. a source is retrieved from ipfs -> can be deleted from the swarm queue)

Make cleanup implementation clearer.