### PR TITLE
Add Harmony networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ In order to fetch from the staging repository, replace https://repo.sourcify.dev
 - Meter Mainnet
 - Aurora Mainnet
 - Aurora Testnet
+- Harmony Shard 0
+- Harmony Shard 1
+- Harmony Shard 2
+- Harmony Shard 3
 
 ## Adding a new chain
 

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -9,7 +9,8 @@ const ETHERSCAN_SUFFIX = "address/${ADDRESS}";
 const BLOCKSCOUT_REGEX = "transaction_hash_link\" href=\"${BLOCKSCOUT_PREFIX}/tx/(.*?)\"";
 const BLOCKSCOUT_SUFFIX = "address/${ADDRESS}/transactions";
 const TELOS_SUFFIX = "v2/evm/get_contract?contract=${ADDRESS}";
-const METER_SUFFIX="api/accounts/${ADDRESS}"
+const METER_SUFFIX = "api/accounts/${ADDRESS}"
+const HARMONY_SUFFIX = "v0/shard/${SHARD}/address/${ADDRESS}/contract"
 
 type ChainGroup = "eth" | "polygon";
 
@@ -275,4 +276,24 @@ export default {
         "contractFetchAddress": "https://explorer.testnet.aurora.dev/" + BLOCKSCOUT_SUFFIX,
         "txRegex": getBlockscoutRegex()
     },
+    "1666600000": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer-v2-api.hmny.io/" + HARMONY_SUFFIX 
+    },
+    "1666600001": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer-v2-api.hmny.io/" + HARMONY_SUFFIX 
+    },
+    "1666600002": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer-v2-api.hmny.io/" + HARMONY_SUFFIX 
+    },
+    "1666600003": {
+        "supported": true,
+        "monitored": false,
+        "contractFetchAddress": "https://explorer-v2-api.hmny.io/" + HARMONY_SUFFIX 
+    }
 }

--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3';
 import * as bunyan from 'bunyan';
 import { Match, InputData, getSupportedChains, getFullnodeChains, Logger, IFileService, FileService, StringMap, cborDecode, CheckedContract, MatchQuality, Chain, Status } from '@ethereum-sourcify/core';
-import { RecompilationResult, getBytecode, recompile, getBytecodeWithoutMetadata as trimMetadata, checkEndpoint, getCreationDataFromArchive, getCreationDataByScraping, getCreationDataFromGraphQL, getCreationDataTelos, getCreationDataMeter } from '../utils';
+import { RecompilationResult, getBytecode, recompile, getBytecodeWithoutMetadata as trimMetadata, checkEndpoint, getCreationDataFromArchive, getCreationDataByScraping, getCreationDataFromGraphQL, getCreationDataTelos, getCreationDataMeter, getCreationDataHarmony } from '../utils';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const multihashes: any = require('multihashes');
 
@@ -339,11 +339,25 @@ export class Injector {
         if (txFetchAddress && (chain == "83" || chain == "82")){
             txFetchAddress = txFetchAddress.replace("${ADDRESS}", contractAddress);
             for (const web3 of this.chains[chain].web3array){
-                this.log.info({loc, chain, contractAddress, fetchAddress: txFetchAddress}, "Querying Meter API")
-                try{
+                this.log.info({ loc, chain, contractAddress, fetchAddress: txFetchAddress }, "Querying Meter API")
+                try {
                     return await getCreationDataMeter(txFetchAddress, web3);
-                }catch(err:any){
+                } catch(err:any){
                     this.log.error({ loc, chain, contractAddress, err: err.message }, "Meter API failed!");
+                }
+            }
+        }
+        
+        // Harmony network
+        if (txFetchAddress && (chain == "1666600000" || chain == "1666600001" || chain == "1666600002" || chain == "1666600003")){
+            const shard = Number(chain) - 1666600000;
+            txFetchAddress = txFetchAddress.replace("${SHARD}", shard.toString()).replace("${ADDRESS}", contractAddress);
+            for (const web3 of this.chains[chain].web3array){
+                this.log.info({ loc, chain, contractAddress, fetchAddress: txFetchAddress }, "Querying Harmony API")
+                try {
+                    return await getCreationDataHarmony(txFetchAddress, web3);
+                } catch(err:any){
+                    this.log.error({ loc, chain, contractAddress, err: err.message }, "Harmony API failed!");
                 }
             }
         }

--- a/services/verification/src/utils.ts
+++ b/services/verification/src/utils.ts
@@ -360,7 +360,7 @@ export async function getCreationDataTelos(fetchAddress: string, web3: Web3): Pr
         }
     }
 
