### PR TITLE
Add Oasis Sapphire Mainnet chain

### DIFF
--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -611,7 +611,7 @@ const sourcifyChains: SourcifyChainsObject = {
     // Oasis Sapphire Mainnet
     supported: true,
     monitored: false,
-    contractFetchAddress: "https://explorer.sapphire.oasis.dev/" + BLOCKSCOUT_SUFFIX,
+    contractFetchAddress: "https://explorer.sapphire.oasis.io/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
   },
   "23295": {

--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -607,6 +607,13 @@ const sourcifyChains: SourcifyChainsObject = {
     contractFetchAddress: "https://testnet.explorer.emerald.oasis.dev/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
   },
+  "23294": {
+    // Oasis Sapphire Mainnet
+    supported: true,
+    monitored: false,
+    contractFetchAddress: "https://explorer.sapphire.oasis.dev/" + BLOCKSCOUT_SUFFIX,
+    txRegex: getBlockscoutRegex(),
+  },
   "23295": {
     // Oasis Sapphire Testnet
     supported: true,

--- a/test/chains/chain-tests.js
+++ b/test/chains/chain-tests.js
@@ -1266,6 +1266,24 @@ describe("Test Supported Chains", function () {
     "shared/withImmutables.metadata.json"
    );
 
+  // Oasis Sapphire Mainnet
+  verifyContract(
+    "0xFBcb580DD6D64fbF7caF57FB0439502412324179",
+    "23294",
+    "Oasis Sapphire",
+    ["shared/1_Storage.sol"],
+    "shared/1_Storage.metadata.json"
+  );
+  verifyContractWithImmutables(
+    "0xA0FB05d6Ce497beb162C4EbA4F203544B18A3f31",
+    "23294",
+    "Oasis Sapphire",
+    ["uint256"],
+    [1234],
+    ["shared/WithImmutables.sol"],
+    "shared/withImmutables.metadata.json"
+  );
+
   // Oasis Sapphire Testnet
   verifyContract(
     "0xFBcb580DD6D64fbF7caF57FB0439502412324179",


### PR DESCRIPTION
Adds the confidential Oasis Sapphire Mainnet chain 23294.

Merge after the [Sapphire Mainnet endpoint](https://sapphire.oasis.io/) is officially announced.