### PR TITLE
Use a local ipfs gw on tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -77,23 +77,52 @@
       "outputCapture": "std"
     },
     {
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "name": "CLI",
-      "program": "${workspaceFolder}/dist/cli/sourcify.js",
-      "request": "launch",
-      "restart": true,
-      "preLaunchTask": "tsc: build - tsconfig.json",
       "type": "node",
+      "request": "launch",
+      "name": "Mocha - All",
+      "program": "${workspaceFolder}/node_modules/.bin/lerna",
+      "env": {
+        "TESTING": "true",
+      },
       "args": [
-        "-c",
-        "1",
-        "-a",
-        "0xfff0f5801a9e13426c306455A3BcC5EF3e9BC979",
-        "-f",
-        "test/testcontracts/ERC20Standard/ERC20Standard.sol",
-        "test/testcontracts/ERC20Standard/metadata.json"
-      ]
+        "run",
+        "test",
+        "--stream"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js",
+        "${workspaceFolder}/packages/**/build/**/*.js"
+      ],
+      "smartStep": true,
+      "skipFiles": [
+        "<node_internals>/**",
+        "node_modules/**"
+      ],
+      "console": "integratedTerminal",
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha - Server",
+      "program": "${workspaceRoot}/node_modules/.bin/mocha",
+      "env": {
+        "DEBUG": "express:*", // Debug all express modules *
+        "TESTING": "true",
+      },
+      "args": [
+        "${workspaceFolder}/test/server.js",
+        "--no-timeout",
+        // Run a single test when debugging
+        // "--grep=v0.6.12",
+        "--exit",
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js",
+        "${workspaceFolder}/packages/**/build/**/*.js",
+      ],
+      "smartStep": true,
+      "console": "integratedTerminal",
+      // "internalConsoleOptions": "neverOpen"
     },
     {
       "type": "node",
@@ -123,50 +152,6 @@
       // "internalConsoleOptions": "neverOpen"
     },
     {
-      "internalConsoleOptions": "openOnSessionStart",
-      "name": "Mocha - All",
-      "program": "${workspaceFolder}/node_modules/.bin/mocha",
-      "request": "launch",
-      "args": [
-        "--no-timeout",
-        "--colors"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/dist/**/*.js",
-        "${workspaceFolder}/packages/**/build/**/*.js"
-      ],
-      "smartStep": true,
-      "envFile": "${workspaceFolder}/environments/.env",
-      "env": {
-        "TESTING": "true",
-      },
-      "skipFiles": [
-        "<node_internals>/**",
-        "node_modules/**"
-      ],
-      "type": "pwa-node",
-      "console": "integratedTerminal",
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Mocha - File",
-      "program": "${workspaceRoot}/node_modules/.bin/mocha",
-      "args": [
-        "--timeout",
-        "999999",
-        "--colors",
-        "${file}"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/dist/**/*.js",
-        "${workspaceFolder}/packages/**/build/**/*.js"
-      ],
-      "smartStep": true,
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
-    },
-    {
       "type": "node",
       "request": "launch",
       "name": "Mocha - Monitor",
@@ -185,30 +170,6 @@
       "smartStep": true,
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Mocha - Server",
-      "program": "${workspaceRoot}/node_modules/.bin/mocha",
-      "env": {
-        "DEBUG": "express:*", // Debug all express modules *
-        "TESTING": "true",
-      },
-      "args": [
-        "${workspaceFolder}/test/server.js",
-        "--no-timeout",
-        // Run a single test when debugging
-        // "--grep=v0.6.12",
-        "--exit",
-      ],
-      "outFiles": [
-        "${workspaceFolder}/dist/**/*.js",
-        "${workspaceFolder}/packages/**/build/**/*.js",
-      ],
-      "smartStep": true,
-      "console": "integratedTerminal",
-      // "internalConsoleOptions": "neverOpen"
     },
     {
       "type": "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "express-validator": "^6.6.1",
         "http-status-codes": "^2.1.4",
         "ipfs-http-client": "^56.0.3",
+        "ipfs-http-gateway": "0.9.3",
         "memorystore": "^1.6.7",
         "node-fetch": "2.6.6",
         "serve-index": "^1.9.1",
@@ -947,6 +948,293 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/@hapi/accept": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/ammo": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/bounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
+    "node_modules/@hapi/call": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/catbox": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/catbox-memory": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/content": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+    },
+    "node_modules/@hapi/hapi": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.3.0.tgz",
+      "integrity": "sha512-zvPSRvaQyF3S6Nev9aiAzko2/hIFZmNSJNcs07qdVaVAvj8dGJSV4fVUuQSnufYJAGiSau+U5LxMLhx79se5WA==",
+      "dependencies": {
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.3",
+        "@hapi/subtext": "^7.1.0",
+        "@hapi/teamwork": "^5.1.0",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/heavy": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/iron": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/mimos": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/nigel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/pez": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.1.0.tgz",
+      "integrity": "sha512-YfB0btnkLB3lb6Ry/1KifnMPBm5ZPfaAHWFskzOMAgDgXgcBgA+zjpIynyEiBfWEz22DBT8o1e2tAaBdlt8zbw==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
+      }
+    },
+    "node_modules/@hapi/podium": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/shot": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/somever": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "dependencies": {
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/statehood": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/subtext": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.1.0.tgz",
+      "integrity": "sha512-n94cU6hlvsNRIpXaROzBNEJGwxC+HA69q769pChzej84On8vsU14guHDub7Pphr/pqn5b93zV3IkMPDU5AUiXA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.1.0",
+        "@hapi/wreck": "17.x.x"
+      }
+    },
+    "node_modules/@hapi/teamwork": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/vise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/wreck": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
+      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3187,6 +3475,24 @@
       "version": "1.1.0",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "license": "MIT",