-    throw new Error(`Creation data could not be scraped from ${fetchAddress}`);
+    throw new Error(`Creation data could not be fetched from ${fetchAddress}`);
 }
 
 export async function getCreationDataMeter(fetchAddress: string, web3: Web3): Promise<string> {
@@ -374,7 +374,21 @@ export async function getCreationDataMeter(fetchAddress: string, web3: Web3): Pr
         }
     }
 
-    throw new Error(`Creation data could not be scraped from ${fetchAddress}`);
+    throw new Error(`Creation data could not be fetched from ${fetchAddress}`);
+}
+
+export async function getCreationDataHarmony(fetchAddress: string, web3: Web3): Promise<string> {
+    const res = await fetch(fetchAddress);
+    if (res.status === StatusCodes.OK) {
+        const response = await res.json();
+        if (response.transactionHash) {
+            const txHash = response.transactionHash;
+            const tx = await web3.eth.getTransaction(txHash);
+            return tx.input;
+        }
+    }
+
+    throw new Error(`Creation data could not be fetched from ${fetchAddress}`);
 }
 
 

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -32,6 +32,10 @@ export const CHAIN_OPTIONS = [
     {value: "meter testnet", label: "Meter Testnet", id: 83},
     {value: "aurora mainnet", label: "Aurora Mainnet", id: 1313161554 },
     {value: "aurora testnet", label: "Aurora Testnet", id: 1313161555 },
+    {value: "harmony shard 0", label: "Harmony Shard 0", id: 1666600000 },
+    {value: "harmony shard 1", label: "Harmony Shard 1", id: 1666600001 },
+    {value: "harmony shard 2", label: "Harmony Shard 2", id: 1666600002 },
+    {value: "harmony shard 3", label: "Harmony Shard 3", id: 1666600003 },
 ];
 
 export const ID_TO_CHAIN = {};


### PR DESCRIPTION
Fixes #645 

Testnet is not added since I haven't found an API to get deployment tx hash given the contract address for testnet. If I found any or receive feedback from the Harmony team, I'll add them.

Also, I can't follow correctly how does the `web3.eth.getTransaction` points to the specified chain, should I add rpc endpoints to `sourcify-chains.ts`?

### Contract
```
// SPDX-License-Identifier: GPL-3.0
pragma solidity >=0.4.16 <0.9.0;

contract SimpleStorage {
    uint storedData;

    function set(uint x) public {
        storedData = x;
    }

    function get() public view returns (uint) {
        return storedData;
    }
}
```

### Metadata

```
{"compiler":{"version":"0.8.7+commit.e28d00a7"},"language":"Solidity","output":{"abi":[{"inputs":[],"name":"get","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"x","type":"uint256"}],"name":"set","outputs":[],"stateMutability":"nonpayable","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"contracts/1_Storage.sol":"SimpleStorage"},"evmVersion":"london","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"contracts/1_Storage.sol":{"keccak256":"0xfa79bfa0e9d7acbb32774a2228765441c93b1fda3eb717ea515bea50f83e26aa","license":"GPL-3.0","urls":["bzz-raw://f6b7cf35ca688a5ef9315575cdb2fdebb791d45a8a3edeaa962753909ccd24e7","dweb:/ipfs/QmYoekw8e8yYmBfCCHRsb3hZJ64iJ7sR5XF8W69m2ntMho"]}},"version":1}
```

### Addresses

Mainnet Shard 0: [0xa57b5cf2f083219eb630d74712060feee6f098fe](https://explorer-v2-api.hmny.io/v0/shard/0/address/0xa57b5cf2f083219eb630d74712060feee6f098fe/contract)
Mainnet Shard 1: [0x9faf6ae7aa8e882b216c4ef1af14008f2a8d13c0](https://explorer-v2-api.hmny.io/v0/shard/1/address/0x9faf6ae7aa8e882b216c4ef1af14008f2a8d13c0/contract)
Mainnet Shard 2: [0x9faf6ae7aa8e882b216c4ef1af14008f2a8d13c0](https://explorer-v2-api.hmny.io/v0/shard/2/address/0x9faf6ae7aa8e882b216c4ef1af14008f2a8d13c0/contract)
Mainnet Shard 3: [0x9faf6ae7aa8e882b216c4ef1af14008f2a8d13c0](https://explorer-v2-api.hmny.io/v0/shard/3/address/0x9faf6ae7aa8e882b216c4ef1af14008f2a8d13c0/contract)