### PR TITLE
Adding contracts route and Telos networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ You can find examples in our Postman collection in the root of this project `Sou
 * [Get source files (full match)](docs/api/server/getByChainAndAddress.md) : `GET /files/:chain/:address`
 * [Get file tree (full or partial match)](docs/api/server/getAnyTreeByChainAndAddress.md) : `GET /files/tree/any/:chain/:address`
 * [Get source files (full or partial match)](docs/api/server/getAnyByChainAndAddress.md) : `GET /files/any/:chain/:address`
+* [Get contract addresses (full or partial match)](docs/api/server/getContractsByChain.md) : `GET /files/contracts/:chain`
 * [Server health](docs/api/server/health.md) : `GET /health`
 
 ### Repository API

--- a/docs/api/server/getContractsByChain.md
+++ b/docs/api/server/getContractsByChain.md
@@ -1,0 +1,41 @@
+# Get verified contract addresses for the chain
+
+Returns all verified contracts from the repository for the desired chain. Searches for full and partial matches.
+
+**URL** : `/files/contracts/:chain`
+
+**Method** : `GET`
+
+## Responses
+
+**Condition** : Chain is available as a full match or partial match in the repository.
+
+**Code** : `200 OK`
+
+**Content** : 
+
+```json
+{
+    "full": [
+        "0x1fE5d745beABA808AAdF52057Dd7AAA47b42cFD0",
+        "0xE9c31091868d68598Ac881738D159A63532d12f9"
+    ],
+    "partial": [
+        "0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9",
+        "0xE9c31091868d68598Ac881738D159A63532d12f9"
+    ]
+}
+```
+
+### OR
+
+**Condition** : Chain is not available as both full match or partial match in the repository.
+
+**Code** : `404 Not Found`
+
+**Content** : 
+```json
+{
+    "error": "Contracts have not been found!"
+}
+```

--- a/services/core/src/services/FileService.ts
+++ b/services/core/src/services/FileService.ts
@@ -3,7 +3,7 @@ import Path from 'path';
 import fs from 'fs';
 import web3 from 'web3';
 import * as bunyan from 'bunyan';
-import { FileObject, Match, Tag, MatchLevel, FilesInfo, MatchQuality } from '../utils/types';
+import { FileObject, Match, Tag, MatchLevel, FilesInfo, MatchQuality, ContractData } from '../utils/types';
 import { getChainId } from '../utils/utils';
 import { Logger } from '../utils/logger';
 import rimraf from 'rimraf';
@@ -28,6 +28,7 @@ export interface IFileService {
     repositoryPath: string;
     getTree(chainId: any, address: string, match: string): Promise<FilesInfo<string>>;
     getContent(chainId: any, address: string, match: string): Promise<FilesInfo<FileObject>>;
+    getContracts(chainId: any): Promise<ContractData>;
 }
 
 export class FileService implements IFileService {
@@ -76,6 +77,14 @@ export class FileService implements IFileService {
 
         return files;
     }
+    fetchAllContracts = async(chain: String): Promise<ContractData> => {
+        const fullPath = this.repositoryPath + `/contracts/full_match/${chain}/`;
+        const partialPath = this.repositoryPath + `/contracts/partial_match/${chain}/`;
+        return {
+            full: (fs.existsSync(fullPath)) ? fs.readdirSync(fullPath) : [],
+            partial: (fs.existsSync(partialPath)) ? fs.readdirSync(partialPath) : []
+        };
+    }
     
     getTree = async (chainId: any, address: string, match: MatchLevel): Promise<FilesInfo<string>> => {
         chainId = getChainId(chainId);
@@ -99,6 +108,10 @@ export class FileService implements IFileService {
         return { status: "partial", files };
     }
 
+    getContracts = async(chainId: any): Promise<ContractData> => {
+        const contracts = await this.fetchAllContracts(chainId);
+        return contracts
+    }
     private generateContractPath(pathConfig: PathConfig) {
         return Path.join(
             this.repositoryPath,

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -162,21 +162,15 @@ export default {
         "txRegex": getBlockscoutRegex()
     },
     "40": {
-        "fullnode": {
-            "dappnode": "https://mainnet.telos.net/evm"
-        },
         "supported": true,
         "monitored": false,
-        "contractFetchAddress": "https://bscscan.com/" + ETHERSCAN_SUFFIX,
+        "contractFetchAddress": "https://mainnet.telos.net/v2/explore/evm/" + ETHERSCAN_SUFFIX,
         "txRegex": ETHERSCAN_REGEX
     },
     "41": {
-        "fullnode": {
-            "dappnode": "https://testnet.telos.net/evm"
-        },
         "supported": true,
         "monitored": false,
-        "contractFetchAddress": "https://bscscan.com/" + ETHERSCAN_SUFFIX,
+        "contractFetchAddress": "https://testnet.telos.net/v2/explore/evm/" + ETHERSCAN_SUFFIX,
         "txRegex": ETHERSCAN_REGEX
     }
 }

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -160,5 +160,23 @@ export default {
         "monitored": true,
         "contractFetchAddress": "https://cchain.explorer.avax.network/" + BLOCKSCOUT_SUFFIX,
         "txRegex": getBlockscoutRegex()
+    },
+    "40": {
+        "fullnode": {
+            "dappnode": "https://mainnet.telos.net/evm"
+        },
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://bscscan.com/" + ETHERSCAN_SUFFIX,
+        "txRegex": ETHERSCAN_REGEX
+    },
+    "41": {
+        "fullnode": {
+            "dappnode": "https://testnet.telos.net/evm"
+        },
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://bscscan.com/" + ETHERSCAN_SUFFIX,
+        "txRegex": ETHERSCAN_REGEX
     }
 }

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -4,6 +4,7 @@ const ETHERSCAN_REGEX = "at txn <a href='/tx/(.*?)'";
 const ETHERSCAN_SUFFIX = "address/${ADDRESS}";
 const BLOCKSCOUT_REGEX = "transaction_hash_link\" href=\"${BLOCKSCOUT_PREFIX}/tx/(.*?)\"";
 const BLOCKSCOUT_SUFFIX = "address/${ADDRESS}/transactions";
+const TELOS_SUFFIX = "v2/evm/get_contract?contract=${ADDRESS}";
 
 function getCustomURL(chainName: string, useOwn=false) {
     if (useOwn && process.env.TESTING !== "true") {
@@ -164,13 +165,13 @@ export default {
     "40": {
         "supported": true,
         "monitored": false,
-        "contractFetchAddress": "https://mainnet.telos.net/v2/explore/evm/" + ETHERSCAN_SUFFIX,
-        "txRegex": ETHERSCAN_REGEX
+        "contractFetchAddress": "https://mainnet.telos.net/" + TELOS_SUFFIX,
+        "isTelos": true
     },
     "41": {
         "supported": true,
         "monitored": false,
-        "contractFetchAddress": "https://testnet.telos.net/v2/explore/evm/" + ETHERSCAN_SUFFIX,
-        "txRegex": ETHERSCAN_REGEX
+        "contractFetchAddress": "https://testnet.telos.net/" + TELOS_SUFFIX,
+        "isTelos": true
     }
 }

--- a/services/core/src/utils/types.ts
+++ b/services/core/src/utils/types.ts
@@ -7,6 +7,11 @@ export interface FileObject {
     content?: string
   }
 
+export declare interface ContractData {
+  full: string[],
+  partial: string[]
+}
+
 export interface InputData {
     chain: string,
     addresses: string[],

--- a/services/verification/src/utils.ts
+++ b/services/verification/src/utils.ts
@@ -322,6 +322,21 @@ export async function getCreationDataByScraping(fetchAddress: string, txRegex: s
     throw new Error(`Creation data could not be scraped from ${fetchAddress}`);
 }
 
+export async function getCreationDataTelos(fetchAddress: string, web3: Web3): Promise<string> {
+    const res = await fetch(fetchAddress);
+    if (res.status === StatusCodes.OK) {
+        const response = await res.json();
+        if (response.creation_trx) {
+            const txHash = response.creation_trx;
+            const tx = await web3.eth.getTransaction(txHash);
+            return tx.input;
+        }
+    }
+
+    throw new Error(`Creation data could not be scraped from ${fetchAddress}`);
+}
+
+
 export async function getCreationDataFromGraphQL(fetchAddress: string, contractAddress: string, web3: Web3): Promise<string> {
     const body = JSON.stringify({ query: `
         query AccountCreationTx {

--- a/src/server/controllers/FileController.ts
+++ b/src/server/controllers/FileController.ts
@@ -2,13 +2,14 @@ import { NextFunction, Request, Response, Router } from 'express';
 import BaseController from './BaseController';
 import { IController } from '../../common/interfaces';
 import { StatusCodes } from 'http-status-codes';
-import { Logger, IFileService, MatchLevel, FilesInfo } from '@ethereum-sourcify/core';
+import { Logger, IFileService, MatchLevel, FilesInfo, ContractData } from '@ethereum-sourcify/core';
 import { param, validationResult } from 'express-validator';
 import { isValidAddress, isValidChain } from '../../common/validators/validators';
 import { NotFoundError, ValidationError } from '../../common/errors'
 import * as bunyan from 'bunyan';
 
 type RetrieveMethod = (chain: string, address: string, match: MatchLevel) => Promise<FilesInfo<any>>;
+type ConractRetrieveMethod = (chain: string) => Promise<ContractData>;
 
 export default class FileController extends BaseController implements IController {
     router: Router;
@@ -45,19 +46,41 @@ export default class FileController extends BaseController implements IControlle
         }
     }
 
