### PR TITLE
Increase solc compilcation max output buffer

### DIFF
--- a/services/verification/src/utils.ts
+++ b/services/verification/src/utils.ts
@@ -167,7 +167,7 @@ export async function useCompiler(version: string, solcJsonInput: any, log: Info
     const logObject = {loc: "[RECOMPILE]", version, solcPath};
     log.info(logObject, "Compiling with external executable");
 
-    const shellOutputBuffer = spawnSync(solcPath, ["--standard-json"], {input: inputStringified});
+    const shellOutputBuffer = spawnSync(solcPath, ["--standard-json"], {input: inputStringified, maxBuffer: 1000 * 1000 * 10});
 
     // Handle errors.
     if (shellOutputBuffer.error) {


### PR DESCRIPTION
Increased from the default 200KB to 10MB.
Hopefully it fixes https://github.com/ethereum/sourcify/issues/807