### PR TITLE
Fix only 1 network RPC getting called

### DIFF
--- a/services/validation/src/ValidationService.ts
+++ b/services/validation/src/ValidationService.ts
@@ -305,7 +305,7 @@ export class ValidationService implements IValidationService {
             if (this.isMetadata(obj)) {
                 return obj;
             }
-        } catch (err) { undefined }
+        } catch (err) { undefined } // Don't throw here as other files can be metadata files.
 
         return null;
     }

--- a/services/verification/src/utils.ts
+++ b/services/verification/src/utils.ts
@@ -55,17 +55,19 @@ export async function checkEndpoint(provider: string): Promise<void> {
  */
 export async function getBytecode(web3array: Web3[], address: string): Promise<string> {
     address = Web3.utils.toChecksumAddress(address);
+    const rpcPromises: Promise<string>[] = [];
     for (const web3 of web3array) {
-        try {
-            return <string> await Promise.race([
-                web3.eth.getCode(address),
-                new Promise((_resolve, reject) => {
-                    setTimeout(() => reject('RPC took too long to respond'), 3e3);
-                })
-            ])
-        } catch (err: any) {
-            throw new Error(err);
-        }
+        rpcPromises.push(web3.eth.getCode(address));
+    }
+    try {
+        return <string> await Promise.race([
+            ...rpcPromises,
+            new Promise((_resolve, reject) => {
+                setTimeout(() => reject('RPC took too long to respond'), 3e3);
+            })
+        ])
+    } catch (err: any) {
+        throw new Error(err);
     }
 }
 
@@ -99,12 +101,12 @@ export async function recompile(
 
     const compiled = await useCompiler(version, solcJsonInput, log);
     const output = JSON.parse(compiled);
-    if (!output.contracts || !output.contracts[fileName] || !output.contracts[fileName][contractName]) {
+    if (!output.contracts || !output.contracts[fileName] || !output.contracts[fileName][contractName] || !output.contracts[fileName][contractName].evm || !output.contracts[fileName][contractName].evm.bytecode) {
         const errors = output.errors.filter((e: any) => e.severity === "error").map((e: any) => e.message);
         log.error({ loc, fileName, contractName, version, errors });
         throw new Error(RECOMPILATION_ERR_MSG);
     }
-
+    
     const contract: any = output.contracts[fileName][contractName];
     return {
         creationBytecode: `0x${contract.evm.bytecode.object}`,


### PR DESCRIPTION
Previously the backup RPC's were not being used and only the first RPC. I.e. when our geth node is down, it does not fallback to Alchemy API.