+    createContractEndpoint(contractRetrieveMethod: ConractRetrieveMethod, successMessage: string) {
+        return async (req: Request, res: Response, next: NextFunction) => {
+            const validationErrors = validationResult(req);
+            if (!validationErrors.isEmpty()) {
+                return next(new ValidationError(validationErrors.array()));
+            }
+            let retrieved: ContractData;
+            try {
+                retrieved = await contractRetrieveMethod(req.params.chain);
+                if (retrieved.full.length === 0 && retrieved.partial.length === 0) return next(new NotFoundError("Contracts have not been found!"));
+            } catch (err) {
+                return next(new NotFoundError(err.message));
+            }
+            this.logger.info({
+                chainId: req.params.chain,
+            },
+                successMessage);
+            return res.status(StatusCodes.OK).json(retrieved);
+        }
+    }
+
     registerRoutes = (): Router => {
         [
             { prefix: "/tree/any", method: this.createEndpoint(this.fileService.getTree, "any_match", "getTree any_match success", true) },
             { prefix: "/any", method: this.createEndpoint(this.fileService.getContent, "any_match", "getContent any_match success", true) },
             { prefix: "/tree", method: this.createEndpoint(this.fileService.getTree, "full_match", "getTree full_match success") },
+            { prefix: "/contracts", method: this.createContractEndpoint(this.fileService.getContracts,"getContracts success") },
             { prefix: "", method: this.createEndpoint(this.fileService.getContent, "full_match", "getContent full_match success") }
-
-        ].forEach(pair => this.router.route(pair.prefix + "/:chain/:address").get([
-            param("chain").custom(isValidChain),
-            param("address").custom(isValidAddress)
-        ], 
-            this.safeHandler(pair.method)
-        ));
+            
+        ].forEach(pair => {
+            let validators = [param("chain").custom(isValidChain)];
+            if(pair.prefix != '/contracts') validators.push(param("address").custom(isValidAddress))
+            this.router.route((pair.prefix != '/contracts') ? pair.prefix + "/:chain/:address" : pair.prefix + "/:chain")
+            .get(validators, this.safeHandler(pair.method))
+        });
         return this.router;
     }
 }

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -16,6 +16,9 @@ export const CHAIN_OPTIONS = [
     {value: "avalanche testnet", label: "Avalanche Fuji Testnet", id: 43113},
     {value: "avalanche mainnet", label: "Avalanche Mainnet", id: 43114},
     {value: "arbitrum rinkeby", label: "Arbitrum Testnet Rinkeby", id: 421611},
+    {value: "arbitrum rinkeby", label: "Arbitrum Testnet Rinkeby", id: 421611},
+    {value: "telos mainnet", label: "Telos EVM Mainnet", id: 40},
+    {value: "telos testnet", label: "Telos EVM Testnet", id: 41},
 ];
 
 export const ID_TO_CHAIN = {};


### PR DESCRIPTION
Per conversation on gitter, this PR includes 2 changes:

- It adds support for Telos EVM testnet and mainnet (mainnet going live in coming weeks)
- It adds a new API route for getting a list of contract addresses for a given chain so available contracts are discoverable