### PR TITLE
Adding support for Syscoin and Syscoin Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ watches:
   + Avalanche Fuji Testnet
   + Avalanche Mainnet
   + Arbitrum Testnet Rinkeby
+  + Syscoin Mainnet
+  + Syscoin Tanenbaum Testnet
 
 + a website which allows you to submit sources and metadata for a specific contract address manually
   + https://sourcify.dev (Stable)

--- a/services/core/src/chains.json
+++ b/services/core/src/chains.json
@@ -2195,5 +2195,31 @@
     "faucets": [],
     "explorers": [],
     "infoURL": "https://testnet.wanscan.org"
+  },
+  {
+    "name": "Syscoin Mainnet",
+    "chainId": 57,
+    "shortName": "sys",
+    "chain": "SYS",
+    "network": "mainnet",
+    "networkId": 57,
+    "nativeCurrency": {"name":"Syscoin","symbol":"SYS","decimals":18},
+    "rpc": ["https://nevm.syscoin.org/api/eth-rpc", "https://web3.syscoin.org", "wss://web3.syscoin.org"],
+    "faucets": ["https://faucet.syscoin.org"],
+    "explorers": ["https://nevm.syscoin.org"],
+    "infoURL": "https://syscoin.org"
+  },
+  {
+    "name": "Syscoin Tanenbaum Testnet",
+    "chainId": 5700,
+    "shortName": "sys",
+    "chain": "SYS",
+    "network": "testnet",
+    "networkId": 5700,
+    "nativeCurrency": {"name":"Testnet Syscoin","symbol":"tSYS","decimals":18},
+    "rpc": ["https://tanenbaum.io/api/eth-rpc"],
+    "faucets": ["https://faucet.tanenbaum.io"],
+    "explorers": ["https://tanenbaum.io"],
+    "infoURL": "https://syscoin.org"
   }
 ]

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -19,6 +19,8 @@ export const CHAIN_OPTIONS = [
     {value: "arbitrum rinkeby", label: "Arbitrum Testnet Rinkeby", id: 421611},
     {value: "telos mainnet", label: "Telos EVM Mainnet", id: 40},
     {value: "telos testnet", label: "Telos EVM Testnet", id: 41},
+    {value: "syscoin mainnet", label: "Syscoin Mainnet", id: 57}, 
+    {value: "syscoin testnet", label: "Syscoin Tanenbaum Testnet", id: 5700},
 ];
 
 export const ID_TO_CHAIN = {};


### PR DESCRIPTION
We would like to add support for Syscoin and Syscoin Testnet which, in the upcoming version supports an Ethereum Virtual Machine. We like to have the contracts verified through Sourcify. Please let me know if there is anything else you would like me to do.