### PR TITLE
Mark contracts without bytecode hash as partial matches

### DIFF
--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -372,12 +372,17 @@ export class Injector {
         // Now we can store the re-compiled and correctly formatted metadata file
         // and the sources.
         if (match.address && match.status) {
+            const metadataPath = this.getMetadataPathFromCborEncoded(compilationResult, match.address, chain);
+            if (metadataPath) {
+                this.fileService.save(metadataPath, compilationResult.metadata);
+                this.fileService.deletePartial(chain, match.address);
+            } else {
+                match.status = "partial";
+            }
+
             const matchQuality = this.statusToMatchQuality(match.status);
             this.storeSources(matchQuality, chain, match.address, contract.solidity);
             this.storeMetadata(matchQuality, chain, match.address, compilationResult);
-            if (match.status === "perfect") {
-                this.fileService.deletePartial(chain, match.address);
-            }
 
             if (match.encodedConstructorArgs && match.encodedConstructorArgs.length) {
                 this.storeConstructorArgs(matchQuality, chain, match.address, match.encodedConstructorArgs);
@@ -414,6 +419,27 @@ export class Injector {
             .replace(/(^|\/)[.]+($|\/)/, '_');
     }
 
+    private getMetadataPathFromCborEncoded(compilationResult: RecompilationResult, address: string, chain: string) {
+        const bytes = Web3.utils.hexToBytes(compilationResult.deployedBytecode);
+        const cborData = cborDecode(bytes);
+
+        if (cborData['bzzr0']) {
+            return`/swarm/bzzr0/${Web3.utils.bytesToHex(cborData['bzzr0']).slice(2)}`;
+        } else if (cborData['bzzr1']) {
+            return `/swarm/bzzr1/${Web3.utils.bytesToHex(cborData['bzzr1']).slice(2)}`;
+        } else if (cborData['ipfs']) {
+            return `/ipfs/${multihashes.toB58String(cborData['ipfs'])}`;
+        }
+
+        this.log.error({
+            loc: '[INJECTOR:GET_METADATA_PATH]',
+            address,
+            chain,
+            err: "No metadata hash in cbor encoded data."
+        });
+        return null;
+    }
+
     /**
      * Stores the metadata from compilationResult to the swarm | ipfs subrepo. The exact storage path depends
      * on the swarm | ipfs address extracted from compilationResult.deployedByteode.
@@ -431,32 +457,6 @@ export class Injector {
         },
             compilationResult.metadata
         );
-
-        if (matchQuality === "full") {
-            let metadataPath: string;
-            const bytes = Web3.utils.hexToBytes(compilationResult.deployedBytecode);
-            const cborData = cborDecode(bytes);
-
-            if (cborData['bzzr0']) {
-                metadataPath = `/swarm/bzzr0/${Web3.utils.bytesToHex(cborData['bzzr0']).slice(2)}`;
-            } else if (cborData['bzzr1']) {
-                metadataPath = `/swarm/bzzr1/${Web3.utils.bytesToHex(cborData['bzzr1']).slice(2)}`;
-            } else if (cborData['ipfs']) {
-                metadataPath = `/ipfs/${multihashes.toB58String(cborData['ipfs'])}`;
-            } else {
-                const err = new Error(
-                    "Re-compilation successful, but could not find reference to metadata file in cbor data."
-                );
-
-                this.log.error({
-                    loc: '[INJECTOR:STORE_METADATA]', address, chain, err
-                });
-
-                throw err;
-            }
-
-            this.fileService.save(metadataPath, compilationResult.metadata);
-        }
     }
 
     /**

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -163,7 +163,8 @@ describe("Monitor", function() {
     const contractWrappers = {
         simpleWithImport: new ContractWrapper("./sources/pass/simpleWithImport.js", { metadata: true, sources: true }),
         simpleLiteral: new ContractWrapper("./sources/pass/simple.literal.js", { metadata: true }),
-        withImmutables: new ContractWrapper("./sources/pass/withImmutables.js", { metadata: true, sources: true }, [2])
+        withImmutables: new ContractWrapper("./sources/pass/withImmutables.js", { metadata: true, sources: true }, [2]),
+        withoutMetadataHash: new ContractWrapper("./sources/pass/withoutMetadataHash.js", { metadata: true, sources: true })
     };
 
     let ipfsNode;
@@ -245,6 +246,13 @@ describe("Monitor", function() {
 
     it("should sourcify a contract with immutables", async function() {
         await sourcifyContract(contractWrappers.withImmutables);
+    });
+
+    it("should gracefully handle a contract without an embedded metadata hash", async function() {
+        const monitorWrapper = new MonitorWrapper();
+
+        await waitSecs(MONITOR_SECS);
+        monitorWrapper.stop();
     });
 
     after(async function() {

--- a/test/server.js
+++ b/test/server.js
@@ -369,6 +369,18 @@ describe("Server", function() {
                         });
                 });     
         });
+
+        it("should mark contracts without an embedded metadata hash as a 'partial' match", done => {
+            const address = "0x093203902B71Cdb1dAA83153b3Df284CD1a2f88d";
+            const metadataPath = path.join("test", "sources", "metadata", "withoutMetadataHash.meta.object.json");
+            const metadataBuffer = fs.readFileSync(metadataPath);
+            chai.request(server.app)
+                .post("/")
+                .field("address", address)
+                .field("chain", "5")
+                .attach("files", metadataBuffer)
+                .end((err, res) => assertions(err, res, done, address, "partial"));
+        });
     });
 
     describe("verification v2", function() {

--- a/test/sources/metadata/withoutMetadataHash.meta.object.json
+++ b/test/sources/metadata/withoutMetadataHash.meta.object.json
@@ -1,0 +1,43 @@
+{
+    "compiler": {
+        "version": "0.7.0+commit.9e61f92b"
+    },
+    "language": "Solidity",
+    "output": {
+        "abi": [],
+        "devdoc": {
+            "kind": "dev",
+            "methods": {},
+            "version": 1
+        },
+        "userdoc": {
+            "kind": "user",
+            "methods": {},
+            "version": 1
+        }
+    },
+    "settings": {
+        "compilationTarget": {
+            "contracts/Contract.sol": "Contract"
+        },
+        "evmVersion": "istanbul",
+        "libraries": {},
+        "metadata": {
+            "bytecodeHash": "none",
+            "useLiteralContent": true
+        },
+        "optimizer": {
+            "enabled": false,
+            "runs": 200
+        },
+        "remappings": []
+    },
+    "sources": {
+        "contracts/Contract.sol": {
+            "content": "//SPDX-License-Identifier: Unlicense\npragma solidity ^0.7.0;\n\ncontract Contract {}\n",
+            "keccak256": "0x12c9c3c58310574ec340c35a1246a667e3d71964542e0393ea2078b37de7a4cb",
+            "license": "Unlicense"
+        }
+    },
+    "version": 1
+}

--- a/test/sources/pass/withoutMetadataHash.js
+++ b/test/sources/pass/withoutMetadataHash.js
@@ -1,0 +1,18 @@
+module.exports = {
+    "compilerOutput": {
+        "abi": [],
+        "evm": {
+        "bytecode": {
+            "object": "0x6080604052348015600f57600080fd5b50601680601d6000396000f3fe6080604052600080fdfea164736f6c6343000700000a"
+        },
+        "deployedBytecode": {
+            "object": "0x6080604052600080fdfea164736f6c6343000700000a"
+        }
+        },
+        "metadata": '{"compiler":{"version":"0.7.0+commit.9e61f92b"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"contracts/Contract.sol":"Contract"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"none","useLiteralContent":true},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"contracts/Contract.sol":{"content":"//SPDX-License-Identifier: Unlicense\\npragma solidity ^0.7.0;\\n\\ncontract Contract {}\\n","keccak256":"0x12c9c3c58310574ec340c35a1246a667e3d71964542e0393ea2078b37de7a4cb","license":"Unlicense"}},"version":1}'
+    },
+    "sourceCodes": {
+        "Contract.sol": "//SPDX-License-Identifier: Unlicense\\npragma solidity ^0.7.0;\\n\\ncontract Contract {}\\n"
+    }
+}
+  


### PR DESCRIPTION
- Closes #465.
- Contracts without bytecode hash (metadata hash embedded at the end part of the contract) can not be marked as full matches any longer.
- Tests the behavior with two new tests (one in server.js, one in monitor.js; the monitor test just expects monitor not to fail in case of a contract without bytecode hash).