@@ -3337,6 +3643,11 @@
       "engines": {
         "node": ">=14.16"
       }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.1",
@@ -3843,6 +4154,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -4043,6 +4359,28 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/args": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
+      "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/args/node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -4245,6 +4583,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "license": "MIT",
@@ -4368,7 +4714,6 @@
     },
     "node_modules/bl": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -6667,6 +7012,20 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-fetch": {
       "version": "1.9.1",
       "license": "MIT",
@@ -7904,6 +8263,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "node_modules/fast-write-atomic": {
       "version": "0.2.1",
       "dev": true,
@@ -7948,10 +8320,61 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
+      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -8046,6 +8469,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
       "version": "3.2.7",
@@ -8365,6 +8793,8 @@
     },
     "node_modules/ganache/node_modules/@trufflesuite/bigint-buffer": {
       "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz",
+      "integrity": "sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==",
       "dev": true,
       "hasInstallScript": true,
       "inBundle": true,
@@ -8378,6 +8808,8 @@
     },
     "node_modules/ganache/node_modules/@trufflesuite/bigint-buffer/node_modules/node-gyp-build": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8437,6 +8869,8 @@
     },
     "node_modules/ganache/node_modules/abstract-leveldown": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8470,6 +8904,8 @@
     },
     "node_modules/ganache/node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
         {
@@ -8490,12 +8926,16 @@
     },
     "node_modules/ganache/node_modules/brorand": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/ganache/node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
       "funding": [
         {
@@ -8533,6 +8973,8 @@
     },
     "node_modules/ganache/node_modules/catering": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.0.tgz",
+      "integrity": "sha512-M5imwzQn6y+ODBfgi+cfgZv2hIUI6oYU/0f35Mdb1ujGeqeoI5tOnl9Q13DTH7LW+7er+NYq8stNOKZD/Z3U/A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8545,6 +8987,8 @@
     },
     "node_modules/ganache/node_modules/elliptic": {
       "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8560,6 +9004,8 @@
     },
     "node_modules/ganache/node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -8577,6 +9023,8 @@
     },
     "node_modules/ganache/node_modules/hash.js": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8587,6 +9035,8 @@
     },
     "node_modules/ganache/node_modules/hmac-drbg": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8598,6 +9048,8 @@
     },
     "node_modules/ganache/node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true,
       "funding": [
         {
@@ -8618,12 +9070,16 @@
     },
     "node_modules/ganache/node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ganache/node_modules/is-buffer": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true,
       "funding": [
         {
@@ -8647,6 +9103,8 @@
     },
     "node_modules/ganache/node_modules/keccak": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
       "dev": true,
       "hasInstallScript": true,
       "inBundle": true,
@@ -8662,6 +9120,8 @@
     },
     "node_modules/ganache/node_modules/level-concat-iterator": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8674,6 +9134,8 @@
     },
     "node_modules/ganache/node_modules/level-supports": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8695,6 +9157,8 @@
     },
     "node_modules/ganache/node_modules/leveldown": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
+      "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
       "dev": true,
       "hasInstallScript": true,
       "inBundle": true,
