### PR TITLE
Add support for contracts with library address placeholders

### DIFF
--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -54,14 +54,10 @@ export interface Match {
   storageTimestamp?: Date,
   message?: string,
   encodedConstructorArgs?: string,
+  libraryMap?: StringMap
 }
 
 export type Status = 'perfect' | 'partial' | null;
-
-export type CompareResult = {
-  status: Status,
-  encodedConstructorArgs: string
-}
 
 /**
  * A type for specfifying the strictness level of querying (only full or any kind of matches)

--- a/services/verification/src/utils.ts
+++ b/services/verification/src/utils.ts
@@ -12,7 +12,7 @@ import { ethers } from 'ethers';
 const GITHUB_SOLC_REPO = "https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/";
 
 export interface RecompilationResult {
-    bytecode: string,
+    creationBytecode: string,
     deployedBytecode: string,
     metadata: string
 }
@@ -96,7 +96,7 @@ export async function recompile(
 
     const contract: any = output.contracts[fileName][contractName];
     return {
-        bytecode: `0x${contract.evm.bytecode.object}`,
+        creationBytecode: `0x${contract.evm.bytecode.object}`,
         deployedBytecode: `0x${contract.evm.deployedBytecode.object}`,
         metadata: contract.metadata.trim()
     }

--- a/test/sources/contracts/UsingLibrary.sol
+++ b/test/sources/contracts/UsingLibrary.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.0;
+
+library Lib {
+    function foo() public pure returns (string memory) {
+        return "hello from foo";
+    }
+}
+
+contract Con {
+    function bar() public pure returns (string memory) {
+        return Lib.foo();
+    }
+}

--- a/test/sources/metadata/using-library.meta.object.json
+++ b/test/sources/metadata/using-library.meta.object.json
@@ -1,0 +1,59 @@
+{
+	"compiler": {
+		"version": "0.8.1+commit.df193b15"
+	},
+	"language": "Solidity",
+	"output": {
+		"abi": [
+			{
+				"inputs": [],
+				"name": "bar",
+				"outputs": [
+					{
+						"internalType": "string",
+						"name": "",
+						"type": "string"
+					}
+				],
+				"stateMutability": "pure",
+				"type": "function"
+			}
+		],
+		"devdoc": {
+			"kind": "dev",
+			"methods": {},
+			"version": 1
+		},
+		"userdoc": {
+			"kind": "user",
+			"methods": {},
+			"version": 1
+		}
+	},
+	"settings": {
+		"compilationTarget": {
+			"contracts/UsingLibrary.sol": "Con"
+		},
+		"evmVersion": "istanbul",
+		"libraries": {},
+		"metadata": {
+			"bytecodeHash": "ipfs"
+		},
+		"optimizer": {
+			"enabled": false,
+			"runs": 200
+		},
+		"remappings": []
+	},
+	"sources": {
+		"contracts/UsingLibrary.sol": {
+			"keccak256": "0xffc7744cd9f08ce5e4cb2268278d83aa43edb3cd1951380de113df3d2362dfd3",
+			"license": "GPL-3.0",
+			"urls": [
+				"bzz-raw://d2ae926a74e79531347475e9dc9bd5ade2363b5fd048ae660a5b9c8be157ec77",
+				"dweb:/ipfs/QmfPvusGP5y1fA3Fm29pQiSWasdghaowGDAiwrH2Xcd8c3"
+			]
+		}
+	},
+	"version": 1
+}


### PR DESCRIPTION
Placeholders in the recompiled bytecode are replaced with addresses from corresponding locations in the actual deployed bytecode. Similarly to `constructor-args.txt`, stored under `library-map.json`.