### PR TITLE
Chain 1001 - update contract fetch address

### DIFF
--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -527,7 +527,7 @@ export default {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      "https://klaytn-testnet.aws-k8s.blockscout.com/" + BLOCKSCOUT_SUFFIX,
+      "https://klaytn-testnet.blockscout.com/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
   },
   "8217": {


### PR DESCRIPTION
The explorer for the network was moved to a different url. PR updates it for the contract fetch address.