@@ -8715,12 +9179,16 @@
     },
     "node_modules/ganache/node_modules/minimalistic-assert": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ganache/node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -8735,18 +9203,24 @@
     },
     "node_modules/ganache/node_modules/napi-macros": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/ganache/node_modules/node-addon-api": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/ganache/node_modules/node-gyp-build": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8758,6 +9232,8 @@
     },
     "node_modules/ganache/node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -8778,12 +9254,16 @@
     },
     "node_modules/ganache/node_modules/queue-tick": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+      "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/ganache/node_modules/readable-stream": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8798,6 +9278,8 @@
     },
     "node_modules/ganache/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -8818,6 +9300,8 @@
     },
     "node_modules/ganache/node_modules/secp256k1": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "dev": true,
       "hasInstallScript": true,
       "inBundle": true,
@@ -8833,6 +9317,8 @@
     },
     "node_modules/ganache/node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8855,6 +9341,8 @@
     },
     "node_modules/ganache/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -9817,6 +10305,17 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/hapi-pino": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.5.0.tgz",
+      "integrity": "sha512-p0phuePalD8965r6mboCBLIMWRO2vQAx+VSnXhTKxnF/4Sf+dk8Uze7109w9QfhlvGMqvBTEF6SxGStObBB/Lw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "abstract-logging": "^2.0.0",
+        "pino": "^6.0.0",
+        "pino-pretty": "^4.0.0"
+      }
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "license": "ISC",
@@ -10708,6 +11207,56 @@
         "retimer": "^3.0.0"
       }
     },
+    "node_modules/ipfs-http-gateway": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-gateway/-/ipfs-http-gateway-0.9.3.tgz",
+      "integrity": "sha512-69eQ7EjSNbO3mnlQkUxJxVSaJ17wswDmUA6l/0sB7rEPD5E+reXeJbO7RCUT4zvB5YPgDgudsujyzYK4QJud3A==",
+      "dependencies": {
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/hapi": "^20.0.0",
+        "debug": "^4.1.1",
+        "hapi-pino": "^8.3.0",
+        "ipfs-core-types": "^0.10.3",
+        "ipfs-http-response": "^2.0.3",
+        "is-ipfs": "^6.0.1",
+        "it-last": "^1.0.4",
+        "it-to-stream": "^1.0.0",
+        "joi": "^17.2.1",
+        "multiformats": "^9.5.1",
+        "uint8arrays": "^3.0.0",
+        "uri-to-multiaddr": "^6.0.0"
+      }
+    },
+    "node_modules/ipfs-http-gateway/node_modules/ipfs-core-types": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.10.3.tgz",
+      "integrity": "sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==",
+      "dependencies": {
+        "@ipld/dag-pb": "^2.1.3",
+        "interface-datastore": "^6.0.2",
+        "ipfs-unixfs": "^6.0.3",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.5.1"
+      }
+    },
+    "node_modules/ipfs-http-response": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-2.0.3.tgz",
+      "integrity": "sha512-4VViBSJTySPih9KeDXmuSnPxcO1QNAmweLDIQOBm7s7nY7esdLs8EOHBbAIr3p0ZkRqnGvujtfT5OVfE/5KECQ==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "ejs": "^3.1.6",
+        "file-type": "^16.0.0",
+        "filesize": "^8.0.0",
+        "it-buffer": "^0.1.1",
+        "it-concat": "^2.0.0",
+        "it-reader": "^3.0.0",
+        "it-to-stream": "^1.0.0",
+        "mime-types": "^2.1.30",
+        "p-try-each": "^1.0.1"
+      }
+    },
     "node_modules/ipfs-repo": {
       "version": "13.0.7",
       "dev": true,
@@ -11266,7 +11815,6 @@
     },
     "node_modules/is-ipfs": {
       "version": "6.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iso-url": "^1.1.3",
@@ -11536,7 +12084,6 @@
     },
     "node_modules/it-buffer": {
       "version": "0.1.3",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "bl": "^5.0.0",
@@ -11545,7 +12092,6 @@
     },
     "node_modules/it-concat": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^5.0.0"
@@ -11671,7 +12217,6 @@
     },
     "node_modules/it-reader": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^5.0.0"
@@ -11732,6 +12277,115 @@
         "event-iterator": "^2.0.0",
         "iso-url": "^1.1.2",
         "ws": "^7.3.1"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jake/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jake/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.8.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
