### PR TITLE
Chain 8217 - update contract fetch address

### DIFF
--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -478,7 +478,7 @@ export default {
     monitored: false,
     contractFetchAddress: "https://scan.crystaleum.org/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
-  },    
+  },
   "420666": { // Kekchain Testnet (kektest)
     supported: true,
     monitored: false,
@@ -535,7 +535,7 @@ export default {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      "https://klaytn-mainnet.aws-k8s.blockscout.com/" + BLOCKSCOUT_SUFFIX,
+      "https://klaytn-mainnet.blockscout.com/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
   },
   "336": {


### PR DESCRIPTION
The explorer for the network was moved to a different url. PR updates it for the contract fetch address.

I couldn't find any instructions for that case, and named the branch as `add-chain-{chainId}`, so tests for new networks could run. Will update as required, if updates should be made in other way