### PR TITLE
Rename Polygon Mumbai for easier user selection in dropdowns

### DIFF
--- a/services/core/src/chains.json
+++ b/services/core/src/chains.json
@@ -8735,8 +8735,8 @@
     "networkId": 78110
   },
   {
-    "name": "Mumbai",
-    "title": "Polygon Testnet Mumbai",
+    "name": "Polygon Mumbai Testnet",
+    "title": "Polygon Mumbai Testnet",
     "chain": "Polygon",
     "rpc": [
       "https://matic-mumbai.chainstacklabs.com",


### PR DESCRIPTION
After this change, Polygon Mumbai Testnet will be listed underneath Polygon Mainnet in dropdowns.

![image](https://user-images.githubusercontent.com/91382964/187954558-3526fd04-2147-4295-bb94-0c085854ac62.png)


https://github.com/ethereum/sourcify/issues/784