+      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/js-sdsl": {
@@ -12052,6 +12706,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -12714,7 +13376,6 @@
     },
     "node_modules/mafmt": {
       "version": "10.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "multiaddr": "^10.0.0"
@@ -13965,6 +14626,14 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -15262,6 +15931,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-try-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/p-try-each/-/p-try-each-1.0.1.tgz",
+      "integrity": "sha512-WyUjRAvK4CG9DUW21ZsNYcBj6guN7pgZAOFR8mUtyNXyPC5WUo3L48nxI5TsGEZ+VJhZXzyeH/Sxi2lxYcPp3A=="
+    },
     "node_modules/p-waterfall": {
       "version": "1.0.0",
       "dev": true,
@@ -15477,6 +16151,18 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/peer-id": {
       "version": "0.15.4",
       "dev": true,
@@ -15572,6 +16258,122 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pino": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
+      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
+      "dependencies": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.8.0.tgz",
+      "integrity": "sha512-mhQfHG4rw5ZFpWL44m0Utjo4GC2+HMfdNvxyA8lLw0sIqn6fCf7uQe6dPckUcW/obly+OQHD7B/MTso6LNizYw==",
+      "dependencies": {
+        "@hapi/bourne": "^2.0.0",
+        "args": "^5.0.1",
+        "chalk": "^4.0.0",
+        "dateformat": "^4.5.1",
+        "fast-safe-stringify": "^2.0.7",
+        "jmespath": "^0.15.0",
+        "joycon": "^2.2.5",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/pino-pretty/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
     },
     "node_modules/pkg-dir": {
       "version": "3.0.0",
@@ -15711,6 +16513,11 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -16003,6 +16810,11 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "dev": true,
@@ -16250,6 +17062,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/readdir-scoped-modules": {
@@ -16543,6 +17370,11 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -17419,6 +18251,15 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "4.2.0",
       "dev": true,
@@ -17532,7 +18373,6 @@
     },
     "node_modules/split2": {
       "version": "3.2.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "readable-stream": "^3.0.0"
@@ -17856,7 +18696,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17879,6 +18718,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/superagent": {
@@ -18351,6 +19206,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tough-cookie": {
@@ -18899,6 +19770,38 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-to-multiaddr": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-6.0.0.tgz",
+      "integrity": "sha512-vGHLrfvWQwoMv1YiHWU5ZOK2M/TV0qheXIanuW6jAL6VFD1vMK7xqL/zOxc32tKhlJgSt6vTJI4yALS+vFZKEA==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/uri-to-multiaddr",
+      "dependencies": {
+        "is-ip": "^3.1.0",
+        "multiaddr": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/uri-to-multiaddr/node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uri-to-multiaddr/node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/urix": {
@@ -27151,7 +28054,7 @@
         "@ethereumjs/evm": "^1.2.3",
         "@ethereumjs/statemanager": "^1.0.2",
         "@ethereumjs/util": "^8.0.3",
-        "@ethereumjs/vm": "^6.3.0",
+        "@ethereumjs/vm": "6.3.0",
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -28982,11 +29885,6 @@
       "engines": {
         "node": ">=14.16"
       }
-    },
-    "packages/lib-sourcify/node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/lib-sourcify/node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -37214,18 +38112,6 @@
         "node": ">=0.12"
       }
     },
-    "packages/lib-sourcify/node_modules/peek-readable": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "packages/lib-sourcify/node_modules/performance-now": {
       "version": "2.1.0",
       "license": "MIT"
@@ -38673,22 +39559,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "packages/lib-sourcify/node_modules/strtok3": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "packages/lib-sourcify/node_modules/stubs": {
@@ -44670,7 +45540,7 @@
         "@ethereumjs/evm": "^1.2.3",
         "@ethereumjs/statemanager": "^1.0.2",
         "@ethereumjs/util": "^8.0.3",
-        "@ethereumjs/vm": "^6.3.0",
+        "@ethereumjs/vm": "6.3.0",
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -50170,10 +51040,6 @@
             "defer-to-connect": "^2.0.1"
           }
         },
-        "@tokenizer/token": {
-          "version": "0.3.0",
-          "dev": true
-        },
         "@tootallnate/once": {
           "version": "1.1.2",
           "dev": true
@@ -55453,10 +56319,6 @@
             "sha.js": "^2.4.8"
           }
         },
-        "peek-readable": {
-          "version": "4.1.0",
-          "dev": true
-        },
         "performance-now": {
           "version": "2.1.0"
         },
@@ -56366,14 +57228,6 @@
               "version": "1.0.5",
               "dev": true
             }
