### PR TITLE
Add Sokol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ watches:
   + Kovan
   + Goerli
   + xDai
+  + POA Network Sokol
   + Polygon (previously Matic)
   + Mumbai Testnet (Polygon/Matic)
   + Binance Smart Chain Mainnet (monitoring temporarily suspended)

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -2,12 +2,15 @@ import Web3 from "web3";
 
 const ETHERSCAN_REGEX = "at txn <a href='/tx/(.*?)'";
 const ETHERSCAN_SUFFIX = "address/${ADDRESS}";
-const BLOCKSCOUT_REGEX = "transaction_hash_link\" href=\"/tx/(.*?)\"";
+const BLOCKSCOUT_REGEX = "transaction_hash_link\" href=\"${BLOCKSCOUT_PREFIX}/tx/(.*?)\"";
 const BLOCKSCOUT_SUFFIX = "address/${ADDRESS}/transactions";
-const BLOCKSCOUT_XDAI_REGEX = "transaction_hash_link\" href=\"/xdai/mainnet/tx/(.*?)\"";
 
 function createArchiveEndpoint(hostPrefix: string) {
     return new Web3(`https://${hostPrefix}.alchemyapi.io/v2/${process.env.ALCHEMY_ID}`)
+}
+
+function getBlockscoutRegex(blockscoutPrefix="") {
+    return BLOCKSCOUT_REGEX.replace("${BLOCKSCOUT_PREFIX}", blockscoutPrefix);
 }
 
 export default {
@@ -68,6 +71,12 @@ export default {
         "contractFetchAddress": "https://bscscan.com/" + ETHERSCAN_SUFFIX,
         "txRegex": ETHERSCAN_REGEX
     },
+    "77": {
+        "supported": true,
+        "monitored": true,
+        "contractFetchAddress": "https://blockscout.com/poa/sokol/" + BLOCKSCOUT_SUFFIX,
+        "txRegex": getBlockscoutRegex("/poa/sokol")
+    },
     "97": {
         "supported": true,
         "monitored": false,
@@ -78,36 +87,36 @@ export default {
         "supported": true,
         "monitored": true,
         "contractFetchAddress": "https://blockscout.com/xdai/mainnet/" + BLOCKSCOUT_SUFFIX,
-        "txRegex": BLOCKSCOUT_XDAI_REGEX
+        "txRegex": getBlockscoutRegex("/xdai/mainnet")
     },
     "137": {
         "supported": true,
         "monitored": true,
         "contractFetchAddress": "https://explorer-mainnet.maticvigil.com/" + BLOCKSCOUT_SUFFIX,
-        "txRegex": BLOCKSCOUT_REGEX
+        "txRegex": getBlockscoutRegex()
     },
     "42220": {
         "supported": true,
         "monitored": true,
         "contractFetchAddress": "https://explorer.celo.org/" + BLOCKSCOUT_SUFFIX,
-        "txRegex": BLOCKSCOUT_REGEX
+        "txRegex": getBlockscoutRegex()
     },
     "44787": {
         "supported": true,
         "monitored": true,
         "contractFetchAddress": "https://alfajores-blockscout.celo-testnet.org/" + BLOCKSCOUT_SUFFIX,
-        "txRegex": BLOCKSCOUT_REGEX
+        "txRegex": getBlockscoutRegex()
     },
     "62320": {
         "supported": true,
         "monitored": true,
         "contractFetchAddress": "https://baklava-blockscout.celo-testnet.org/" + BLOCKSCOUT_SUFFIX,
-        "txRegex": BLOCKSCOUT_REGEX
+        "txRegex": getBlockscoutRegex()
     },
     "80001": {
         "supported": true,
         "monitored": true,
         "contractFetchAddress": "https://explorer-mumbai.maticvigil.com/" + BLOCKSCOUT_SUFFIX,
-        "txRegex": BLOCKSCOUT_REGEX
+        "txRegex": getBlockscoutRegex()
     }
 }

--- a/test/server.js
+++ b/test/server.js
@@ -255,11 +255,11 @@ describe("Server", function() {
                 .end((err, res) => assertions(err, res, done, address));
         });
 
-        const verifyContractWithImmutables = (address, chainId, chainName) => {
+        const verifyContractWithImmutables = (address, chainId, chainName, metadataFileName="withImmutables.meta.object.json") => {
             it(`should verify a contract with immutables on ${chainName}`, done => {
                 const sourcePath = path.join("test", "sources", "contracts", "WithImmutables.sol");
                 const sourceBuffer = fs.readFileSync(sourcePath);
-                const metadataPath = path.join("test", "sources", "metadata", "withImmutables.meta.object.json");
+                const metadataPath = path.join("test", "sources", "metadata", metadataFileName);
                 const metadataBuffer = fs.readFileSync(metadataPath);
                 chai.request(server.app)
                     .post("/")
@@ -282,6 +282,8 @@ describe("Server", function() {
         verifyContractWithImmutables("0x3CE1a25376223695284edc4C2b323C3007010C94", "100", "xDai");
         
         verifyContractWithImmutables("0x66ec3fBf4D7d7B7483Ae4fBeaBDD6022037bfa1a", "44787", "Alfajores Celo");
+
+        verifyContractWithImmutables("0xD222286c59c0B9c8D06Bac42AfB7B8CB153e7Bf7", "77", "Sokol", "withImmutables2.meta.object.json");
 
         it("should return 'partial', then delete partial when 'full' match", done => {
             const partialMetadataPath = path.join("test", "testcontracts", "1_Storage", "metadata-modified.json");

--- a/test/sources/metadata/withImmutables2.meta.object.json
+++ b/test/sources/metadata/withImmutables2.meta.object.json
@@ -1,0 +1,95 @@
+{
+	"compiler": {
+		"version": "0.7.4+commit.3f05b770"
+	},
+	"language": "Solidity",
+	"output": {
+		"abi": [
+			{
+				"inputs": [
+					{
+						"internalType": "uint256",
+						"name": "a",
+						"type": "uint256"
+					}
+				],
+				"stateMutability": "nonpayable",
+				"type": "constructor"
+			},
+			{
+				"inputs": [],
+				"name": "_a",
+				"outputs": [
+					{
+						"internalType": "uint256",
+						"name": "",
+						"type": "uint256"
+					}
+				],
+				"stateMutability": "view",
+				"type": "function"
+			},
+			{
+				"inputs": [],
+				"name": "read",
+				"outputs": [
+					{
+						"internalType": "string",
+						"name": "",
+						"type": "string"
+					}
+				],
+				"stateMutability": "view",
+				"type": "function"
+			},
+			{
+				"inputs": [
+					{
+						"internalType": "string",
+						"name": "name",
+						"type": "string"
+					}
+				],
+				"name": "sign",
+				"outputs": [],
+				"stateMutability": "nonpayable",
+				"type": "function"
+			}
+		],
+		"devdoc": {
+			"kind": "dev",
+			"methods": {},
+			"version": 1
+		},
+		"userdoc": {
+			"kind": "user",
+			"methods": {},
+			"version": 1
+		}
+	},
+	"settings": {
+		"compilationTarget": {
+			"contracts/WithImmutables.sol": "WithImmutables"
+		},
+		"evmVersion": "istanbul",
+		"libraries": {},
+		"metadata": {
+			"bytecodeHash": "ipfs"
+		},
+		"optimizer": {
+			"enabled": false,
+			"runs": 200
+		},
+		"remappings": []
+	},
+	"sources": {
+		"contracts/WithImmutables.sol": {
+			"keccak256": "0xbee62e4af99b4199c5b0982f5da15fc58215a4d547724bc574d516df07f66dc2",
+			"urls": [
+				"bzz-raw://6d83c127e075a149ec14c6af579bc7b24955cdb7578ae7da2f253b7142d267cc",
+				"dweb:/ipfs/QmW6tdCTV7X5dd5LCKDWedbMmkurQTMi4ePx7LY3DNuLn7"
+			]
+		}
+	},
+	"version": 1
+}

--- a/ui-draft/src/common/constants.ts
+++ b/ui-draft/src/common/constants.ts
@@ -13,6 +13,7 @@ export const CHAIN_GROUPS = [
         label: "xDai",
         chains: [
             {value: "xdai", label: "xDai", id: 100},
+            {value: "sokol", label: "Sokol", id: 77},
         ]
     },
     {

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -5,6 +5,7 @@ export const CHAIN_OPTIONS = [
     {value: "kovan", label: "Kovan", id: 42},
     {value: "goerli", label: "Görli", id: 5},
     {value: "xdai", label: "xDai", id: 100},
+    {value: "sokol", label: "Sokol", id: 77},
     {value: "binance smart chain mainnet", label: "Binance Smart Chain Mainnet", id: 56},
     {value: "binance smart chain testnet", label: "Binance Smart Chain Testnet", id: 97},
     {value: "matic mainnet", label: "Polygon (previously Matic)", id: 137},


### PR DESCRIPTION
Support the verification of contracts deployed on POA Network Sokol. Support is added for:
- API verification
- old UI verification
- new UI-draft verification
- automatic monitor verification

This PR updates README.md and adds a new mocha test.

Closes https://github.com/ethereum/sourcify/issues/451.