### PR TITLE
refactor: `getFunction` is simpler

### DIFF
--- a/packages/contract-call-decoder/src/lib/ContractCallDecoder.ts
+++ b/packages/contract-call-decoder/src/lib/ContractCallDecoder.ts
@@ -100,9 +100,7 @@ export const findSelectorAndAbiItemFromSignatureHash = (
 ) => {
   try {
     const interf = new Interface(abi);
-    const selector = Object.keys(interf.functions).find((selector) => {
-      return interf.getSighash(selector) === functionSignatureHash;
-    });
+    const selector = interf.getFunction(functionSignatureHash);
     if (!selector) {
       return false;
     }


### PR DESCRIPTION
Get function from ABI directly using `functionSelector`

<img width="845" alt="image" src="https://user-images.githubusercontent.com/38040789/208091764-8f78fee8-7668-43c7-aded-9e6a5c104cf1.png">
