### PR TITLE
Adding support for OneLedger Mainnet and Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ watches:
   + Avalanche Fuji Testnet
   + Avalanche Mainnet
   + Arbitrum Testnet Rinkeby
+  + OneLedger Mainnet
+  + OneLedger Testnet Frankenstein
 
 + a website which allows you to submit sources and metadata for a specific contract address manually
   + https://sourcify.dev (Stable)

--- a/services/core/src/chains.json
+++ b/services/core/src/chains.json
@@ -2195,5 +2195,33 @@
     "faucets": [],
     "explorers": [],
     "infoURL": "https://testnet.wanscan.org"
+  },
+  {
+    "name": "OneLedger Mainnet",
+    "chain": "OLT",
+    "network": "mainnet",
+    "icon": "oneledger",
+    "rpc": ["https://mainnet-rpc.oneledger.network"],
+    "faucets": [],
+    "nativeCurrency": {"name": "OLT","symbol": "OLT","decimals": 18},
+    "infoURL": "https://oneledger.io",
+    "shortName": "oneledger",
+    "chainId": 311752642,
+    "networkId": 311752642,
+    "explorers": [{"name": "OneLedger Block Explorer","url": "https://mainnet-explorer.oneledger.network","standard": "EIP3091"}]
+  },
+  {
+    "name": "OneLedger Testnet Frankenstein",
+    "chain": "OLT",
+    "network": "testnet",
+    "icon": "oneledger",
+    "rpc": ["https://frankenstein-rpc.oneledger.network"],
+    "faucets": ["https://frankenstein-faucet.oneledger.network"],
+    "nativeCurrency": {"name": "OLT","symbol": "OLT","decimals": 18},
+    "infoURL": "https://oneledger.io",
+    "shortName": "frankenstein",
+    "chainId": 4216137055,
+    "networkId": 4216137055,
+    "explorers": [{"name": "OneLedger Block Explorer","url": "https://frankenstein-explorer.oneledger.network","standard": "EIP3091"}]
   }
 ]

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -189,5 +189,23 @@ export default {
         "monitored": false,
         "contractFetchAddress": "https://testnet.telos.net/" + TELOS_SUFFIX,
         "isTelos": true
+    },
+    "311752642": {
+        "supported": true,
+        "monitored": true,
+        "contractFetchAddress": "https://mainnet-explorer.oneledger.network/" + BLOCKSCOUT_SUFFIX,
+        "rpc": [
+            "https://mainnet-rpc.oneledger.network"
+        ],
+        "txRegex": getBlockscoutRegex()
+    },
+    "4216137055": {
+        "supported": true,
+        "monitored": true,
+        "contractFetchAddress": "https://frankenstein-explorer.oneledger.network/" + BLOCKSCOUT_SUFFIX,
+        "rpc": [
+            "https://frankenstein-rpc.oneledger.network"
+        ],
+        "txRegex": getBlockscoutRegex()
     }
 }

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -19,6 +19,8 @@ export const CHAIN_OPTIONS = [
     {value: "arbitrum rinkeby", label: "Arbitrum Testnet Rinkeby", id: 421611},
     {value: "telos mainnet", label: "Telos EVM Mainnet", id: 40},
     {value: "telos testnet", label: "Telos EVM Testnet", id: 41},
+    {value: "oneledger mainnet", label: "OneLedger Mainnet", id: 311752642},
+    {value: "oneledger testnet", label: "OneLedger Testnet Frankenstein", id: 4216137055},
 ];
 
 export const ID_TO_CHAIN = {};


### PR DESCRIPTION
We would like to add support for OneLedger network (Mainnet and Testnet). We already passed checks and have been added to https://chainlist.org/ (https://github.com/ethereum-lists/chains/pull/397), and wish to have an opportunity to verify smart contracts through our blockscout based explorer for the end-user. Please, let me know if anything other needs to be covered here. Thanks.