### PR TITLE
Add contract files to IPFS incrementally 

### DIFF
--- a/environments/.env.dev
+++ b/environments/.env.dev
@@ -40,7 +40,8 @@ IPFS_GW_EXTERNAL_PORT=8080
 IPFS_LIBP2P_EXTERNAL_PORT=4001
 IPFS_API_EXTERNAL_PORT=5001
 IPNS=k51qzi5uqu5dkuzo866rys9qexfvbfdwxjc20njcln808mzjrhnorgu5rh30lb
-IPFS_URL=https://ipfs.io/ipfs/
+IPFS_GATEWAY=https://ipfs.io/ipfs/
+IPFS_API=http://localhost:5001
 # IPs to announce with the ipfs id
 PUBLIC_IP=xxx
 LOCAL_IP=xxx

--- a/environments/.env.dev
+++ b/environments/.env.dev
@@ -41,7 +41,8 @@ IPFS_LIBP2P_EXTERNAL_PORT=4001
 IPFS_API_EXTERNAL_PORT=5001
 IPNS=k51qzi5uqu5dkuzo866rys9qexfvbfdwxjc20njcln808mzjrhnorgu5rh30lb
 IPFS_GATEWAY=https://ipfs.io/ipfs/
-IPFS_API=http://localhost:5001
+# Leave API blank if you don't run an ipfs node
+IPFS_API=
 # IPs to announce with the ipfs id
 PUBLIC_IP=xxx
 LOCAL_IP=xxx

--- a/environments/.env.latest
+++ b/environments/.env.latest
@@ -41,7 +41,8 @@ IPFS_GW_EXTERNAL_PORT=5050
 IPFS_LIBP2P_EXTERNAL_PORT=4002
 IPFS_API_EXTERNAL_PORT=5002
 IPNS=k51qzi5uqu5dkuzo866rys9qexfvbfdwxjc20njcln808mzjrhnorgu5rh30lb
-IPFS_URL=http://ipfs-latest:8080/ipfs/
+IPFS_GATEWAY=http://ipfs-latest:8080/ipfs/
+IPFS_API=http://ipfs-latest:5001
 # IPs to announce with the ipfs id
 PUBLIC_IP=xxx
 LOCAL_IP=xxx

--- a/environments/.env.latest
+++ b/environments/.env.latest
@@ -42,6 +42,7 @@ IPFS_LIBP2P_EXTERNAL_PORT=4002
 IPFS_API_EXTERNAL_PORT=5002
 IPNS=k51qzi5uqu5dkuzo866rys9qexfvbfdwxjc20njcln808mzjrhnorgu5rh30lb
 IPFS_GATEWAY=http://ipfs-latest:8080/ipfs/
+# Leave API blank if you don't run an ipfs node
 IPFS_API=http://ipfs-latest:5001
 # IPs to announce with the ipfs id
 PUBLIC_IP=xxx

--- a/environments/.env.stable
+++ b/environments/.env.stable
@@ -41,6 +41,7 @@ IPFS_LIBP2P_EXTERNAL_PORT=4003
 IPFS_API_EXTERNAL_PORT=5003
 IPNS=k51qzi5uqu5dll0ocge71eudqnrgnogmbr37gsgl12uubsinphjoknl6bbi41p
 IPFS_GATEWAY=http://ipfs-stable:8080/ipfs/
+# Leave API blank if you don't run an ipfs node
 IPFS_API=http://ipfs-stable:5001
 # IPs to announce with the ipfs id
 PUBLIC_IP=xxx

--- a/environments/.env.stable
+++ b/environments/.env.stable
@@ -40,7 +40,8 @@ IPFS_GW_EXTERNAL_PORT=5051
 IPFS_LIBP2P_EXTERNAL_PORT=4003
 IPFS_API_EXTERNAL_PORT=5003
 IPNS=k51qzi5uqu5dll0ocge71eudqnrgnogmbr37gsgl12uubsinphjoknl6bbi41p
-IPFS_URL=http://ipfs-stable:8080/ipfs/
+IPFS_GATEWAY=http://ipfs-stable:8080/ipfs/
+IPFS_API=http://ipfs-stable:5001
 # IPs to announce with the ipfs id
 PUBLIC_IP=xxx
 LOCAL_IP=xxx

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,6 +27,6 @@ TAG=$TAG ./scripts/find_replace.sh
 source ./environments/.env
 ./scripts/prepare.sh
 cd environments