-          }
-        },
-        "strtok3": {
-          "version": "6.3.0",
-          "dev": true,
-          "requires": {
-            "@tokenizer/token": "^0.3.0",
-            "peek-readable": "^4.1.0"
           }
         },
         "stubs": {
@@ -57808,6 +58662,281 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "@hapi/accept": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/ammo": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
+    "@hapi/call": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/catbox": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/content": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "requires": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "requires": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "@hapi/file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+    },
+    "@hapi/hapi": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.3.0.tgz",
+      "integrity": "sha512-zvPSRvaQyF3S6Nev9aiAzko2/hIFZmNSJNcs07qdVaVAvj8dGJSV4fVUuQSnufYJAGiSau+U5LxMLhx79se5WA==",
+      "requires": {
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.3",
+        "@hapi/subtext": "^7.1.0",
+        "@hapi/teamwork": "^5.1.0",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
+      }
+    },
+    "@hapi/heavy": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/iron": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "requires": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/mimos": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "@hapi/nigel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
+      }
+    },
+    "@hapi/pez": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.1.0.tgz",
+      "integrity": "sha512-YfB0btnkLB3lb6Ry/1KifnMPBm5ZPfaAHWFskzOMAgDgXgcBgA+zjpIynyEiBfWEz22DBT8o1e2tAaBdlt8zbw==",
+      "requires": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
+      }
+    },
+    "@hapi/podium": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/shot": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/somever": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "requires": {
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/statehood": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/subtext": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.1.0.tgz",
+      "integrity": "sha512-n94cU6hlvsNRIpXaROzBNEJGwxC+HA69q769pChzej84On8vsU14guHDub7Pphr/pqn5b93zV3IkMPDU5AUiXA==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.1.0",
+        "@hapi/wreck": "17.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/vise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
+      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@humanwhocodes/config-array": {
@@ -59481,6 +60610,24 @@
     "@protobufjs/utf8": {
       "version": "1.1.0"
     },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sindresorhus/is": {
       "version": "4.6.0"
     },
@@ -59603,6 +60750,11 @@
       "requires": {
         "defer-to-connect": "^2.0.1"
       }
+    },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@types/bn.js": {
       "version": "5.1.1",
@@ -59958,6 +61110,11 @@
         "queue-microtask": "^1.2.3"
       }
     },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "accepts": {
       "version": "1.3.8",
       "requires": {
@@ -60101,6 +61258,24 @@
       "version": "2.0.1",
       "dev": true
     },
+    "args": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
+      "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        }
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "dev": true
@@ -60217,6 +61392,11 @@
       "version": "2.0.0",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "available-typed-arrays": {
       "version": "1.0.5"
     },
@@ -60292,7 +61472,6 @@
     },
     "bl": {
       "version": "5.1.0",
-      "dev": true,
       "requires": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -61889,6 +63068,14 @@
     "ee-first": {
       "version": "1.1.1"
     },
+    "ejs": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
     "electron-fetch": {
       "version": "1.9.1",
       "requires": {
@@ -62763,6 +63950,16 @@
       "version": "2.0.6",
       "dev": true
     },
+    "fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "fast-write-atomic": {
       "version": "0.2.1",
       "dev": true
@@ -62795,9 +63992,50 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "dev": true
+    },
+    "filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "filesize": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
+      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -62861,6 +64099,11 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "3.2.7",
@@ -63087,6 +64330,8 @@
       "dependencies": {
         "@trufflesuite/bigint-buffer": {
           "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz",
+          "integrity": "sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63095,6 +64340,8 @@
           "dependencies": {
             "node-gyp-build": {
               "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+              "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
               "bundled": true,
               "dev": true
             }
@@ -63140,6 +64387,8 @@
         },
         "abstract-leveldown": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+          "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63167,16 +64416,22 @@
         },
         "base64-js": {
           "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
           "bundled": true,
           "dev": true
         },
         "brorand": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
           "bundled": true,
           "dev": true
         },
         "buffer": {
           "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63194,6 +64449,8 @@
         },
         "catering": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.0.tgz",
+          "integrity": "sha512-M5imwzQn6y+ODBfgi+cfgZv2hIUI6oYU/0f35Mdb1ujGeqeoI5tOnl9Q13DTH7LW+7er+NYq8stNOKZD/Z3U/A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63202,6 +64459,8 @@
         },
         "elliptic": {
           "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63216,6 +64475,8 @@
           "dependencies": {
             "bn.js": {
               "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
               "bundled": true,
               "dev": true
             }
@@ -63227,6 +64488,8 @@
         },
         "hash.js": {
           "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63236,6 +64499,8 @@
         },
         "hmac-drbg": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63246,21 +64511,29 @@
         },
         "ieee754": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
           "bundled": true,
           "dev": true
         },
         "inherits": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true
         },
         "is-buffer": {
           "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
           "bundled": true,
           "dev": true
         },
         "keccak": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+          "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63271,6 +64544,8 @@
         },
         "level-concat-iterator": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+          "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63279,6 +64554,8 @@
         },
         "level-supports": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
           "bundled": true,
           "dev": true
         },
@@ -63292,6 +64569,8 @@
         },
         "leveldown": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
