### PR TITLE
Replace IPFS_LIBP2P_EXTERNAL_PORT in .env.stable

### DIFF
--- a/environments/.env.stable
+++ b/environments/.env.stable
@@ -40,7 +40,7 @@ BUCKET_NAME=s3://sourcify-ethereum
 # IPFS config
 IPFS_SECRET=xxx
 IPFS_GW_EXTERNAL_PORT=5051
-IPFS_LIBP2P_EXTERNAL_PORT=4001
+IPFS_LIBP2P_EXTERNAL_PORT=4002
 IPFS_API_EXTERNAL_PORT=5003
 IPNS=k51qzi5uqu5dll0ocge71eudqnrgnogmbr37gsgl12uubsinphjoknl6bbi41p
 IPFS_URL=http://ipfs-stable:8080/ipfs/


### PR DESCRIPTION
The old port was occupied, so a new one was chosen. Basically a hotfix of https://github.com/ethereum/sourcify/pull/513.

Some checks are failing because there are issues with the Ropsten Geth node, in use by both monitor and server.