### PR TITLE
added ZetaChain Athens testnet

### DIFF
--- a/services/core/src/chains.json
+++ b/services/core/src/chains.json
@@ -11135,5 +11135,29 @@
         "standard": "none"
       }
     ]
+  },
+  {
+    "name": "ZetaChain Athens Testnet",
+    "chain": "ZetaChain",
+    "icon": "Zetachain",
+    "rpc": ["https://api.athens2.zetachain.com/evm"],
+    "faucets": ["https://labs.zetachain.com/get-zeta"],
+    "nativeCurrency": {
+      "name": "Zeta",
+      "symbol": "aZETA",
+      "decimals": 18
+    },
+    "infoURL": "https://docs.zetachain.com/",
+    "shortName": "zetachain-athens",
+    "chainId": 7001,
+    "networkId": 7001,
+    "status": "active",
+    "explorers": [
+      {
+        "name": "ZetaChain Athens Testnet Explorer",
+        "url": "https://explorer.athens.zetachain.com",
+        "standard": "none"
+      }
+    ]
   }
 ]

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -577,6 +577,14 @@ const sourcifyChains: SourcifyChainsObject = {
       "https://blockscout.com/optimism/bedrock-alpha/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex("/optimism/bedrock-alpha"),
   },
+  "7001": {
+    // ZetaChain: Athens Testnet
+    supported: true,
+    monitored: false,
+    contractFetchAddress: "https://blockscout.athens2.zetachain.com/" + BLOCKSCOUT_SUFFIX,
+    txRegex: getBlockscoutRegex(),
+    rpc: ["https://archive.athens2.zetachain.com/evm"],
+  },
 };
 
 export default sourcifyChains;

--- a/test/chains/chain-tests.js
+++ b/test/chains/chain-tests.js
@@ -1159,6 +1159,24 @@ describe("Test Supported Chains", function () {
     "shared/withImmutables.metadata.json"
   );
 
+  // ZetaChain: Athens Testnet
+  verifyContract(
+    "0x1f42652a86918fd84E74e066db94E3078d25Dd8D",
+    "7001",
+    "ZetaChain Athens Testnet",
+    ["shared/1_Storage.sol"],
+    "shared/1_Storage.metadata.json"
+  );
+  verifyContractWithImmutables(
+    "0x7fe7d2F60399913e8ECeb8BAe9adDf9B809E8F6d",
+    "7001",
+    "ZetaChain Athens Testnet",
+    ["uint256"],
+    [7001],
+    ["shared/WithImmutables.sol"],
+    "shared/withImmutables.metadata.json"
+  );
+
 
   //////////////////////
   // Helper functions //


### PR DESCRIPTION
Add support for the ZetaChain Athens testnet

ZetaChain being added to [ethereum-lists/chains](https://github.com/ethereum-lists/chains) is in progress - https://github.com/ethereum-lists/chains/pull/1963