### PR TITLE
checkByAddress does not return partial matches

### DIFF
--- a/docs/api/server/verification1/check-all-by-addresses.md
+++ b/docs/api/server/verification1/check-all-by-addresses.md
@@ -18,7 +18,7 @@ Checks if contract with the desired chain and address is verified and in the rep
 [
     {
         "address": "0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9",
-        "chains": [
+        "chainIds": [
           {
             chainId: '1',
             status: 'perfect'
@@ -27,7 +27,7 @@ Checks if contract with the desired chain and address is verified and in the rep
     },
     {
         "address": "0x0A67477639a71bf98528280D3724f465A1814740",
-        "chains": [
+        "chainIds": [
           {
             chainId: '1',
             status: 'perfect'
@@ -38,9 +38,18 @@ Checks if contract with the desired chain and address is verified and in the rep
           }
         ]
     },
-    {
-        "address": "0x0A67477639a71bf98528280D3724f465A1814741",
-        "status": "false"
-    },
+]
+```
+
+**Code** : `404 NOT FOUND`
+
+**Content** : 
+
+```json
+[
+  {
+    "address": "0x0A67477639a71bf98528280D3724f465A1814741",
+    "status": "false"
+  },
 ]
 ```

--- a/docs/api/server/verification1/check-all-by-addresses.md
+++ b/docs/api/server/verification1/check-all-by-addresses.md
@@ -1,0 +1,46 @@
+# Check all by addresses
+
+Checks if contract with the desired chain and address is verified and in the repository. It will search for both perfect and partial matches.
+
+**URL** : `check-all-by-addresses?addresses={address}&chainIds={chainIds}`
+
+**URL (deprecated)** : `checkAllByAddresses?addresses={address}&chainIds={chainIds}`
+
+**Method** : `GET`
+
+## Response
+
+**Code** : `200 OK`
+
+**Content** : 
+
+```json
+[
+    {
+        "address": "0x0000A906D248Cc99FB8CB296C8Ad8C6Df05431c9",
+        "chains": [
+          {
+            chainId: '1',
+            status: 'perfect'
+          }
+        ]
+    },
+    {
+        "address": "0x0A67477639a71bf98528280D3724f465A1814740",
+        "chains": [
+          {
+            chainId: '1',
+            status: 'perfect'
+          }
+          {
+            chainId: '5',
+            status: 'partial'
+          }
+        ]
+    },
+    {
+        "address": "0x0A67477639a71bf98528280D3724f465A1814741",
+        "status": "false"
+    },
+]
+```

--- a/services/core/src/services/FileService.ts
+++ b/services/core/src/services/FileService.ts
@@ -3,7 +3,7 @@ import Path from 'path';
 import fs from 'fs';
 import web3 from 'web3';
 import * as bunyan from 'bunyan';
-import { FileObject, Match, Tag, MatchLevel, FilesInfo, MatchQuality, ContractData } from '../utils/types';
+import { FileObject, Match, Status, Tag, MatchLevel, FilesInfo, MatchQuality, ContractData } from '../utils/types';
 import { getChainId } from '../utils/utils';
 import { Logger } from '../utils/logger';
 import rimraf from 'rimraf';
@@ -125,6 +125,31 @@ export class FileService implements IFileService {
     }
 
     /**
+     * Checks if path exists and for a particular chain returns the perfect or partial match
+     * 
+     * @param fullContractPath
+     * @param partialContractPath
+     */
+    fetchFromStorage(fullContractPath: string, partialContractPath: string): { time: Date, status: Status } {
+        if (fs.existsSync(fullContractPath)) {
+            return {
+                time: fs.statSync(fullContractPath).birthtime,
+                status: 'perfect'
+            }
+        }
+
+        if (fs.existsSync(partialContractPath)) {
+            return {
+                time: fs.statSync(partialContractPath).birthtime,
+                status: 'partial'
+            }
+        }
+
+        throw new Error('path not found')
+    }
+
+
+    /**
      * Checks contract existence in repository.
      * 
      * @param address
@@ -146,6 +171,43 @@ export class FileService implements IFileService {
                 status: "perfect",
                 storageTimestamp
             }];
+        } catch (e) {
+            throw new Error("Address not found in repository");
+        }
+    }
+
+    /**
+     * Checks contract existence in repository for full and partial matches.
+     * 
+     * @param address
+     * @param chain
+     * @param repository
+     */
+    findAllByAddress(address: string, chain: string): Match[] {
+        const fullContractPath = this.generateContractPath({
+            matchQuality: "full",
+            chain,
+            address,
+            fileName: "metadata.json"
+        });
+
+        const partialContractPath = this.generateContractPath({
+            matchQuality: "partial",
+            chain,
+            address,
+            fileName: "metadata.json"
+        })
+
+        try {
+
+            const storage = this.fetchFromStorage(fullContractPath, partialContractPath)
+            return [
+                {
+                    address,
+                    status: storage?.status,
+                    storageTimestamp: storage?.time,
+                },
+            ];
         } catch (e) {
             throw new Error("Address not found in repository");
         }

--- a/services/core/src/services/FileService.ts
+++ b/services/core/src/services/FileService.ts
@@ -23,6 +23,7 @@ export interface IFileService {
     fetchAllFilePaths(chain: string, address: string): Array<FileObject>;
     fetchAllFileContents(chain: string, address: string): Array<FileObject>;
     findByAddress(address: string, chain: string): Match[];
+    findAllByAddress(address: string, chain: string): Match[];
     save(path: string | PathConfig, file: string): void;
     deletePartial(chain: string, address: string): void;
     repositoryPath: string;

--- a/services/verification/src/services/VerificationService.ts
+++ b/services/verification/src/services/VerificationService.ts
@@ -6,6 +6,7 @@ import * as bunyan from 'bunyan';
 
 export interface IVerificationService {
     findByAddress(address: string, chain: string): Match[];
+    findAllByAddress(address: string, chain: string): Match[];
     inject(inputData: InputData): Promise<Match>;
 }
 

--- a/services/verification/src/services/VerificationService.ts
+++ b/services/verification/src/services/VerificationService.ts
@@ -19,11 +19,26 @@ export class VerificationService implements IVerificationService {
         this.logger = logger || Logger("VerificationService");
     }
 
-    findByAddress = (address: string, chain: string) => {
+    findByAddress = (address: string, chain: string): Match[] => {
         // Try to find by address, return on success.
         let matches: Match[] = [];
         try {
             matches = this.fileService.findByAddress(address, chain);
+        } catch (err) {
+            const msg = "Could not find file in repository"
+            this.logger.info({
+                loc: '[POST:VERIFICATION_BY_ADDRESS_FAILED]',
+                address: address
+            }, msg);
+        }
+        return matches;
+    }
+
+    findAllByAddress = (address: string, chain: string): Match[] => {
+        // Try to find by address, return on success.
+        let matches: Match[] = [];
+        try {
+            matches = this.fileService.findAllByAddress(address, chain);
         } catch (err) {
             const msg = "Could not find file in repository"
             this.logger.info({

--- a/src/server/controllers/VerificationController.ts
+++ b/src/server/controllers/VerificationController.ts
@@ -131,7 +131,7 @@ export default class VerificationController extends BaseController implements IC
         for (const address of req.addresses) {
             for (const chainId of req.chainIds) {
                 try {
-                    const found: Match[] = this.verificationService.findByAddress(address, chainId);
+                    const found: Match[] = this.verificationService.findAllByAddress(address, chainId);
                     if (found.length != 0) {
                         if (!map.has(address)) {
                             map.set(address, { address, chainIds: [] });

--- a/test/server.js
+++ b/test/server.js
@@ -29,6 +29,11 @@ const binaryParser = function (res, cb) {
 
 const EXTENDED_TIME = 20000; // 20 seconds
 
+const foundContractChain = {
+  chainId: "5",
+  status: "perfect",
+};
+
 describe("Server", function () {
   const server = new Server();
 
@@ -197,6 +202,111 @@ describe("Server", function () {
       chai
         .request(server.app)
         .get("/check-by-addresses")
+        .query({
+          chainIds: contractChain,
+          addresses: contractAddress.toLowerCase(),
+        })
+        .end((err, res) => {
+          chai.expect(err).to.be.null;
+          chai.expect(res.status).to.equal(StatusCodes.OK);
+          chai.expect(res.body).to.have.a.lengthOf(1);
+          const result = res.body[0];
+          chai.expect(result.address).to.equal(contractAddress);
+          chai.expect(result.status).to.equal("false");
+          done();
+        });
+    });
+  });
+
+  describe("/check-all-by-addresses", function () {
+    this.timeout(EXTENDED_TIME);
+
+    it("should fail for missing chainIds", (done) => {
+      chai
+        .request(server.app)
+        .get("/check-all-by-addresses")
+        .query({ addresses: contractAddress })
+        .end((err, res) => {
+          assertError(err, res, "chainIds");
+          done();
+        });
+    });
+
+    it("should fail for missing addresses", (done) => {
+      chai
+        .request(server.app)
+        .get("/check-all-by-addresses")
+        .query({ chainIds: 1 })
+        .end((err, res) => {
+          assertError(err, res, "addresses");
+          done();
+        });
+    });
+
+    const assertStatus = (err, res, expectedStatus, expectedChainIds, done) => {
+      chai.expect(err).to.be.null;
+      chai.expect(res.status).to.equal(StatusCodes.OK);
+      const resultArray = res.body;
+      chai.expect(resultArray).to.have.a.lengthOf(1);
+      const result = resultArray[0];
+      chai.expect(result.address).to.equal(contractAddress);
+      chai.expect(result.status).to.equal(expectedStatus);
+      chai.expect(result.chainIds).to.deep.equal(expectedChainIds);
+      if (done) done();
+    };
+
+    it("should return false for previously unverified contract", (done) => {
+      chai
+        .request(server.app)
+        .get("/check-all-by-addresses")
+        .query({ chainIds: contractChain, addresses: contractAddress })
+        .end((err, res) => assertStatus(err, res, "false", undefined, done));
+    });
+
+    it("should fail for invalid address", (done) => {
+      chai
+        .request(server.app)
+        .get("/check-all-by-addresses")
+        .query({ chainIds: contractChain, addresses: fakeAddress })
+        .end((err, res) => {
+          assertError(err, res, "addresses");
+          done();
+        });
+    });
+
+    it("should return true for previously verified contract", (done) => {
+      chai
+        .request(server.app)
+        .get("/check-all-by-addresses")
+        .query({ chainIds: contractChain, addresses: contractAddress })
+        .end((err, res) => {
+          assertStatus(err, res, "false", undefined);
+          chai
+            .request(server.app)
+            .post("/")
+            .field("address", contractAddress)
+            .field("chain", contractChain)
+            .attach("files", metadataBuffer, "metadata.json")
+            .attach("files", sourceBuffer)
+            .end((err, res) => {
+              chai.expect(err).to.be.null;
+              chai.expect(res.status).to.equal(StatusCodes.OK);
+
+              chai
+                .request(server.app)
+                .get("/check-all-by-addresses")
+                .query({ chainIds: contractChain, addresses: contractAddress })
+                .end((err, res) =>
+                  assertStatus(err, res, undefined, [foundContractChain], done)
+                );
+            });
+        });
+    });
+
+    it("should convert addresses to checksummed format", (done) => {
+      chai
+        .request(server.app)
+        .get("/check-all-by-addresses")
         .query({
           chainIds: contractChain,
           addresses: contractAddress.toLowerCase(),

--- a/ui/src/api/verifier.ts
+++ b/ui/src/api/verifier.ts
@@ -21,10 +21,15 @@ type CheckAddressesResult = {
     error: string
 }
 
+type ChainIdsResponse = {
+    chainId: string,
+    status: string
+}
+
 export type ServersideAddressCheck = {
     address: string,
     status: string,
-    chainIds?: string[]
+    chainIds?: ChainIdsResponse[]
 };
 
 export const verify = async (formData: any): Promise<VerificationResult> => {
@@ -67,12 +72,12 @@ export const checkAddresses = async (addresses: string, chainIds: string): Promi
     }
 
     try {
-        const response = await fetch(`${SERVER_URL}/checkByAddresses?addresses=${addresses}&chainIds=${chainIds}`, {
+        const response = await fetch(`${SERVER_URL}/checkAllByAddresses?addresses=${addresses}&chainIds=${chainIds}`, {
             method: "GET"
-        })
+        }) 
         const body: ServersideAddressCheck[] = await response.json();
 
-        data.successful = body.filter(value => value.status === 'perfect');
+        data.successful = body.filter(value => value?.chainIds?.length >= 0);
         data.unsuccessful = body.filter(value => value.status === 'false').map(e => e.address);
 
     } catch (e) {

--- a/ui/src/components/verifier/Verifier.tsx
+++ b/ui/src/components/verifier/Verifier.tsx
@@ -123,7 +123,7 @@ const Verifier: React.FC = () => {
                 </p>
                 <p key={checkResult.address}>Also partially verified on: {
                     intersperse(
-                        checkResult.chainIds.filter(chain => chain.status === verificationState.PARTIAL).map(chainId => chainToLink(chainId.chainId, checkResult.address)), 
+                        checkResult.chainIds.filter(chain => chain.status === verificationState.PARTIAL).map(chainId => chainToLink(chainId.chainId, checkResult.address, verificationState.PARTIAL)), 
                         ", "
                     )
                 }
@@ -132,13 +132,14 @@ const Verifier: React.FC = () => {
         )
     }
 
-    const chainToLink = (chainId: string, address: string): JSX.Element => {
+    const chainToLink = (chainId: string, address: string, type = verificationState.PERFECT): JSX.Element => {
+        const path = type === verificationState.PERFECT ? REPOSITORY_URL_FULL_MATCH : REPOSITORY_URL_PARTIAL_MATCH;
         const chain = ID_TO_CHAIN[chainId];
         const label = chain ? chain.label : "Unknown chain";
         return <a
             target="_blank"
             rel="noopener noreferrer"
-            href={`${REPOSITORY_URL_FULL_MATCH}/${chainId}/${address}`}
+            href={`${path}/${chainId}/${address}`}
             style={ { wordBreak: "break-word" } }
             key={chainId}
         >{label}</a>;

--- a/ui/src/components/verifier/Verifier.tsx
+++ b/ui/src/components/verifier/Verifier.tsx
@@ -112,22 +112,29 @@ const Verifier: React.FC = () => {
     }
 
     const checkResultToElement = (checkResult: ServersideAddressCheck) => {
+        const fullMatches = checkResult.chainIds.filter(chain => chain.status === verificationState.PERFECT)
+        const partialMatches = checkResult.chainIds.filter(chain => chain.status === verificationState.PARTIAL)
         return (
             <>
-                <p key={checkResult.address}>{checkResult.address} is fully verified on: {
-                    intersperse(
-                        checkResult.chainIds.filter(chain => chain.status === verificationState.PERFECT).map(chainId => chainToLink(chainId.chainId, checkResult.address)), 
-                        ", "
-                    )
+                <p key={checkResult.address}>{checkResult.address}</p>
+                { fullMatches.length > 0 && 
+                    <p>Fully verified on: {
+                        intersperse(
+                            fullMatches.map(chainId => chainToLink(chainId.chainId, checkResult.address)), 
+                            ", "
+                        )
+                    }
+                    </p>
                 }
-                </p>
-                <p key={checkResult.address}>Also partially verified on: {
-                    intersperse(
-                        checkResult.chainIds.filter(chain => chain.status === verificationState.PARTIAL).map(chainId => chainToLink(chainId.chainId, checkResult.address, verificationState.PARTIAL)), 
-                        ", "
-                    )
+                { partialMatches.length > 0 &&
+                    <p key={checkResult.address}>Partially verified on: {
+                        intersperse(
+                            partialMatches.map(chainId => chainToLink(chainId.chainId, checkResult.address, verificationState.PARTIAL)), 
+                            ", "
+                        )
+                    }
+                    </p>
                 }
-                </p>
             </>
         )
     }

--- a/ui/src/components/verifier/Verifier.tsx
+++ b/ui/src/components/verifier/Verifier.tsx
@@ -13,6 +13,11 @@ import LoadingOverlay from "../LoadingOverlay";
 import Spinner from "../Spinner";
 import { AddressInput, FileUpload } from "./form";
 
+const verificationState = {
+    PARTIAL: 'partial',
+    PERFECT: 'perfect'
+}
+
 const initialState: VerifierState = {
     loading: false,
     address: "",
@@ -107,12 +112,24 @@ const Verifier: React.FC = () => {
     }
 
     const checkResultToElement = (checkResult: ServersideAddressCheck) => {
-        return <p key={checkResult.address}>{checkResult.address} is verified on: {
-            intersperse(
-                checkResult.chainIds.map(chainId => chainToLink(chainId, checkResult.address)), 
-                ", "
-            )
-        }</p>
+        return (
+            <>
+                <p key={checkResult.address}>{checkResult.address} is fully verified on: {
+                    intersperse(
+                        checkResult.chainIds.filter(chain => chain.status === verificationState.PERFECT).map(chainId => chainToLink(chainId.chainId, checkResult.address)), 
+                        ", "
+                    )
+                }
+                </p>
+                <p key={checkResult.address}>Also partially verified on: {
+                    intersperse(
+                        checkResult.chainIds.filter(chain => chain.status === verificationState.PARTIAL).map(chainId => chainToLink(chainId.chainId, checkResult.address)), 
+                        ", "
+                    )
+                }
+                </p>
+            </>
+        )
     }
 
     const chainToLink = (chainId: string, address: string): JSX.Element => {
@@ -182,7 +199,7 @@ const Verifier: React.FC = () => {
             return;
         }
 
-        if (data.status === 'partial') {
+        if (data.status === verificationState.PARTIAL) {
             globalDispatch({
                 type: "SHOW_NOTIFICATION", payload: {
                     type: "success",


### PR DESCRIPTION
Currently the endpoints /check-by-address and /checkByAddress that look if an address is verified in any of the chains in the Sourcify repo only look for full matches. When a contract address that is partially matched is input, the endpoint returns that it is not found.

This PR introduces a new API route (`/check-all-by-address` or `/checkAllByAddress`)  for fetching all matches for a verified addresses. The response returned by this route will look like this:

```json
{
        "address": "0x0A67477639a71bf98528280D3724f465A1814740",
        "chainIds": [
          {
            chainId: '1',
            status: 'perfect'
          }
          {
            chainId: '5',
            status: 'partial'
          }
        ]
    },
```
With this, we can easily display on the frontend which chains have a partial or full verification of a contract 

Closes #593