### PR TITLE
Adding Syscoin Mainnet Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ In order to fetch from the staging repository, replace https://repo.sourcify.dev
 - Arbitrum Testnet Rinkeby
 - Ubiq
 - OneLedger Testnet Frankenstein
+- Syscoin Mainnet
 - Syscoin Tanenbaum Testnet
 - Optimistic Ethereum Mainnet
 - Optimistic Ethereum Kovan Testnet

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -190,6 +190,12 @@ export default {
         "contractFetchAddress": "https://snowtrace.io/" + ETHERSCAN_SUFFIX,
         "txRegex": ETHERSCAN_REGEX
     },
+    "57": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer.syscoin.org/" + BLOCKSCOUT_SUFFIX,
+        "txRegex": getBlockscoutRegex()
+    },
     "5700": {
         "supported": true,
         "monitored": false,

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -21,6 +21,7 @@ export const CHAIN_OPTIONS = [
     {value: "telos testnet", label: "Telos EVM Testnet", id: 41},
     {value: "ubiq", label: "Ubiq", id: 8},
     {value: "oneledger testnet", label: "OneLedger Testnet Frankenstein", id: 4216137055},
+    {value: "syscoin mainnet", label: "Syscoin Mainnet", id: 57},
     {value: "syscoin testnet", label: "Syscoin Tanenbaum Testnet", id: 5700},
     {value: "optimistic mainnet", label: "Optimistic Ethereum Mainnet", id: 10},
     {value: "optimistic kovan", label: "Optimistic Ethereum Testnet Kovan", id: 69},


### PR DESCRIPTION
The Syscoin Mainnet is up and running, so we would like to add support to Sourcify.

ethereum-lists/chains has been merged: ethereum-lists/chains#644

An ERC-20 contract: https://github.com/willyko/nevm-test-token

Contract address https://explorer.syscoin.org/address/0xB2d0641fc8863514B6533b129fD744200eE17D29/transactions

The repo also contains the meta data: https://github.com/willyko/nevm-test-token/blob/addffcd5724bf6503cf0222e4480f13c227cf6a4/build/contracts/TestToken.json#L388

Please let me know if there is anything else needed.

Thank you for your time.