### PR TITLE
Add Oasis Sapphire Testnet chain again

### DIFF
--- a/services/core/src/sourcify-chains.ts
+++ b/services/core/src/sourcify-chains.ts
@@ -607,6 +607,13 @@ const sourcifyChains: SourcifyChainsObject = {
     contractFetchAddress: "https://testnet.explorer.emerald.oasis.dev/" + BLOCKSCOUT_SUFFIX,
     txRegex: getBlockscoutRegex(),
   },
+  "23295": {
+    // Oasis Sapphire Testnet
+    supported: true,
+    monitored: false,
+    contractFetchAddress: "https://testnet.explorer.sapphire.oasis.dev/" + BLOCKSCOUT_SUFFIX,
+    txRegex: getBlockscoutRegex(),
+  },
   "19": {
     //  Songbird Canary Network
     supported: true,

--- a/test/chains/chain-tests.js
+++ b/test/chains/chain-tests.js
@@ -1266,6 +1266,24 @@ describe("Test Supported Chains", function () {
     "shared/withImmutables.metadata.json"
    );
 
+  // Oasis Sapphire Testnet
+  verifyContract(
+    "0xFBcb580DD6D64fbF7caF57FB0439502412324179",
+    "23295",
+    "Oasis Sapphire Testnet",
+    ["shared/1_Storage.sol"],
+    "shared/1_Storage.metadata.json"
+  );
+  verifyContractWithImmutables(
+    "0x5a1C04012bc233c898aebb8BB4353F80D96f3dD2",
+    "23295",
+    "Oasis Sapphire Testnet",
+    ["uint256"],
+    [123],
+    ["shared/WithImmutables.sol"],
+    "shared/withImmutables.metadata.json"
+  );
+
 
   //////////////////////
   // Helper functions //


### PR DESCRIPTION
The new [Sapphire 0.4.0](https://github.com/oasisprotocol/sapphire-paratime/releases/tag/v0.4.0-testnet) supports unencrypted calls. Sourcify test contract has now been deployed with an unencrypted transaction and checks for immutable contracts should correctly pass.

Related: #895 