### PR TITLE
Add support for Optimistic Mainnet network 

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ In order to fetch from the staging repository, replace https://repo.sourcify.dev
 - Ubiq
 - OneLedger Testnet Frankenstein
 - Syscoin Tanenbaum Testnet
+- Optimistic Mainnet
 
 ## Adding a new chain
 

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -222,5 +222,14 @@ export default {
             "https://frankenstein-rpc.oneledger.network"
         ],
         "txRegex": getBlockscoutRegex()
-    }
+    },
+    "10": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://optimistic.etherscan.io/" + ETHERSCAN_SUFFIX,
+        "rpc": [
+            'https://mainnet.optimism.io'
+        ],
+        "txRegex": ETHERSCAN_REGEX
+    },
 }

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -22,6 +22,7 @@ export const CHAIN_OPTIONS = [
     {value: "ubiq", label: "Ubiq", id: 8},
     {value: "oneledger testnet", label: "OneLedger Testnet Frankenstein", id: 4216137055},
     {value: "syscoin testnet", label: "Syscoin Tanenbaum Testnet", id: 5700},
+    {value: "optimistic mainnet", label: "Optimistic Ethereum Mainnet", id: 10},
 ];
 
 export const ID_TO_CHAIN = {};


### PR DESCRIPTION
Adds optimistic mainnet to the supported networks in addition to optimistic kovan which was merged in #550 

Pending optimistic mainnet regenesis scheduled for 11th November after which we can provide the sources off OE mainnet as well. 

Resolves #352  