### PR TITLE
Update Avalanche subnet creation data fetch address

### DIFF
--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -14,7 +14,7 @@ const BLOCKSCOUT_REGEX =
 const BLOCKSCOUT_SUFFIX = "address/${ADDRESS}/transactions";
 const TELOS_SUFFIX = "v2/evm/get_contract?contract=${ADDRESS}";
 const METER_SUFFIX = "api/accounts/${ADDRESS}";
-const AVALANCHE_SUBNET_SUFFIX = "address/${ADDRESS}/contract";
+const AVALANCHE_SUBNET_SUFFIX = "contracts/${ADDRESS}/transactions:getDeployment";
 
 type ChainName = "eth" | "polygon" | "arb" | "opt";
 
@@ -411,7 +411,7 @@ const sourcifyChains: SourcifyChainsObject = {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      `https://subnet-explorer-api.avax-test.network/v1.1/11111/` +
+      `https://glacier-api.avax.network/v1/chains/11111/` +
       AVALANCHE_SUBNET_SUFFIX,
   },
   "192837465": {
@@ -443,7 +443,7 @@ const sourcifyChains: SourcifyChainsObject = {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      `https://subnet-explorer-api.avax-test.network/v1.1/335/` +
+      `https://glacier-api.avax.network/v1/chains/335/` +
       AVALANCHE_SUBNET_SUFFIX,
   },
   "53935": {
@@ -451,7 +451,7 @@ const sourcifyChains: SourcifyChainsObject = {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      `https://subnet-explorer-api.avax.network/v1.1/53935/` +
+      `https://glacier-api.avax.network/v1/chains/53935/` +
       AVALANCHE_SUBNET_SUFFIX,
   },
   "73799": {
@@ -490,7 +490,7 @@ const sourcifyChains: SourcifyChainsObject = {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      `https://subnet-explorer-api.avax-test.network/v1.1/432201/` +
+      `https://glacier-api.avax.network/v1/chains/432201/` +
       AVALANCHE_SUBNET_SUFFIX,
   },
   "432204": {
@@ -498,7 +498,7 @@ const sourcifyChains: SourcifyChainsObject = {
     supported: true,
     monitored: false,
     contractFetchAddress:
-      `https://subnet-explorer-api.avax.network/v1.1/432204/` +
+      `https://glacier-api.avax.network/v1/chains/432204/` +
       AVALANCHE_SUBNET_SUFFIX,
   },
   "103090": {

--- a/services/verification/src/utils.ts
+++ b/services/verification/src/utils.ts
@@ -574,8 +574,8 @@ export async function getCreationDataAvalancheSubnet(
   const res = await fetch(fetchAddress);
   if (res.status === StatusCodes.OK) {
     const response = await res.json();
-    if (response.contract?.creator?.tx) {
-      const txHash = response.contract?.creator?.tx;
+    if (response.nativeTransaction?.txHash) {
+      const txHash = response.nativeTransaction?.txHash;
       const tx = await web3.eth.getTransaction(txHash);
       return tx.input;
     }


### PR DESCRIPTION
We are in the process of deprecating [subnet-explorer-api](https://subnet-explorer-api.avax.network) and moving all functionality over to our new glacier-api. This PR updates the contract creation data fetch address.