-docker image prune --all -f
+docker image prune -f
 eval ${COMPOSE_COMMAND} pull
 eval COMPOSE_HTTP_TIMEOUT=1200 ${COMPOSE_COMMAND} up -d

--- a/services/core/src/utils/CheckedContract.ts
+++ b/services/core/src/utils/CheckedContract.ts
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 import { InvalidSources, MissingSources } from '..';
 
 const IPFS_PREFIX = "dweb:/ipfs/";
-const IPFS_URL = process.env.IPFS_URL || 'https://ipfs.io/ipfs/';
+const IPFS_GATEWAY = process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
 const FETCH_TIMEOUT = parseInt(process.env.FETCH_TIMEOUT) || 3000; // ms
 /**
  * Abstraction of a checked solidity contract. With metadata and source (solidity) files.
@@ -175,7 +175,7 @@ export class CheckedContract {
                 for (const url of file.urls) {
                     if (url.startsWith(IPFS_PREFIX)) {
                         const ipfsCode = url.slice(IPFS_PREFIX.length);
-                        const ipfsUrl = IPFS_URL + ipfsCode;
+                        const ipfsUrl = IPFS_GATEWAY + ipfsCode;
                         retrievedContent = await performFetch(ipfsUrl, hash, fileName, log);
                         if (retrievedContent) {
                             break;

--- a/services/ipfs/entrypoint.sh
+++ b/services/ipfs/entrypoint.sh
@@ -35,6 +35,27 @@ ipfs key import main /app/ipfs-${TAG}.key
 
 ipfs daemon --enable-pubsub-experiment --enable-namesys-pubsub --enable-gc &
 
+# Add the whole repo and publish on start
+date
+echo "Starting ipfs add"
+hash=$(ipfs add -Q -r /root/.ipfs/repository)
+echo "Finished ipfs add! New ipfs hash: $hash"
+date
+
+# cp the repo under MFS
+echo "Copying to MFS"
+ipfs files cp -p /ipfs/$hash/ /
+echo "Copied to MFS"
+date
+
+# Get the root hash
+rootHash=$(ipfs files stat / | head -n 1)
+
+echo "Publishing rootHash $rootHash under ipns key"
+ipfs -D name publish --key=main $rootHash
+echo "Published rootHash $rootHash under ipns key"
+date
+
 # Start the run once job.
 echo "Docker container has been started"
 

--- a/services/ipfs/entrypoint.sh
+++ b/services/ipfs/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ipfs init --profile server
+ipfs init --profile=server,badgerds
 ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 
 ## Build announced address config according to https://docs.ipfs.io/how-to/configure-node/#addresses. Need to announce the public and local IPs in swarm manually since docker does not know these IPs.
@@ -24,7 +24,6 @@ ANNOUNCED_ADDRESSES=$ANNOUNCED_ADDRESSES']'
 ipfs config Addresses.Announce $ANNOUNCED_ADDRESSES --json
 ipfs config --json Reprovider.Strategy '"pinned"'
 ipfs config --json Experimental.AcceleratedDHTClient true
-ipfs config --json Experimental.FilestoreEnabled true
 
 # Allow WebUI to be accesible from host
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'

--- a/services/ipfs/entrypoint.sh
+++ b/services/ipfs/entrypoint.sh
@@ -38,18 +38,23 @@ ipfs daemon --enable-pubsub-experiment --enable-namesys-pubsub --enable-gc &
 # Add the whole repo and publish on start
 date
 echo "Starting ipfs add"
-hash=$(ipfs add -Q -r /root/.ipfs/repository)
+hash=$(ipfs add -Q -r /root/.ipfs/repository/contracts)
 echo "Finished ipfs add! New ipfs hash: $hash"
 date
 
 # cp the repo under MFS
 echo "Copying to MFS"
-ipfs files cp -p /ipfs/$hash/ /
+ipfs files cp -p /ipfs/$hash /contracts
 echo "Copied to MFS"
 date
 
-# Get the root hash
-rootHash=$(ipfs files stat / | head -n 1)
+# Add manifest and stats to MFS.
+manifestHash=$(ipfs add -Q /root/.ipfs/repository/manifest.json)
+statsHash=$(ipfs add -Q /root/.ipfs/repository/stats.json)
+ipfs files cp -p /ipfs/$manifestHash /manifest.json
+ipfs files cp -p /ipfs/$statsHash /stats.json
+
+rootHash=$(ipfs files stat / --hash)
 
 echo "Publishing rootHash $rootHash under ipns key"
 ipfs -D name publish --key=main $rootHash

--- a/services/ipfs/publish.sh
+++ b/services/ipfs/publish.sh
@@ -31,10 +31,10 @@ date
 # Update the new manifest and stats in MFS.
 manifestHash=$(ipfs add -Q /root/.ipfs/repository/manifest.json)
 statsHash=$(ipfs add -Q /root/.ipfs/repository/stats.json)
-# rm old CIDs from MFS path
+# rm old files from MFS 
 ipfs files rm /manifest.json
 ipfs files rm /stats.json
-# Link
+# add new manifest and stats
 ipfs files cp -p /ipfs/$manifestHash /manifest.json
 ipfs files cp -p /ipfs/$statsHash /stats.json
 

--- a/services/ipfs/publish.sh
+++ b/services/ipfs/publish.sh
@@ -28,34 +28,11 @@ echo $OUTPUT > $REPOSITORY_PATH/stats.json
 
 date
 echo "Starting ipfs add"
-hash=$(ipfs add -Q -r --fscache --nocopy /root/.ipfs/repository/contracts)
+hash=$(ipfs add -Q -r /root/.ipfs/repository)
 echo "Finished ipfs add! New ipfs hash: $hash"
 date
 
-# As manifest.json frequently changes, it is not possible to add whole /repository with Filestore (i.e. --nocopy).
-# Just add&pin repository/contracts and link the folders full_match, partial_match manually under the MFS (Mutable File System) directory /contracts.
-echo "Linking under /contracts"
-# rm old CIDs from MFS path
-ipfs files rm -r /contracts/full_match
-ipfs files rm -r /contracts/partial_match
-# Link new CIDs
-ipfs files cp -p /ipfs/$hash/full_match /contracts/
-ipfs files cp -p /ipfs/$hash/partial_match /contracts/
-
-# Add manifest and stats to ipfs (without Filestore)
-manifestHash=$(ipfs add -Q /root/.ipfs/repository/manifest.json)
-statsHash=$(ipfs add -Q /root/.ipfs/repository/stats.json)
-# rm old CIDs from MFS path
-ipfs files rm /manifest.json
-ipfs files rm /stats.json
-# Link
-ipfs files cp -p /ipfs/$manifestHash /manifest.json
-ipfs files cp -p /ipfs/$statsHash /stats.json
-
-# Get the root hash
-rootHash=$(ipfs files stat / | head -n 1)
-
 echo "Publishing hash under ipns key"
-ipfs -D name publish --key=main $rootHash
+ipfs -D name publish --key=main $hash
 echo "Published hash under ipns key"
 date

--- a/services/verification/package-lock.json
+++ b/services/verification/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ethereum-sourcify/core": "*",
         "bunyan": "^1.8.15",
+        "ipfs-http-client": "^56.0.3",
         "node-fetch": "^2.6.1",
         "promise.any": "^2.0.2",
         "semver": "^7.3.6",
@@ -432,6 +433,86 @@
         "@ethersproject/strings": "^5.4.0"
       }
     },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.1.tgz",
+      "integrity": "sha512-XqG8VEzHjQDC/Qcy5Gyf1kvAav5VuAugc6c7VtdaRLI+3d8lJrUP3F76GYJNNXuEnRZ58cCBnNNglkIGTdg1+A==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.9.tgz",
+      "integrity": "sha512-NNKHmgHxc2zOEaB8qOUpAb2UK1vcEE/rBeh018Da/RzXE7N8GwiTJLRZ3Fe/G4fsiis67G0sagRz/YNQcANRsQ==",
+      "dependencies": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.16.tgz",
+      "integrity": "sha512-5+A87ZsKZ2yEEjtW6LIzTgDJcm6O24d0lmXlubwtMblI5ZB+aTw7PH6kjc8fM6pbnNtVg4Y+c+WZ3zCxdesIBg==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -467,6 +548,16 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/node": {
       "version": "12.19.3",
@@ -551,6 +642,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -695,6 +791,14 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
+    "node_modules/blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "dependencies": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -738,6 +842,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -989,6 +1098,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/cborg": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.2.tgz",
+      "integrity": "sha512-kgJLMcEw+2jP9QV372+5oJG7U24gxjf+EZYXupdnJJ3Uuw6shgHUqXi49ex6eb7ArWOrX5j0Ik7yETBP7t7F6Q==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -1212,6 +1329,24 @@
         "type": "^1.0.1"
       }
     },
+    "node_modules/dag-jose": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-1.0.0.tgz",
+      "integrity": "sha512-U0b/YsIPBp6YZNTFrVjwLZAlY3qGRxZTIEcM/CcQmrVrCWq9MWQq9pheXVSPLIhF4SNwzp2SikPva4/BIrJY+g==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^6.0.3",
+        "multiformats": "^9.0.2"
+      }
+    },
+    "node_modules/dag-jose/node_modules/@ipld/dag-cbor": {
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.15.tgz",
+      "integrity": "sha512-Vm3VTSTwlmGV92a3C5aeY+r2A18zbH2amehNhsX8PBa3muXICaWrN8Uri85A5hLH7D7ElhE8PdjxD6kNqUmTZA==",
+      "dependencies": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1323,6 +1458,37 @@
         "node": ">=4.2"
       }
     },
+    "node_modules/dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
+    "node_modules/dns-over-http-resolver/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dns-over-http-resolver/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
@@ -1359,6 +1525,17 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "node_modules/electron-fetch": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
+      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/elliptic": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -1381,6 +1558,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1388,6 +1584,11 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/es-abstract": {
       "version": "1.19.0",
@@ -1732,6 +1933,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-fifo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
+      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1852,6 +2058,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "node_modules/get-stream": {
       "version": "4.1.0",
@@ -2194,6 +2405,21 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/interface-datastore": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.0.tgz",
+      "integrity": "sha512-oNHdsrWBsI/kDwUtEgt+aaZtQFKtQYN0TGZzc3SGiIA6m+plZ6malhmsygtbmDpfpIsNNC7ce9Gyaj+Tki+gVw==",
+      "dependencies": {
+        "interface-store": "^2.0.1",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -2207,12 +2433,197 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipfs-core-types": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.10.3.tgz",
+      "integrity": "sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==",
+      "dependencies": {
+        "@ipld/dag-pb": "^2.1.3",
+        "interface-datastore": "^6.0.2",
+        "ipfs-unixfs": "^6.0.3",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.5.1"
+      }
+    },
+    "node_modules/ipfs-core-utils": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.14.3.tgz",
+      "integrity": "sha512-aBkewVhgAj3NWXPwu6imj0wADGiGVZmJzqKzODOJsibDjkx6FGdMv8kvvqtLnK8LS/dvSk9yk32IDtuDyYoV7Q==",
+      "dependencies": {
+        "any-signal": "^3.0.0",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.10.3",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.6",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.5.1",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ipfs-http-client": {
+      "version": "56.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-56.0.3.tgz",
+      "integrity": "sha512-E3L5ylVl6BjyRUsNehvfuRBYp1hj8vQ8in4zskVPMNzXs6JiCFUbif5a6BtcAlSK4xPQyJCeLNNAWLUeFQTLNA==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
+        "any-signal": "^3.0.0",
+        "dag-jose": "^1.0.0",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.10.3",
+        "ipfs-core-utils": "^0.14.3",
+        "ipfs-utils": "^9.0.6",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.5.1",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=15.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/ipfs-http-client/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ipfs-http-client/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ipfs-unixfs": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.7.tgz",
+      "integrity": "sha512-5mKbQgvux6n5lQ+upGWWPKcoswXahdOcyGQ2SbIIRV6eBJMzxLprzKsyb0GMsg80tHX2wnNOxBKSCiSGjb+54A==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-utils": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.6.tgz",
+      "integrity": "sha512-/WfdwOIiJVb3uqfKRQ9Eo+vCEKsDgp7h4Pdc37MRwAiFciZ7xKAkEqsfXubV0VQi8x5jWTifeHn8WEPBLL451w==",
+      "dependencies": {
+        "any-signal": "^3.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
+        "is-electron": "^2.2.0",
+        "iso-url": "^1.1.5",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+        "react-native-fetch-api": "^2.0.0",
+        "stream-to-it": "^0.2.2"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/node-fetch": {
+      "name": "@achingbrain/node-fetch",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -2281,6 +2692,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
+      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+    },
     "node_modules/is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
@@ -2307,6 +2723,17 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-map": {
@@ -2472,6 +2899,14 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2487,6 +2922,76 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "node_modules/it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "node_modules/it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "node_modules/it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "node_modules/it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-to-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/iterate-iterator": {
@@ -2591,6 +3096,11 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -2643,6 +3153,25 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -2795,6 +3324,32 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/multiaddr": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "dependencies": {
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "dependencies": {
+        "multiaddr": "^10.0.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
     "node_modules/multibase": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
@@ -2813,6 +3368,11 @@
       "dependencies": {
         "varint": "^5.0.0"
       }
+    },
+    "node_modules/multiformats": {
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "node_modules/multihashes": {
       "version": "0.4.21",
@@ -2870,6 +3430,25 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "peerDependencies": {
+        "node-fetch": "*"
+      }
     },
     "node_modules/ncp": {
       "version": "2.0.0",
@@ -3042,6 +3621,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dependencies": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3072,6 +3668,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/parse-duration": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.2.tgz",
+      "integrity": "sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg=="
     },
     "node_modules/parse-headers": {
       "version": "2.0.4",
@@ -3165,6 +3766,36 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/protobufjs/node_modules/@types/node": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
+      "integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -3273,6 +3904,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react-native-fetch-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
+      "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
+      "dependencies": {
+        "p-defer": "^3.0.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -3285,6 +3924,19 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/receptacle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -3340,6 +3992,11 @@
       "dependencies": {
         "lowercase-keys": "^1.0.0"
       }
+    },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -3681,6 +4338,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "dependencies": {
+        "get-iterator": "^1.0.2"
+      }
+    },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -3873,6 +4538,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/timeout-abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
+      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "dependencies": {
+        "retimer": "^3.0.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -3986,6 +4659,14 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/ultron": {
@@ -4837,6 +5518,86 @@
         "@ethersproject/strings": "^5.4.0"
       }
     },
+    "@ipld/dag-cbor": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.1.tgz",
+      "integrity": "sha512-XqG8VEzHjQDC/Qcy5Gyf1kvAav5VuAugc6c7VtdaRLI+3d8lJrUP3F76GYJNNXuEnRZ58cCBnNNglkIGTdg1+A==",
+      "requires": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/dag-json": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.9.tgz",
+      "integrity": "sha512-NNKHmgHxc2zOEaB8qOUpAb2UK1vcEE/rBeh018Da/RzXE7N8GwiTJLRZ3Fe/G4fsiis67G0sagRz/YNQcANRsQ==",
+      "requires": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/dag-pb": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.16.tgz",
+      "integrity": "sha512-5+A87ZsKZ2yEEjtW6LIzTgDJcm6O24d0lmXlubwtMblI5ZB+aTw7PH6kjc8fM6pbnNtVg4Y+c+WZ3zCxdesIBg==",
+      "requires": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -4866,6 +5627,16 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "@types/node": {
       "version": "12.19.3",
@@ -4942,6 +5713,11 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
     "arg": {
       "version": "4.1.3",
@@ -5051,6 +5827,14 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
+    "blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "requires": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5091,6 +5875,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -5289,6 +6078,11 @@
         "nofilter": "^1.0.4"
       }
     },
+    "cborg": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.2.tgz",
+      "integrity": "sha512-kgJLMcEw+2jP9QV372+5oJG7U24gxjf+EZYXupdnJJ3Uuw6shgHUqXi49ex6eb7ArWOrX5j0Ik7yETBP7t7F6Q=="
+    },
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -5484,6 +6278,26 @@
         "type": "^1.0.1"
       }
     },
+    "dag-jose": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-1.0.0.tgz",
+      "integrity": "sha512-U0b/YsIPBp6YZNTFrVjwLZAlY3qGRxZTIEcM/CcQmrVrCWq9MWQq9pheXVSPLIhF4SNwzp2SikPva4/BIrJY+g==",
+      "requires": {
+        "@ipld/dag-cbor": "^6.0.3",
+        "multiformats": "^9.0.2"
+      },
+      "dependencies": {
+        "@ipld/dag-cbor": {
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.15.tgz",
+          "integrity": "sha512-Vm3VTSTwlmGV92a3C5aeY+r2A18zbH2amehNhsX8PBa3muXICaWrN8Uri85A5hLH7D7ElhE8PdjxD6kNqUmTZA==",
+          "requires": {
+            "cborg": "^1.5.4",
+            "multiformats": "^9.5.4"
+          }
+        }
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5571,6 +6385,31 @@
       "resolved": "https://registry.npmjs.org/directory-tree/-/directory-tree-2.2.5.tgz",
       "integrity": "sha512-qmeuql8N7hQB5b+cnlvbcHSjKBNpRjLY5KcvyFd9CTC5uTN7sJshEQ/ExZidAcEUEYcC/76i8ikLtbBMG81YRg=="
     },
+    "dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "requires": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
@@ -5604,6 +6443,14 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "electron-fetch": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
+      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
+    },
     "elliptic": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -5623,6 +6470,24 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -5630,6 +6495,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "es-abstract": {
       "version": "1.19.0",
@@ -5938,6 +6808,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-fifo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
+      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6034,6 +6909,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -6283,6 +7163,21 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "interface-datastore": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.0.tgz",
+      "integrity": "sha512-oNHdsrWBsI/kDwUtEgt+aaZtQFKtQYN0TGZzc3SGiIA6m+plZ6malhmsygtbmDpfpIsNNC7ce9Gyaj+Tki+gVw==",
+      "requires": {
+        "interface-store": "^2.0.1",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -6293,10 +7188,154 @@
         "side-channel": "^1.0.4"
       }
     },
+    "ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "ipfs-core-types": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.10.3.tgz",
+      "integrity": "sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==",
+      "requires": {
+        "@ipld/dag-pb": "^2.1.3",
+        "interface-datastore": "^6.0.2",
+        "ipfs-unixfs": "^6.0.3",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.5.1"
+      }
+    },
+    "ipfs-core-utils": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.14.3.tgz",
+      "integrity": "sha512-aBkewVhgAj3NWXPwu6imj0wADGiGVZmJzqKzODOJsibDjkx6FGdMv8kvvqtLnK8LS/dvSk9yk32IDtuDyYoV7Q==",
+      "requires": {
+        "any-signal": "^3.0.0",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.10.3",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.6",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.5.1",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "ipfs-http-client": {
+      "version": "56.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-56.0.3.tgz",
+      "integrity": "sha512-E3L5ylVl6BjyRUsNehvfuRBYp1hj8vQ8in4zskVPMNzXs6JiCFUbif5a6BtcAlSK4xPQyJCeLNNAWLUeFQTLNA==",
+      "requires": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
+        "any-signal": "^3.0.0",
+        "dag-jose": "^1.0.0",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.10.3",
+        "ipfs-core-utils": "^0.14.3",
+        "ipfs-utils": "^9.0.6",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.5.1",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "ipfs-unixfs": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.7.tgz",
+      "integrity": "sha512-5mKbQgvux6n5lQ+upGWWPKcoswXahdOcyGQ2SbIIRV6eBJMzxLprzKsyb0GMsg80tHX2wnNOxBKSCiSGjb+54A==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
+      }
+    },
+    "ipfs-utils": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.6.tgz",
+      "integrity": "sha512-/WfdwOIiJVb3uqfKRQ9Eo+vCEKsDgp7h4Pdc37MRwAiFciZ7xKAkEqsfXubV0VQi8x5jWTifeHn8WEPBLL451w==",
+      "requires": {
+        "any-signal": "^3.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
+        "is-electron": "^2.2.0",
+        "iso-url": "^1.1.5",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+        "react-native-fetch-api": "^2.0.0",
+        "stream-to-it": "^0.2.2"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "node-fetch": {
+          "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
+        }
+      }
     },
     "is-arguments": {
       "version": "1.1.1",
@@ -6337,6 +7376,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-electron": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
+      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+    },
     "is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
@@ -6354,6 +7398,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "requires": {
+        "ip-regex": "^4.0.0"
+      }
     },
     "is-map": {
       "version": "2.0.2",
@@ -6458,6 +7510,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
+    "iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -6470,6 +7527,64 @@
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
+      }
+    },
+    "it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "requires": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "iterate-iterator": {
@@ -6561,6 +7676,11 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -6601,6 +7721,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -6719,6 +7854,34 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multiaddr": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "requires": {
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
+    "multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "requires": {
+        "multiaddr": "^10.0.0"
+      }
+    },
     "multibase": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
@@ -6735,6 +7898,11 @@
       "requires": {
         "varint": "^5.0.0"
       }
+    },
+    "multiformats": {
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "multihashes": {
       "version": "0.4.21",
@@ -6789,6 +7957,17 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+    },
+    "native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "requires": {}
     },
     "ncp": {
       "version": "2.0.0",
@@ -6912,6 +8091,20 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -6936,6 +8129,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-duration": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.2.tgz",
+      "integrity": "sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg=="
     },
     "parse-headers": {
       "version": "2.0.4",
@@ -7001,6 +8199,33 @@
         "es-aggregate-error": "^1.0.3",
         "get-intrinsic": "^1.1.1",
         "iterate-value": "^1.0.2"
+      }
+    },
+    "protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.32",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
+          "integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw=="
+        }
       }
     },
     "proxy-addr": {
@@ -7092,6 +8317,14 @@
         "unpipe": "1.0.0"
       }
     },
+    "react-native-fetch-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
+      "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
+      "requires": {
+        "p-defer": "^3.0.0"
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -7100,6 +8333,21 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "request": {
@@ -7148,6 +8396,11 @@
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
+    },
+    "retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -7423,6 +8676,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "requires": {
+        "get-iterator": "^1.0.2"
+      }
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -7559,6 +8820,14 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "timeout-abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
+      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "requires": {
+        "retimer": "^3.0.0"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7639,6 +8908,14 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
       "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
+    },
+    "uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "requires": {
+        "multiformats": "^9.4.2"
+      }
     },
     "ultron": {
       "version": "1.1.1",

--- a/services/verification/package.json
+++ b/services/verification/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@ethereum-sourcify/core": "*",
     "bunyan": "^1.8.15",
+    "ipfs-http-client": "^56.0.3",
     "node-fetch": "^2.6.1",
     "promise.any": "^2.0.2",
     "semver": "^7.3.6",

--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -80,7 +80,7 @@ export class Injector {
         this.web3timeout = config.web3timeout || 3000;
 
         this.fileService = config.fileService || new FileService(this.repositoryPath, this.log);
-        this.ipfsClient = create({url: process.env.IPFS_API});
+        this.ipfsClient = process.env.IPFS_API ? create({url: process.env.IPFS_API}) : undefined;
     }
 
     /**
@@ -488,7 +488,9 @@ export class Injector {
                 this.storeLibraryMap(matchQuality, chain, match.address, match.libraryMap);
             }
 
-            await this.addToIpfsMfs(matchQuality, chain, match.address);
+            if (this.ipfsClient) {
+                await this.addToIpfsMfs(matchQuality, chain, match.address);
+            }
 
         } else if (match.status === "extra-file-input-bug") {
             return match

--- a/services/verification/src/services/Injector.ts
+++ b/services/verification/src/services/Injector.ts
@@ -5,6 +5,8 @@ import { RecompilationResult, getBytecode, recompile, getBytecodeWithoutMetadata
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const multihashes: any = require('multihashes');
 import semverSatisfies from 'semver/functions/satisfies';
+import { create, IPFSHTTPClient, globSource } from 'ipfs-http-client'
+import path from 'path';
 
 export interface InjectorConfig {
     silent?: boolean,
@@ -64,6 +66,7 @@ export class Injector {
     public fileService: IFileService;
     private web3timeout: number;
     repositoryPath: string;
+    private ipfsClient: IPFSHTTPClient;
 
     /**
      * Constructor
@@ -77,6 +80,7 @@ export class Injector {
         this.web3timeout = config.web3timeout || 3000;
 
         this.fileService = config.fileService || new FileService(this.repositoryPath, this.log);
+        this.ipfsClient = create({url: process.env.IPFS_API});
     }
 
     /**
@@ -462,6 +466,9 @@ export class Injector {
         // and the sources.
         if (match.address && (match.status === "perfect" || match.status === "partial")) {
             const metadataPath = this.getMetadataPathFromCborEncoded(compilationResult.deployedBytecode, match.address, chain);
+
+            // Saves the metadata file with its ipfs CID under /repository/ipfs/Qmvz....
+            // TODO: Do we need this?
             if (metadataPath) {
                 this.fileService.save(metadataPath, compilationResult.metadata);
                 this.fileService.deletePartial(chain, match.address);
@@ -480,6 +487,8 @@ export class Injector {
             if (match.libraryMap && Object.keys(match.libraryMap).length) {
                 this.storeLibraryMap(matchQuality, chain, match.address, match.libraryMap);
             }
+
+            await this.addToIpfsMfs(matchQuality, chain, match.address);
 
         } else if (match.status === "extra-file-input-bug") {
             return match
@@ -613,5 +622,30 @@ export class Injector {
         },
             JSON.stringify(libraryMap, null, indentationSpaces)
         );
+    }
+
+    /**
+     * Adds the verified contract's folder to IPFS via MFS
+     * 
+     * @param matchQuality 
+     * @param chain 
+     * @param address 
+     */
+    private async addToIpfsMfs(matchQuality: MatchQuality, chain: string, address: string) {
+        const contractFolderDir = this.fileService.generateAbsoluteFilePath({matchQuality, chain, address})
+        const ipfsMFSDir = "/" + this.fileService.generateRelativeContractDir({matchQuality, chain, address})
+        const filesAsyncIterable = globSource(contractFolderDir, '**/*');
+        for await (const file of filesAsyncIterable) {
+            if (!file.content) continue; // skip directories
+            const mfsPath = path.join(ipfsMFSDir, file.path);
+            await this.ipfsClient.files.mkdir(path.dirname(mfsPath), { parents: true });
+            // Readstream to Buffers
+            const chunks: Buffer[] = [];
+            for await (const chunk of file.content) {
+                chunks.push(chunk)
+            }
+            const fileBuffer = Buffer.concat(chunks)
+            await this.ipfsClient.files.write(mfsPath, fileBuffer, { create: true }); 
+        }
     }
 }

