### PR TITLE
Default SolcJs compiler

### DIFF
--- a/packages/lib-sourcify/src/lib/solidityCompiler.ts
+++ b/packages/lib-sourcify/src/lib/solidityCompiler.ts
@@ -48,31 +48,29 @@ export async function useCompiler(version: string, solcJsonInput: JsonInput) {
     solcPath = await getSolcExecutable(solcPlatform, version);
   }
   if (solcPath) {
-    if (solcPath) {
-      const shellOutputBuffer = spawnSync(solcPath, ['--standard-json'], {
-        input: inputStringified,
-        maxBuffer: 1000 * 1000 * 10,
-      });
+    const shellOutputBuffer = spawnSync(solcPath, ['--standard-json'], {
+      input: inputStringified,
+      maxBuffer: 1000 * 1000 * 10,
+    });
 
-      // Handle errors.
-      let error: false | Error = false;
-      if (shellOutputBuffer.error) {
-        const typedError: NodeJS.ErrnoException = shellOutputBuffer.error;
-        // Handle compilation output size > stdout buffer
-        if (typedError.code === 'ENOBUFS') {
-          error = new Error('Compilation output size too large');
-        }
-        error = new Error('Compilation Error');
+    // Handle errors.
+    let error: false | Error = false;
+    if (shellOutputBuffer.error) {
+      const typedError: NodeJS.ErrnoException = shellOutputBuffer.error;
+      // Handle compilation output size > stdout buffer
+      if (typedError.code === 'ENOBUFS') {
+        error = new Error('Compilation output size too large');
       }
-      if (!shellOutputBuffer.stdout) {
-        error = new Error(RECOMPILATION_ERR_MSG);
-      }
-      if (error) {
-        console.error(error);
-        throw error;
-      }
-      compiled = shellOutputBuffer.stdout.toString();
+      error = new Error('Compilation Error');
     }
+    if (!shellOutputBuffer.stdout) {
+      error = new Error(RECOMPILATION_ERR_MSG);
+    }
+    if (error) {
+      console.error(error);
+      throw error;
+    }
+    compiled = shellOutputBuffer.stdout.toString();
   } else {
     const soljson = await getSolcJs(version);
     if (soljson) {
@@ -137,6 +135,11 @@ function validateSolcPath(solcPath: string): boolean {
   return false;
 }
 
+/**
+ * Fetches a solc binary from GitHub and saves it to the given path.
+ *
+ * If platform is "bin", it will download the solc-js binary.
+ */
 async function fetchAndSaveSolc(
   platform: string,
   solcPath: string,

--- a/packages/lib-sourcify/src/lib/solidityCompiler.ts
+++ b/packages/lib-sourcify/src/lib/solidityCompiler.ts
@@ -103,7 +103,7 @@ export async function useCompiler(version: string, solcJsonInput: JsonInput) {
 }
 
 // TODO: Handle where and how solc is saved
-async function getSolcExecutable(
+export async function getSolcExecutable(
   platform: string,
   version: string
 ): Promise<string | null> {

--- a/packages/lib-sourcify/test/functions.spec.ts
+++ b/packages/lib-sourcify/test/functions.spec.ts
@@ -75,7 +75,7 @@ describe('Verify Solidity Compiler', () => {
       });
       expect(compiledJSON?.contracts?.['test.sol']?.C).to.not.equals(undefined);
     } catch (e: any) {
-      expect.fail('Compiler error:');
+      expect.fail(e.message);
     } finally {
       Object.defineProperty(process, 'platform', {
         value: realPlatform,

--- a/packages/lib-sourcify/test/functions.spec.ts
+++ b/packages/lib-sourcify/test/functions.spec.ts
@@ -24,7 +24,7 @@ describe('Verify Solidity Compiler', () => {
     await getSolcJs('0.8.17+commit.8df45f5f');
   });
   it('Should fetch latest solc from github', async () => {
-    await getSolcExecutable('0.8.9+commit.e5eed63a');
+    await getSolcExecutable('linux-amd64', '0.8.9+commit.e5eed63a');
   });
   it('Should return a compiler error', async () => {
     try {

--- a/packages/lib-sourcify/test/functions.spec.ts
+++ b/packages/lib-sourcify/test/functions.spec.ts
@@ -29,6 +29,30 @@ describe('Verify Solidity Compiler', () => {
         await getSolcExecutable('linux-amd64', '0.8.9+commit.e5eed63a')
       ).not.equals(null);
     });
+    it('Should compile with solc', async () => {
+      try {
+        const compiledJSON = await useCompiler('0.8.9+commit.e5eed63a', {
+          language: 'Solidity',
+          sources: {
+            'test.sol': {
+              content: 'contract C { function f() public  {} }',
+            },
+          },
+          settings: {
+            outputSelection: {
+              '*': {
+                '*': ['*'],
+              },
+            },
+          },
+        });
+        expect(compiledJSON?.contracts?.['test.sol']?.C).to.not.equals(
+          undefined
+        );
+      } catch (e: any) {
+        expect.fail(e.message);
+      }
+    });
   }
   it('Should return a compiler error', async () => {
     try {

--- a/packages/lib-sourcify/test/functions.spec.ts
+++ b/packages/lib-sourcify/test/functions.spec.ts
@@ -18,17 +18,20 @@ import { Metadata, MissingSources } from '../src/lib/types';
 
 describe('Verify Solidity Compiler', () => {
   it('Should fetch latest SolcJS compiler', async () => {
-    await getSolcJs();
+    expect(await getSolcJs()).not.equals(null);
   });
   it('Should fetch SolcJS compiler passing only version', async () => {
-    await getSolcJs('0.8.17+commit.8df45f5f');
+    expect(await getSolcJs('0.8.17+commit.8df45f5f')).not.equals(false);
   });
-  it('Should fetch latest solc from github', async () => {
-    await getSolcExecutable('linux-amd64', '0.8.9+commit.e5eed63a');
-  });
+  if (process.platform === 'linux') {
+    it('Should fetch latest solc from github', async () => {
+      expect(
+        await getSolcExecutable('linux-amd64', '0.8.9+commit.e5eed63a')
+      ).not.equals(null);
+    });
+  }
   it('Should return a compiler error', async () => {
     try {
-      process.env.SOLC_REPO = '/tmp/solc-repo-' + Date.now();
       await useCompiler('0.8.9+commit.e5eed63a', {
         language: 'Solidity',
         sources: {
@@ -44,10 +47,41 @@ describe('Verify Solidity Compiler', () => {
           },
         },
       });
-    } catch (e) {
-      //
+    } catch (e: any) {
+      expect(e.message.startsWith('Compiler error:')).to.be.true;
     }
-    delete process.env.SOLC_REPO;
+  });
+  it('Should compile with solcjs', async () => {
+    const realPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'not existing platform',
+      writable: false,
+    });
+    try {
+      const compiledJSON = await useCompiler('0.8.9+commit.e5eed63a', {
+        language: 'Solidity',
+        sources: {
+          'test.sol': {
+            content: 'contract C { function f() public  {} }',
+          },
+        },
+        settings: {
+          outputSelection: {
+            '*': {
+              '*': ['*'],
+            },
+          },
+        },
+      });
+      expect(compiledJSON?.contracts?.['test.sol']?.C).to.not.equals(undefined);
+    } catch (e: any) {
+      expect.fail('Compiler error:');
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: realPlatform,
+        writable: false,
+      });
+    }
   });
 });
 


### PR DESCRIPTION
- [x] fix #954 force solcjs to use the setupMethods api
  * download the solcjs binary like the amd one
  * use the downloaded binary through setupMethods
  * check existing binaries before downloading new one
- [x] implement #955 