+          "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63306,11 +64585,15 @@
         },
         "minimalistic-assert": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
           "bundled": true,
           "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
           "bundled": true,
           "dev": true
         },
@@ -63320,31 +64603,43 @@
         },
         "napi-macros": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+          "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
           "bundled": true,
           "dev": true
         },
         "node-addon-api": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
           "bundled": true,
           "dev": true
         },
         "node-gyp-build": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
           "bundled": true,
           "dev": true
         },
         "queue-microtask": {
           "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+          "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
           "bundled": true,
           "dev": true
         },
         "queue-tick": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+          "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
           "bundled": true,
           "dev": true
         },
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63355,11 +64650,15 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "bundled": true,
           "dev": true
         },
         "secp256k1": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+          "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63370,6 +64669,8 @@
         },
         "string_decoder": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -63386,6 +64687,8 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true
         }
@@ -64025,6 +65328,17 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
+      }
+    },
+    "hapi-pino": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.5.0.tgz",
+      "integrity": "sha512-p0phuePalD8965r6mboCBLIMWRO2vQAx+VSnXhTKxnF/4Sf+dk8Uze7109w9QfhlvGMqvBTEF6SxGStObBB/Lw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "abstract-logging": "^2.0.0",
+        "pino": "^6.0.0",
+        "pino-pretty": "^4.0.0"
       }
     },
     "har-schema": {
@@ -64695,6 +66009,58 @@
         }
       }
     },
+    "ipfs-http-gateway": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-gateway/-/ipfs-http-gateway-0.9.3.tgz",
+      "integrity": "sha512-69eQ7EjSNbO3mnlQkUxJxVSaJ17wswDmUA6l/0sB7rEPD5E+reXeJbO7RCUT4zvB5YPgDgudsujyzYK4QJud3A==",
+      "requires": {
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/hapi": "^20.0.0",
+        "debug": "^4.1.1",
+        "hapi-pino": "^8.3.0",
+        "ipfs-core-types": "^0.10.3",
+        "ipfs-http-response": "^2.0.3",
+        "is-ipfs": "^6.0.1",
+        "it-last": "^1.0.4",
+        "it-to-stream": "^1.0.0",
+        "joi": "^17.2.1",
+        "multiformats": "^9.5.1",
+        "uint8arrays": "^3.0.0",
+        "uri-to-multiaddr": "^6.0.0"
+      },
+      "dependencies": {
+        "ipfs-core-types": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.10.3.tgz",
+          "integrity": "sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==",
+          "requires": {
+            "@ipld/dag-pb": "^2.1.3",
+            "interface-datastore": "^6.0.2",
+            "ipfs-unixfs": "^6.0.3",
+            "multiaddr": "^10.0.0",
+            "multiformats": "^9.5.1"
+          }
+        }
+      }
+    },
+    "ipfs-http-response": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-2.0.3.tgz",
+      "integrity": "sha512-4VViBSJTySPih9KeDXmuSnPxcO1QNAmweLDIQOBm7s7nY7esdLs8EOHBbAIr3p0ZkRqnGvujtfT5OVfE/5KECQ==",
+      "requires": {
+        "debug": "^4.3.1",
+        "ejs": "^3.1.6",
+        "file-type": "^16.0.0",
+        "filesize": "^8.0.0",
+        "it-buffer": "^0.1.1",
+        "it-concat": "^2.0.0",
+        "it-reader": "^3.0.0",
+        "it-to-stream": "^1.0.0",
+        "mime-types": "^2.1.30",
+        "p-try-each": "^1.0.1"
+      }
+    },
     "ipfs-repo": {
       "version": "13.0.7",
       "dev": true,
@@ -65067,7 +66433,6 @@
     },
     "is-ipfs": {
       "version": "6.0.2",
-      "dev": true,
       "requires": {
         "iso-url": "^1.1.3",
         "mafmt": "^10.0.0",
@@ -65224,7 +66589,6 @@
     },
     "it-buffer": {
       "version": "0.1.3",
-      "dev": true,
       "requires": {
         "bl": "^5.0.0",
         "buffer": "^6.0.3"
@@ -65232,7 +66596,6 @@
     },
     "it-concat": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "bl": "^5.0.0"
       }
@@ -65341,7 +66704,6 @@
     },
     "it-reader": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "bl": "^5.0.0"
       }
@@ -65396,6 +66758,84 @@
         "iso-url": "^1.1.2",
         "ws": "^7.3.1"
       }
