### PR TITLE
Fix dockerized ipfs nodes unreachable

### DIFF
--- a/services/ipfs/entrypoint.sh
+++ b/services/ipfs/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ipfs init --profile server
+ipfs init
 ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 ipfs config --json Experimental.ShardingEnabled true
 


### PR DESCRIPTION
The previous `server` profile disables localhost discovery. According to [docs](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#profiles) this is for when running a server but breaks things when dockerized. Change should make the ipfs node reachable over the docker network and also from outside.

See #495