### PR TITLE
Add support for Aurora Mainnet and Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ In order to fetch from the staging repository, replace https://repo.sourcify.dev
 - Boba Network Rinkeby Testnet
 - Velas EVM Mainnet
 - Meter Mainnet
+- Aurora Mainnet
+- Aurora Testnet
 
 ## Adding a new chain
 

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -254,4 +254,16 @@ export default {
         "contractFetchAddress": "https://evmexplorer.velas.com/" + BLOCKSCOUT_SUFFIX,
         "txRegex": getBlockscoutRegex()
     },
+    "1313161554": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer.mainnet.aurora.dev/" + BLOCKSCOUT_SUFFIX,
+        "txRegex": getBlockscoutRegex()
+    },
+    "1313161555": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer.testnet.aurora.dev/" + BLOCKSCOUT_SUFFIX,
+        "txRegex": getBlockscoutRegex()
+    },
 }

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -28,6 +28,8 @@ export const CHAIN_OPTIONS = [
     {value: "boba network rinkeby", label: "Boba Network Rinkeby Testnet", id: 28 },
     {value: "velas", label: "Velas EVM Mainnet", id: 106},
     {value: "meter mainnet", label: "Meter Mainnet", id: 82},
+    {value: "aurora mainnet", label: "Aurora Mainnet", id: 1313161554 },
+    {value: "aurora testnet", label: "Aurora Testnet", id: 1313161555 },
 ];
 
 export const ID_TO_CHAIN = {};


### PR DESCRIPTION
Test contract:
```
//SPDX-License-Identifier: Unlicense
pragma solidity ^0.8.4;

import "hardhat/console.sol";

contract Greeter {
  constructor() {
    console.log("Hello from Aurora");
  }
}
```

Metadata:  `[{"type":"constructor","stateMutability":"nonpayable","inputs":[]}]` 
Mainnet address: 0xCf6aA13d06d9733479Da028792e51893c28CECa9 [details](https://explorer.mainnet.aurora.dev/address/0xCf6aA13d06d9733479Da028792e51893c28CECa9/contracts)
Testnet address: 0xE610bDf4A3e65db05F070312Ed2d9b95CB2c747A [details](https://explorer.testnet.aurora.dev/address/0xE610bDf4A3e65db05F070312Ed2d9b95CB2c747A/contracts)

Please let me know if more information is needed, or if you have any questions.
Thank you in advance.