### PR TITLE
use etherscan API instead of scraping the txHash

### DIFF
--- a/src/server/services/VerificationService-util.ts
+++ b/src/server/services/VerificationService-util.ts
@@ -28,6 +28,13 @@ export const getCreatorTx = async (
     if (creatorTx) return creatorTx;
   }
 
+  // Chains using Etherscan API
+  if (sourcifyChain.chainId == 1) {
+    const response = await fetchFromApi(contractFetchAddressFilled);
+    if (response?.result?.[0]?.txHash)
+      return response?.result?.[0]?.txHash as string;
+  }
+
   // Telos
   if (sourcifyChain.chainId == 40 || sourcifyChain.chainId == 41) {
     const response = await fetchFromApi(contractFetchAddressFilled);

--- a/src/server/services/VerificationService-util.ts
+++ b/src/server/services/VerificationService-util.ts
@@ -29,7 +29,17 @@ export const getCreatorTx = async (
   }
 
   // Chains using Etherscan API
-  if (sourcifyChain.chainId == 1) {
+  if (
+    sourcifyChain.chainId == 1 ||
+    sourcifyChain.chainId == 5 ||
+    sourcifyChain.chainId == 11155111 ||
+    sourcifyChain.chainId == 56 ||
+    sourcifyChain.chainId == 137 ||
+    sourcifyChain.chainId == 42161 ||
+    sourcifyChain.chainId == 43114 ||
+    sourcifyChain.chainId == 10 ||
+    sourcifyChain.chainId == 84531
+  ) {
     const response = await fetchFromApi(contractFetchAddressFilled);
     if (response?.result?.[0]?.txHash)
       return response?.result?.[0]?.txHash as string;

--- a/src/sourcify-chains.ts
+++ b/src/sourcify-chains.ts
@@ -8,6 +8,7 @@ import {
   SourcifyChainExtension,
   Chain,
 } from "@ethereum-sourcify/lib-sourcify";
+import config from "./config";
 const allChains = chainsRaw as Chain[];
 
 dotenv.config({
@@ -16,6 +17,7 @@ dotenv.config({
 
 const ETHERSCAN_REGEX = /at txn.*href='\/tx\/(0x.*?)'/.source; // save as string to be able to return the txRegex in /chains response. If stored as RegExp returns {}
 const ETHERSCAN_SUFFIX = "address/${ADDRESS}";
+const ETHERSCAN_API_SUFFIX = `api?module=contract&action=getcontractcreation&contractaddresses=\${ADDRESS}&apikey=${config.server.etherscanAPIKey}`;
 const BLOCKSSCAN_SUFFIX = "api/accounts/${ADDRESS}";
 const BLOCKSCOUT_REGEX =
   'transaction_hash_link" href="${BLOCKSCOUT_PREFIX}/tx/(.*?)"';
@@ -114,9 +116,8 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
     // Ethereum Mainnet
     supported: true,
     monitored: true,
-    contractFetchAddress: "https://etherscan.io/" + ETHERSCAN_SUFFIX,
+    contractFetchAddress: "https://api.etherscan.io/" + ETHERSCAN_API_SUFFIX,
     rpc: buildAlchemyAndCustomRpcURLs("mainnet", "eth", true),
-    txRegex: ETHERSCAN_REGEX,
   },
   "4": {
     // Ethereum Rinkeby Testnet

--- a/src/sourcify-chains.ts
+++ b/src/sourcify-chains.ts
@@ -131,9 +131,9 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
     // Ethereum Goerli Testnet
     supported: true,
     monitored: true,
-    contractFetchAddress: "https://goerli.etherscan.io/" + ETHERSCAN_SUFFIX,
+    contractFetchAddress:
+      "https://api-goerli.etherscan.io/" + ETHERSCAN_API_SUFFIX,
     rpc: buildAlchemyAndCustomRpcURLs("goerli", "eth", true),
-    txRegex: ETHERSCAN_REGEX,
   },
   "11155111": {
     // Ethereum Sepolia Testnet
@@ -142,8 +142,8 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
     rpc: buildAlchemyAndCustomRpcURLs("sepolia", "eth", true).concat(
       "https://rpc.sepolia.org"
     ),
-    contractFetchAddress: "https://sepolia.etherscan.io/" + ETHERSCAN_SUFFIX,
-    txRegex: ETHERSCAN_REGEX,
+    contractFetchAddress:
+      "https://api-sepolia.etherscan.io/" + ETHERSCAN_API_SUFFIX,
   },
   "51": {
     supported: true,
@@ -153,8 +153,7 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
   "56": {
     supported: true,
     monitored: false,
-    contractFetchAddress: "https://bscscan.com/" + ETHERSCAN_SUFFIX,
-    txRegex: ETHERSCAN_REGEX,
+    contractFetchAddress: "https://api.bscscan.com/" + ETHERSCAN_API_SUFFIX,
   },
   "77": {
     supported: true,
@@ -198,9 +197,8 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
   "137": {
     supported: true,
     monitored: true,
-    contractFetchAddress: "https://polygonscan.com/" + ETHERSCAN_SUFFIX,
+    contractFetchAddress: "https://api.polygonscan.com/" + ETHERSCAN_API_SUFFIX,
     rpc: buildAlchemyAndCustomRpcURLs("mainnet", "polygon"),
-    txRegex: ETHERSCAN_REGEX,
   },
   "534": {
     supported: true,
@@ -240,8 +238,7 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
     // Arbitrum Mainnet
     supported: true,
     monitored: true,
-    contractFetchAddress: "https://arbiscan.io/" + ETHERSCAN_SUFFIX,
-    txRegex: ETHERSCAN_REGEX,
+    contractFetchAddress: "https://api.arbiscan.io/" + ETHERSCAN_API_SUFFIX,
     rpc: buildAlchemyAndCustomRpcURLs("mainnet", "arb"),
   },
   "421613": {
@@ -262,8 +259,7 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
   "43114": {
     supported: true,
     monitored: false,
-    contractFetchAddress: "https://snowtrace.io/" + ETHERSCAN_SUFFIX,
-    txRegex: ETHERSCAN_REGEX,
+    contractFetchAddress: "https://api.snowtrace.io/" + ETHERSCAN_API_SUFFIX,
   },
   "57": {
     supported: true,
@@ -311,8 +307,8 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
   "10": {
     supported: true,
     monitored: true,
-    contractFetchAddress: "https://optimistic.etherscan.io/" + ETHERSCAN_SUFFIX,
-    txRegex: ETHERSCAN_REGEX,
+    contractFetchAddress:
+      "https://api-optimistic.etherscan.io/" + ETHERSCAN_API_SUFFIX,
     rpc: buildAlchemyAndCustomRpcURLs("mainnet", "opt"),
   },
   "420": {
@@ -688,8 +684,8 @@ const sourcifyChainsExtensions: SourcifyChainsExtensionsObject = {
     // Base Goerli Testnet
     supported: true,
     monitored: true,
-    contractFetchAddress: "https://goerli.basescan.org/" + ETHERSCAN_SUFFIX,
-    txRegex: ETHERSCAN_REGEX,
+    contractFetchAddress:
+      "https://api-goerli.basescan.org/" + ETHERSCAN_API_SUFFIX,
   },
 };
 


### PR DESCRIPTION
Fixes #941
- [x] Use the new api for mainnet
- [x] Check which other etherscan instances support the new api and add support
  - [x] Goerli https://api-goerli.etherscan.io
  - [x] Sepolia https://api-sepolia.etherscan.io
  - [x] BNB Smart Chain https://api.bscscan.com/
  - [x] ~BNB Testnet~
  - [x] Polygon https://api.polygonscan.com/
  - [x] ~Polygon Mumbai Testnet~
  - [x] Arbitrum https://api.arbiscan.io/
  - [x] ~Snowtrace Testnet~
  - [x] Snowtrace https://api.snowtrace.io/
  - [x] Optimism https://api-optimistic.etherscan.io
  - [x] Base Goerli Testnet https://api-goerli.basescan.org/