### PR TITLE
Temporarily remove Oasis Sapphire

### DIFF
--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -607,13 +607,6 @@ const sourcifyChains: SourcifyChainsObject = {
     contractFetchAddress: "https://testnet.explorer.emerald.oasis.dev/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
   },
-  "23295": {
-    // Oasis Sapphire Testnet
-    supported: true,
-    monitored: false,
-    contractFetchAddress: "https://testnet.explorer.sapphire.oasis.dev/" + BLOCKSCOUT_SUFFIX,
-    txRegex: getBlockscoutRegex(),
-  },
 };
 
 export default sourcifyChains;

--- a/test/chains/chain-tests.js
+++ b/test/chains/chain-tests.js
@@ -1230,24 +1230,6 @@ describe("Test Supported Chains", function () {
     "shared/withImmutables.metadata.json"
   );
 
-  // Oasis Sapphire Testnet
-  verifyContract(
-    "0xFBcb580DD6D64fbF7caF57FB0439502412324179",
-    "23295",
-    "Oasis Sapphire Testnet",
-    ["shared/1_Storage.sol"],
-    "shared/1_Storage.metadata.json"
-  );
-  verifyContractWithImmutables(
-    "0x6e8e9e0DBCa4EF4a65eBCBe4032e7C2a6fb7C623",
-    "23295",
-    "Oasis Sapphire Testnet",
-    ["uint256"],
-    [123],
-    ["shared/WithImmutables.sol"],
-    "shared/withImmutables.metadata.json"
-  );
-
   //////////////////////
   // Helper functions //
   //////////////////////


### PR DESCRIPTION
Remove Oasis Sapphire until immutable contracts are supported. Fixes https://github.com/ethereum/sourcify/issues/894