--- a/src/monitor/source-fetcher.ts
+++ b/src/monitor/source-fetcher.ts
@@ -42,7 +42,7 @@ declare interface TimestampMap {
  */
 export default class SourceFetcher {
     gatewayFetchers = [
-        new GatewayFetcher(new SimpleGateway("ipfs", process.env.IPFS_URL || "https://ipfs.io/ipfs/", "https://cloudflare-ipfs.com/ipfs/")),
+        new GatewayFetcher(new SimpleGateway("ipfs", process.env.IPFS_GATEWAY || "https://ipfs.io/ipfs/", "https://cloudflare-ipfs.com/ipfs/")),
         new GatewayFetcher(new SimpleGateway(["bzzr0", "bzzr1"], "https://swarm-gateways.net/bzz-raw:/"))
     ]
 

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -1,7 +1,7 @@
 process.env.TESTING = "true";
 process.env.MOCK_REPOSITORY = "./mockRepository";
 process.env.MOCK_DATABASE = "./mockDatabase";
-process.env.IPFS_URL = "http://ipfs.io/ipfs/";
+process.env.IPFS_GATEWAY = "http://ipfs.io/ipfs/";
 const GANACHE_PORT = process.env.LOCALCHAIN_PORT
   ? parseInt(process.env.LOCALCHAIN_PORT)
   : 8545;

--- a/test/sourceFetcher.js
+++ b/test/sourceFetcher.js
@@ -12,7 +12,7 @@ describe("Source Fetcher", function () {
   beforeEach(() => {});
 
   it("should fetch metadata from IPFS", (done) => {
-    process.env.IPFS_URL = "http://ipfs.io/ipfs/";
+    process.env.IPFS_GATEWAY = "http://ipfs.io/ipfs/";
     sourceFetcher = new SourceFetcher();
     sourceAddress = new SourceAddress("ipfs", METADATA_HASH);
     sourceFetcher.subscribe(sourceAddress, (fetchedFileStr) => {
@@ -23,13 +23,13 @@ describe("Source Fetcher", function () {
   });
 
   it("should use the fallback IPFS gateway when primary fails", (done) => {
-    process.env.IPFS_URL = "http://testinginvalidgatewaydomain/";
+    process.env.IPFS_GATEWAY = "http://testinginvalidgatewaydomain/";
     sourceFetcher = new SourceFetcher();
     sourceAddress = new SourceAddress("ipfs", METADATA_HASH);
     sourceFetcher.subscribe(sourceAddress, (fetchedFileStr) => {
       const jsonFile = JSON.parse(fetchedFileStr);
       console.log(jsonFile.settings.compilationTarget);
-      process.env.IPFS_URL = "http://ipfs.io/ipfs/"; // Set back to correct value
+      process.env.IPFS_GATEWAY = "http://ipfs.io/ipfs/"; // Set back to correct value
       done();
     });
   });


### PR DESCRIPTION
Instead of `ipfs add`ing the whole repo regularly, add the files to ipfs incrementally as they are being added to the repo via IPFS' Mutable File System (MFS) abstraction. Also revert using Filestore and implicitly the `--raw` leaves encoding, which broke the served CIDs of the files in the repo. Remove `IPFS_URL` var and introduce `IPFS_GATEWAY` + `IPFS_API`. Don't prune `--all` Docker images to avoid building new images when no related file was changed.