+    },
+    "jake": {
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "requires": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
+    },
+    "joi": {
+      "version": "17.8.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
+      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "joycon": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
     },
     "js-sdsl": {
       "version": "4.2.0",
@@ -65616,6 +67056,11 @@
         "level-supports": "^2.0.1",
         "queue-microtask": "^1.2.3"
       }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="
     },
     "levn": {
       "version": "0.4.1",
@@ -66146,7 +67591,6 @@
     },
     "mafmt": {
       "version": "10.0.0",
-      "dev": true,
       "requires": {
         "multiaddr": "^10.0.0"
       }
@@ -66993,6 +68437,11 @@
           }
         }
       }
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
     },
     "ms": {
       "version": "2.1.2"
@@ -67851,6 +69300,11 @@
       "version": "2.2.0",
       "dev": true
     },
+    "p-try-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/p-try-each/-/p-try-each-1.0.1.tgz",
+      "integrity": "sha512-WyUjRAvK4CG9DUW21ZsNYcBj6guN7pgZAOFR8mUtyNXyPC5WUo3L48nxI5TsGEZ+VJhZXzyeH/Sxi2lxYcPp3A=="
+    },
     "p-waterfall": {
       "version": "1.0.0",
       "dev": true,
@@ -68012,6 +69466,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+    },
     "peer-id": {
       "version": "0.15.4",
       "dev": true,
@@ -68071,6 +69530,94 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
+    },
+    "pino": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
+      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
+      "requires": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      }
+    },
+    "pino-pretty": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.8.0.tgz",
+      "integrity": "sha512-mhQfHG4rw5ZFpWL44m0Utjo4GC2+HMfdNvxyA8lLw0sIqn6fCf7uQe6dPckUcW/obly+OQHD7B/MTso6LNizYw==",
+      "requires": {
+        "@hapi/bourne": "^2.0.0",
+        "args": "^5.0.1",
+        "chalk": "^4.0.0",
+        "dateformat": "^4.5.1",
+        "fast-safe-stringify": "^2.0.7",
+        "jmespath": "^0.15.0",
+        "joycon": "^2.2.5",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
     },
     "pkg-dir": {
       "version": "3.0.0",
@@ -68155,6 +69702,11 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "dev": true
+    },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -68361,6 +69913,11 @@
       "version": "1.2.3",
       "dev": true
     },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "quick-lru": {
       "version": "4.0.1",
       "dev": true
@@ -68533,6 +70090,14 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
       }
     },
     "readdir-scoped-modules": {
@@ -68720,6 +70285,11 @@
     "reusify": {
       "version": "1.0.4",
       "dev": true
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -69308,6 +70878,15 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
+    },
     "sort-keys": {
       "version": "4.2.0",
       "dev": true,
@@ -69390,7 +70969,6 @@
     },
     "split2": {
       "version": "3.2.2",
-      "dev": true,
       "requires": {
         "readable-stream": "^3.0.0"
       }
@@ -69608,8 +71186,7 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "strong-log-transformer": {
       "version": "2.1.0",
@@ -69618,6 +71195,15 @@
         "duplexer": "^0.1.1",
         "minimist": "^1.2.0",
         "through": "^2.3.4"
+      }
+    },
+    "strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
       }
     },
     "superagent": {
@@ -69947,6 +71533,15 @@
     },
     "toidentifier": {
       "version": "1.0.1"
+    },
+    "token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -70301,6 +71896,30 @@
       "version": "4.4.1",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "uri-to-multiaddr": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-6.0.0.tgz",
+      "integrity": "sha512-vGHLrfvWQwoMv1YiHWU5ZOK2M/TV0qheXIanuW6jAL6VFD1vMK7xqL/zOxc32tKhlJgSt6vTJI4yALS+vFZKEA==",
+      "requires": {
+        "is-ip": "^3.1.0",
+        "multiaddr": "^10.0.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+        },
+        "is-ip": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+          "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+          "requires": {
+            "ip-regex": "^4.0.0"
+          }
+        }
       }
     },
     "urix": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express-validator": "^6.6.1",
     "http-status-codes": "^2.1.4",
     "ipfs-http-client": "^56.0.3",
+    "ipfs-http-gateway": "0.9.3",
     "memorystore": "^1.6.7",
     "node-fetch": "2.6.6",
     "serve-index": "^1.9.1",

--- a/packages/lib-sourcify/src/lib/CheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/CheckedContract.ts
@@ -14,7 +14,6 @@ import { fetchWithTimeout } from './utils';
 
 // TODO: find a better place for these constants. Reminder: this sould work also in the browser
 const IPFS_PREFIX = 'dweb:/ipfs/';
