### PR TITLE
Make constructor arguments available in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ This paragraph should be read with the following in mind:
 
 The repository (https://repo.sourcify.dev) provides the following GET endpoints:
 * JSON-formatted metadata file (with ABI): `/contracts/<MATCH_QUALITY>/<CHAIN_ID>/<CONTRACT_ADDRESS>/metadata.json`
+* JSON-formatted file with constructor arguments (only for fully matched contracts using [immutable variables](https://ethereum.stackexchange.com/questions/82240/what-is-the-immutable-keyword-in-solidity)): `/contracts/full_match/<CHAIN_ID>/<CONTRACT_ADDRESS>/constructor-args.txt`
 * Source file: `/contracts/<MATCH_QUALITY>/<CHAIN_ID>/<CONTRACT_ADDRESS>/sources/<FILE_PATH>`
 * JSON-formatted full and partial match count per chain: `/stats.json`
 * JSON-formatted timestamp and version of the repo: `/manifest.json`

--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -50,9 +50,17 @@ export interface SourceMap {
 
 export interface Match {
   address: string | null,
-  status: 'perfect' | 'partial' | null,
+  status: Status,
   storageTimestamp?: Date,
-  message?: string
+  message?: string,
+  encodedConstructorArgs?: string,
+}
+
+export type Status = 'perfect' | 'partial' | null;
+
+export type CompareResult = {
+  status: Status,
+  encodedConstructorArgs: string
 }
 
 /**

--- a/test/server.js
+++ b/test/server.js
@@ -15,7 +15,15 @@ const path = require("path");
 const MAX_INPUT_SIZE = require("../dist/server/controllers/VerificationController").default.MAX_INPUT_SIZE;
 const StatusCodes = require('http-status-codes').StatusCodes;
 const { waitSecs } = require("./helpers/helpers");
+const Web3EthAbi = require("web3-eth-abi");
 chai.use(chaiHttp);
+
+const binaryParser = function(res, cb) {
+    res.setEncoding("binary");
+    res.data = "";
+    res.on("data", chunk => res.data += chunk);
+    res.on("end", () => cb(null, Buffer.from(res.data, "binary")));
+}
 
 const EXTENDED_TIME = 20000; // 20 seconds
 
@@ -256,7 +264,7 @@ describe("Server", function() {
                 .end((err, res) => assertions(err, res, done, address));
         });
 
-        const verifyContractWithImmutables = (address, chainId, chainName, metadataFileName="withImmutables.meta.object.json") => {
+        const verifyContractWithImmutables = (address, chainId, chainName, ctorArg, metadataFileName="withImmutables.meta.object.json") => {
             it(`should verify a contract with immutables on ${chainName}`, done => {
                 const sourcePath = path.join("test", "sources", "contracts", "WithImmutables.sol");
                 const sourceBuffer = fs.readFileSync(sourcePath);
@@ -268,23 +276,37 @@ describe("Server", function() {
                     .field("chain", chainId)
                     .attach("files", metadataBuffer, "metadata.json")
                     .attach("files", sourceBuffer, "WithImmutables.sol")
-                    .end((err, res) => assertions(err, res, done, address));
+                    .end((err, res) => {
+                        assertions(err, res, null, address);
+
+                        chai.request(server.app)
+                            .get(`/repository/contracts/full_match/${chainId}/${address}/constructor-args.txt`)
+                            .buffer()
+                            .parse(binaryParser)
+                            .end((err, res) => {
+                                chai.expect(err).to.be.null;
+                                chai.expect(res.status).to.equal(StatusCodes.OK);
+                                const encodedParameter = Web3EthAbi.encodeParameter("uint256", ctorArg);
+                                chai.expect(res.body.toString()).to.equal(encodedParameter);
+                                done();
+                            });
+                    });
             });
         };
 
-        verifyContractWithImmutables("0x656d0062eC89c940213E3F3170EA8b2add1c0143", "3", "Ropsten");
+        verifyContractWithImmutables("0x656d0062eC89c940213E3F3170EA8b2add1c0143", "3", "Ropsten", 987);
 
-        verifyContractWithImmutables("0x656d0062eC89c940213E3F3170EA8b2add1c0143", "4", "Rinkeby");
+        verifyContractWithImmutables("0x656d0062eC89c940213E3F3170EA8b2add1c0143", "4", "Rinkeby", 101);
 
-        verifyContractWithImmutables("0xBdDe4D595F2CDdA92ca274423374E0e1C7286426", "5", "Goerli");
+        verifyContractWithImmutables("0xBdDe4D595F2CDdA92ca274423374E0e1C7286426", "5", "Goerli", 2);
         
-        verifyContractWithImmutables("0x443C64AcC4c6dB358Eb1CA78fdf7577C2a7eA499", "42", "Kovan");
+        verifyContractWithImmutables("0x443C64AcC4c6dB358Eb1CA78fdf7577C2a7eA499", "42", "Kovan", 256);
 
-        verifyContractWithImmutables("0x3CE1a25376223695284edc4C2b323C3007010C94", "100", "xDai");
+        verifyContractWithImmutables("0x3CE1a25376223695284edc4C2b323C3007010C94", "100", "xDai", 123);
         
-        verifyContractWithImmutables("0x66ec3fBf4D7d7B7483Ae4fBeaBDD6022037bfa1a", "44787", "Alfajores Celo");
+        verifyContractWithImmutables("0x66ec3fBf4D7d7B7483Ae4fBeaBDD6022037bfa1a", "44787", "Alfajores Celo", 777);
 
-        verifyContractWithImmutables("0xD222286c59c0B9c8D06Bac42AfB7B8CB153e7Bf7", "77", "Sokol", "withImmutables2.meta.object.json");
+        verifyContractWithImmutables("0xD222286c59c0B9c8D06Bac42AfB7B8CB153e7Bf7", "77", "Sokol", 1234, "withImmutables2.meta.object.json");
 
         it("should return 'partial', then delete partial when 'full' match", done => {
             const partialMetadataPath = path.join("test", "testcontracts", "1_Storage", "metadata-modified.json");


### PR DESCRIPTION
- Close #435.
- The arguments are provided as a text file with hex digits called `constructor-args.txt`, at the same level as `metadata.json`.
- The hex string is "0x" prefixed.
- This stores only the arguments of constructors of contracts using immutable variables.