### PR TITLE
Revert IPFS profile to server

### DIFF
--- a/services/ipfs/entrypoint.sh
+++ b/services/ipfs/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ipfs init
+ipfs init --profile server
 ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 
 ## Build announced address config according to https://docs.ipfs.io/how-to/configure-node/#addresses. Need to announce the public and local IPs in swarm manually since docker does not know these IPs.


### PR DESCRIPTION
On bf7bbab the profile of the server profile of the ipfs node
was removed to allow "local discovery" but it seems it is unrelated to
the networking issues at the time. Announcing the public ip's should
have been sufficient.

Instead the ipfs node started receiving the error:
"ignoring incoming dht message while not in server mode".

Revert back to the server profile.