-export const IPFS_GATEWAY = process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
 const FETCH_TIMEOUT = parseInt(process.env.FETCH_TIMEOUT || '') || 3000; // ms
 /**
  * Abstraction of a checked solidity contract. With metadata and source (solidity) files.
@@ -145,7 +144,7 @@ export class CheckedContract {
         for (const url of file.urls) {
           if (url.startsWith(IPFS_PREFIX)) {
             const ipfsCode = url.slice(IPFS_PREFIX.length);
-            const ipfsUrl = IPFS_GATEWAY + ipfsCode;
+            const ipfsUrl = getIpfsGateway() + ipfsCode;
             retrievedContent = await performFetch(ipfsUrl, hash, fileName);
             if (retrievedContent) {
               break;
@@ -316,4 +315,14 @@ function createJsonInputFromMetadata(
     contractPath,
     contractName,
   };
+}
+
+/**
+ * Because the gateway might change across tests, don't set it to a variable but look for env variable.
+ * Otherwise fall back to the default ipfs.io.
+ *
+ * This will likely moved to server or somewhere else. But keep it here for now.
+ */
+export function getIpfsGateway(): string {
+  return process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
 }

--- a/src/server/controllers/VerificationController.ts
+++ b/src/server/controllers/VerificationController.ts
@@ -9,7 +9,7 @@ import {
   PathContent,
   isEmpty,
   getBytecode,
-  IPFS_GATEWAY,
+  getIpfsGateway,
   performFetch,
   verifyCreate2,
 } from "@ethereum-sourcify/lib-sourcify";
@@ -263,7 +263,7 @@ export default class VerificationController
       );
     }
 
-    const ipfsUrl = `${IPFS_GATEWAY}${metadataIpfsCid}`;
+    const ipfsUrl = `${getIpfsGateway()}${metadataIpfsCid}`;
     const metadataFileName = "metadata.json";
     const retrievedMetadataText = await performFetch(ipfsUrl);
 

--- a/test/server.js
+++ b/test/server.js
@@ -328,7 +328,6 @@ describe("Server", function () {
         [accounts[0], accounts[0]]
       );
 
-      process.env.IPFS_GATEWAY = "https://ipfs.io/ipfs/";
       const res = await agent
         .post("/session/input-contract")
         .field("address", addressDeployed)

--- a/test/server.js
+++ b/test/server.js
@@ -3,7 +3,12 @@ process.env.TESTING = true;
 process.env.MOCK_REPOSITORY = "./dist/data/mock-repository";
 process.env.SOLC_REPO = "./dist/data/solc-repo";
 process.env.SOLJSON_REPO = "/dist/data/soljson-repo";
+// ipfs-http-gateway runs on port 9090
+process.env.IPFS_GATEWAY = "http://localhost:9090/ipfs/";
+process.env.FETCH_TIMEOUT = 15000; // instantiated http-gateway takes a little longer
 
+const IPFS = require("ipfs-core");
+const { HttpGateway } = require("ipfs-http-gateway");
 const ganache = require("ganache");
 const chai = require("chai");
 const chaiHttp = require("chai-http");
@@ -20,7 +25,6 @@ const GANACHE_PORT = 8545;
 const StatusCodes = require("http-status-codes").StatusCodes;
 const { waitSecs, callContractMethodWithTx } = require("./helpers/helpers");
 const { deployFromAbiAndBytecode } = require("./helpers/helpers");
-
 chai.use(chaiHttp);
 
 const binaryParser = function (res, cb) {
@@ -59,6 +63,10 @@ describe("Server", function () {
 
   before(async () => {
     await ganacheServer.listen(GANACHE_PORT);
+    const ipfs = await IPFS.create();
+    const httpGateway = new HttpGateway(ipfs);
+    await httpGateway.start();
+
     console.log("Started ganache local server on port " + GANACHE_PORT);
 
     localWeb3Provider = new Web3(`http://localhost:${GANACHE_PORT}`);
@@ -1486,7 +1494,7 @@ describe("Server", function () {
         "test",
         "sources",
         "truffle",
-        "truffle-example.zip",
+        "truffle-example.zip"
       );
       const zippedTruffleBuffer = fs.readFileSync(zippedTrufflePath);
       chai
@@ -1550,7 +1558,7 @@ describe("Server", function () {
           "test",
           "sources",
           "truffle",
-          "truffle-example.zip",
+          "truffle-example.zip"
         );
         const zippedTruffleBuffer = fs.readFileSync(zippedTrufflePath);
         chai


### PR DESCRIPTION
Since the tests are sometimes failing on CircleCI because of being rate limited by the public ipfs.io gateway, we instead spin up a local nodejs ipfs gw in tests.