### PR TITLE
Verification with Standard JSON Input

### DIFF
--- a/packages/lib-sourcify/src/lib/solidityCompiler.ts
+++ b/packages/lib-sourcify/src/lib/solidityCompiler.ts
@@ -104,6 +104,10 @@ export async function getAllMetadataAndSourcesFromSolcJson(
   solcJson: JsonInput,
   compilerVersion: string
 ): Promise<PathBuffer[]> {
+  if (solcJson.language !== 'Solidity')
+    throw new Error(
+      'Only Solidity is supported, the json has language: ' + solcJson.language
+    );
   const outputSelection = {
     '*': {
       '*': ['metadata'],
@@ -117,6 +121,8 @@ export async function getAllMetadataAndSourcesFromSolcJson(
   solcJson.settings.outputSelection = outputSelection;
   const compiled = await useCompiler(compilerVersion, solcJson);
   const metadataAndSources: PathBuffer[] = [];
+  if (!compiled.contracts)
+    throw new Error('No contracts found in the compiled json output');
   for (const contractPath in compiled.contracts) {
     for (const contract in compiled.contracts[contractPath]) {
       const metadata = compiled.contracts[contractPath][contract].metadata;

--- a/packages/lib-sourcify/src/lib/solidityCompiler.ts
+++ b/packages/lib-sourcify/src/lib/solidityCompiler.ts
@@ -4,8 +4,7 @@ import fs from 'fs';
 import { spawnSync } from 'child_process';
 import { fetchWithTimeout } from './utils';
 import { StatusCodes } from 'http-status-codes';
-import { JsonInput } from './types';
-import { PathContent } from './types';
+import { JsonInput, PathBuffer } from './types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const solc = require('solc');
 
@@ -104,7 +103,7 @@ export async function useCompiler(version: string, solcJsonInput: JsonInput) {
 export async function getAllMetadataAndSourcesFromSolcJson(
   solcJson: JsonInput,
   compilerVersion: string
-): Promise<PathContent[]> {
+): Promise<PathBuffer[]> {
   const outputSelection = {
     '*': {
       '*': ['metadata'],
@@ -117,18 +116,18 @@ export async function getAllMetadataAndSourcesFromSolcJson(
   }
   solcJson.settings.outputSelection = outputSelection;
   const compiled = await useCompiler(compilerVersion, solcJson);
-  const metadataAndSources: PathContent[] = [];
+  const metadataAndSources: PathBuffer[] = [];
   for (const contractPath in compiled.contracts) {
     for (const contract in compiled.contracts[contractPath]) {
       const metadata = compiled.contracts[contractPath][contract].metadata;
       const metadataPath = `${contractPath}-metadata.json`;
       metadataAndSources.push({
         path: metadataPath,
-        content: btoa(metadata), //TODO: Don't use btoa. This is there because PathContent requires a base64 encoded strings.
+        buffer: Buffer.from(metadata),
       });
       metadataAndSources.push({
         path: `${contractPath}`,
-        content: solcJson.sources[contractPath].content as string,
+        buffer: Buffer.from(solcJson.sources[contractPath].content as string),
       });
     }
   }

--- a/src/server/controllers/VerificationController.ts
+++ b/src/server/controllers/VerificationController.ts
@@ -225,9 +225,13 @@ export default class VerificationController
         solcJson,
         compilerVersion
       );
+      const metadataAndSourcesPathContents: PathContent[] =
+        metadataAndSources.map((pb) => {
+          return { path: pb.path, content: pb.buffer.toString(FILE_ENCODING) };
+        });
 
       const session = req.session;
-      const newFilesCount = saveFiles(metadataAndSources, session);
+      const newFilesCount = saveFiles(metadataAndSourcesPathContents, session);
       if (newFilesCount) {
         await checkContractsInSession(session);
       }

--- a/src/server/controllers/VerificationController.ts
+++ b/src/server/controllers/VerificationController.ts
@@ -696,27 +696,27 @@ export default class VerificationController
         .custom((chain, { req }) => (req.chain = checkChainId(chain))),
       body("compilerVersion").exists().bail(),
       body("contractName").exists().bail(),
-      body("contextVariables.msgSender").optional(),
-      body("contextVariables.abiEncodedConstructorArguments").optional(),
+      // body("contextVariables.msgSender").optional(),
+      // body("contextVariables.abiEncodedConstructorArguments").optional(),
       // Handle non-json multipart/form-data requests.
-      body("abiEncodedConstructorArguments")
-        .optional()
-        .custom(
-          (abiEncodedConstructorArguments, { req }) =>
-            (req.body.contextVariables = {
-              abiEncodedConstructorArguments,
-              ...req.body.contextVariables,
-            })
-        ),
-      body("msgSender")
-        .optional()
-        .custom(
-          (msgSender, { req }) =>
-            (req.body.contextVariables = {
-              msgSender,
-              ...req.body.contextVariables,
-            })
-        ),
+      // body("abiEncodedConstructorArguments")
+      //   .optional()
+      //   .custom(
+      //     (abiEncodedConstructorArguments, { req }) =>
+      //       (req.body.contextVariables = {
+      //         abiEncodedConstructorArguments,
+      //         ...req.body.contextVariables,
+      //       })
+      //   ),
+      // body("msgSender")
+      //   .optional()
+      //   .custom(
+      //     (msgSender, { req }) =>
+      //       (req.body.contextVariables = {
+      //         msgSender,
+      //         ...req.body.contextVariables,
+      //       })
+      //   ),
       body("creatorTxHash")
         .optional()
         .custom(

--- a/src/server/controllers/VerificationController.ts
+++ b/src/server/controllers/VerificationController.ts
@@ -735,7 +735,7 @@ export default class VerificationController
       .post(this.safeHandler(this.addInputFilesEndpoint));
 
     this.router
-      .route(["/input-files", "/session/input-solc-json"])
+      .route(["/session/input-solc-json"])
       .post(
         body("compilerVersion").exists().bail(),
         this.safeHandler(this.addInputSolcJsonEndpoint)

--- a/src/server/controllers/VerificationController.ts
+++ b/src/server/controllers/VerificationController.ts
@@ -206,12 +206,6 @@ export default class VerificationController
     const compilerVersion = req.body.compilerVersion;
 
     for (const inputFile of inputFiles) {
-      if (!inputFile.path.endsWith(".json")) {
-        throw new BadRequestError(
-          `File ${inputFile.path} is not a JSON file. Please upload a file with the .json extension.`
-        );
-      }
-
       let solcJson;
       try {
         solcJson = JSON.parse(inputFile.buffer.toString());

--- a/test/server.js
+++ b/test/server.js
@@ -753,6 +753,83 @@ describe("Server", function () {
       chai.expect(isExist, "Immutable references not saved").to.be.true;
     });
 
+    it("should return validation error for adding standard input JSON without a compiler version", async () => {
+      const address = await deployFromAbiAndBytecode(
+        localWeb3Provider,
+        artifact.abi, // Storage.sol
+        artifact.bytecode,
+        accounts[0]
+      );
+      const solcJsonPath = path.join(
+        "test",
+        "testcontracts",
+        "Storage",
+        "StorageJsonInput.json"
+      );
+      const solcJsonBuffer = fs.readFileSync(solcJsonPath);
+
+      const res = await chai
+        .request(server.app)
+        .post("/verify/solc-json")
+        .attach("files", solcJsonBuffer)
+        .field("address", address)
+        .field("chain", defaultContractChain);
+
+      assertValidationError(null, res, "compilerVersion");
+    });
+
+    it("should return validation error for adding standard input JSON without a contract name", async () => {
+      const address = await deployFromAbiAndBytecode(
+        localWeb3Provider,
+        artifact.abi, // Storage.sol
+        artifact.bytecode,
+        accounts[0]
+      );
+      const solcJsonPath = path.join(
+        "test",
+        "testcontracts",
+        "Storage",
+        "StorageJsonInput.json"
+      );
+      const solcJsonBuffer = fs.readFileSync(solcJsonPath);
+
+      const res = await chai
+        .request(server.app)
+        .post("/verify/solc-json")
+        .attach("files", solcJsonBuffer)
+        .field("address", address)
+        .field("chain", defaultContractChain)
+        .field("compilerVersion", "0.8.4+commit.c7e474f2");
+
+      assertValidationError(null, res, "contractName");
+    });
+
+    it("should verify a contract with Solidity standard input JSON", async () => {
+      const address = await deployFromAbiAndBytecode(
+        localWeb3Provider,
+        artifact.abi, // Storage.sol
+        artifact.bytecode,
+        accounts[0]
+      );
+      const solcJsonPath = path.join(
+        "test",
+        "testcontracts",
+        "Storage",
+        "StorageJsonInput.json"
+      );
+      const solcJsonBuffer = fs.readFileSync(solcJsonPath);
+
+      const res = await chai
+        .request(server.app)
+        .post("/verify/solc-json")
+        .attach("files", solcJsonBuffer)
+        .field("address", address)
+        .field("chain", defaultContractChain)
+        .field("compilerVersion", "0.8.4+commit.c7e474f2")
+        .field("contractName", "Storage");
+
+      assertVerification(null, res, null, address, defaultContractChain);
+    });
     describe("hardhat build-info file support", function () {
       this.timeout(EXTENDED_TIME);
       let address;

--- a/test/server.js
+++ b/test/server.js
@@ -773,7 +773,8 @@ describe("Server", function () {
         .post("/verify/solc-json")
         .attach("files", solcJsonBuffer)
         .field("address", address)
-        .field("chain", defaultContractChain);
+        .field("chain", defaultContractChain)
+        .field("contractName", "Storage");
 
       assertValidationError(null, res, "compilerVersion");
     });

--- a/test/testcontracts/Storage/StorageJsonInput.json
+++ b/test/testcontracts/Storage/StorageJsonInput.json
@@ -1,0 +1,32 @@
+{
+  "settings": {
+    "evmVersion": "istanbul",
+    "libraries": {
+      "": {}
+    },
+    "metadata": {
+      "bytecodeHash": "ipfs"
+    },
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    },
+    "remappings": [],
+    "outputSelection": {
+      "*": {
+        "Storage": [
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object",
+          "evm.deployedBytecode.immutableReferences",
+          "metadata"
+        ]
+      }
+    }
+  },
+  "sources": {
+    "project:/contracts/Storage.sol": {
+      "content": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retrieve() public view returns (uint256){\n        return number;\n    }\n}\n"
+    }
+  },
+  "language": "Solidity"
+}

--- a/ui/src/components/ChainSelect/index.tsx
+++ b/ui/src/components/ChainSelect/index.tsx
@@ -1,39 +1,12 @@
-import Fuse from "fuse.js";
 import React, { useContext } from "react";
-import SelectSearch, {
-  SelectSearchOption,
-  SelectSearchProps,
-} from "react-select-search";
 import { Context } from "../../Context";
 import "./style.css";
+import { fuzzySearch } from "../fuzzySearch";
+import SelectSearch, { SelectSearchProps } from "react-select-search";
 
-// Fix incorrect value field type of onChange. Should be string and not SelectedOptionValue
-type WithoutOnChange = Omit<SelectSearchProps, "onChange">; // Remove prop
-// Add correct onChange prop type
-type ModifiedSelectSearchProps = WithoutOnChange & {
-  onChange: (value: number) => void;
-};
-// Typecast. Don't cast with "SelectSearch as unknown as FC<Modified>" to not lose the types other than onChange.
-const CustomSelectSearch =
-  SelectSearch as React.FC<WithoutOnChange> as React.FC<ModifiedSelectSearchProps>;
-
-function fuzzySearch(options: SelectSearchOption[]) {
-  const fuse = new Fuse(options, {
-    keys: ["name", "groupName", "items.name"],
-    threshold: 0.6,
-  });
-  return (value: string) => {
-    if (!value.length) {
-      return options;
-    }
-    return fuse
-      .search(value)
-      .map((res: Fuse.FuseResult<SelectSearchOption>) => res.item);
-  };
-}
 type ChainSelectProps = {
   value: string | undefined;
-  handleChainIdChange: (chainId: number) => void;
+  handleChainIdChange: SelectSearchProps["onChange"];
   id?: string;
   availableChains?: number[];
 };
@@ -56,7 +29,7 @@ export default function ChainSelect({
   }
 
   return (
-    <CustomSelectSearch
+    <SelectSearch
       onChange={handleChainIdChange}
       value={value}
       options={filteredChains.map((chain) => ({

--- a/ui/src/components/GitHubBranchSelect/index.tsx
+++ b/ui/src/components/GitHubBranchSelect/index.tsx
@@ -1,39 +1,12 @@
-import Fuse from "fuse.js";
 import React, { useEffect, useState } from "react";
-import SelectSearch, {
-  SelectSearchOption,
-  SelectSearchProps,
-} from "react-select-search";
+import SelectSearch, { SelectSearchProps } from "react-select-search";
 import "./style.css";
+import { fuzzySearch } from "../fuzzySearch";
 
-// Fix incorrect value field type of onChange. Should be string and not SelectedOptionValue
-type WithoutOnChange = Omit<SelectSearchProps, "onChange">; // Remove prop
-// Add correct onChange prop type
-type ModifiedSelectSearchProps = WithoutOnChange & {
-  onChange: (value: string) => void;
-};
-// Typecast. Don't cast with "SelectSearch as unknown as FC<Modified>" to not lose the types other than onChange.
-const CustomSelectSearch =
-  SelectSearch as React.FC<WithoutOnChange> as React.FC<ModifiedSelectSearchProps>;
-
-function fuzzySearch(options: SelectSearchOption[]) {
-  const fuse = new Fuse(options, {
-    keys: ["name", "groupName", "items.name"],
-    threshold: 0.6,
-  });
-  return (value: string) => {
-    if (!value.length) {
-      return options;
-    }
-    return fuse
-      .search(value)
-      .map((res: Fuse.FuseResult<SelectSearchOption>) => res.item);
-  };
-}
 type GitHubBranchSelectProps = {
   repository: string;
   value: string | undefined;
-  handleBranchChange: (branch: string) => void;
+  handleBranchChange: SelectSearchProps["onChange"];
   handleBranchesLoaded: (error?: GitHubBranchSelectError) => void;
   id?: string;
 };
@@ -86,7 +59,7 @@ export default function GitHubBranchSelect({
   }, [repository, handleBranchesLoaded]);
 
   return (
-    <CustomSelectSearch
+    <SelectSearch
       onChange={handleBranchChange}
       value={value}
       options={branches.map((branch) => ({

--- a/ui/src/components/Toast/index.tsx
+++ b/ui/src/components/Toast/index.tsx
@@ -33,7 +33,7 @@ const Toast = ({ message, isShown, dismiss }: ToastProps) => {
           </button>
         </div>
       </div>
-      <div className="p-3 bg-red-400 rounded-b-lg break-words text-white">
+      <div className="p-3 bg-red-400 rounded-b-lg break-words text-white overflow-y-scroll max-h-96">
         {message}
       </div>
     </div>

--- a/ui/src/components/fuzzySearch.tsx
+++ b/ui/src/components/fuzzySearch.tsx
@@ -1,0 +1,17 @@
+import Fuse from "fuse.js";
+import { SelectSearchOption } from "react-select-search";
+
+export function fuzzySearch(options: SelectSearchOption[]) {
+  const fuse = new Fuse(options, {
+    keys: ["name", "groupName", "items.name"],
+    threshold: 0.6,
+  });
+  return (value: string) => {
+    if (!value.length) {
+      return options;
+    }
+    return fuse
+      .search(value)
+      .map((res: Fuse.FuseResult<SelectSearchOption>) => res.item);
+  };
+}

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -15,6 +15,7 @@ export const SOLIDITY_ETHEREUM_URL = `https://solidity.ethereum.org/2020/06/25/s
 // SESSION API
 export const SESSION_DATA_URL = `${SERVER_URL}/session/data`;
 export const ADD_FILES_URL = `${SERVER_URL}/session/input-files`;
+export const ADD_SOLC_JSON_URL = `${SERVER_URL}/session/input-solc-json`;
 export const ADD_FILES_FROM_CONTRACT_URL = `${SERVER_URL}/session/input-contract`;
 export const VERIFY_VALIDATED_URL = `${SERVER_URL}/session/verify-validated`;
 export const VERIFY_FROM_ETHERSCAN = `${SERVER_URL}/session/verify/etherscan`;

--- a/ui/src/pages/Verifier/CheckedContractsView/CheckedContract/ChainAddressForm/index.tsx
+++ b/ui/src/pages/Verifier/CheckedContractsView/CheckedContract/ChainAddressForm/index.tsx
@@ -23,6 +23,7 @@ import { HiChevronDown } from "react-icons/hi";
 import ReactTooltip from "react-tooltip";
 import Constructorarguments from "../../../../../components/ConstructorArguments";
 import InputToggle from "../../../../../components/InputToggle";
+import { SelectedOptionValue } from "react-select-search";
 
 type ChainAddressFormProps = {
   customStatus: string;
@@ -87,11 +88,12 @@ const ChainAddressForm = ({
     });
   };
 
-  const handleChainIdChange = (newChainId: number) => {
-    const newChainIdStr = newChainId.toString();
+  const handleChainIdChange = (
+    selectedOptionValue: SelectedOptionValue | SelectedOptionValue[]
+  ) => {
+    const newChainIdStr = `${selectedOptionValue as SelectedOptionValue}`;
     setChainId(newChainIdStr);
     verifyButtonRef.current?.focus();
-    console.log(`New id is: ${newChainId}`);
   };
 
   const handleMsgSenderChange: ChangeEventHandler<HTMLInputElement> = (e) => {

--- a/ui/src/pages/Verifier/ContractInput.tsx
+++ b/ui/src/pages/Verifier/ContractInput.tsx
@@ -3,6 +3,7 @@ import Input from "../../components/Input";
 import ChainSelect from "../../components/ChainSelect";
 import { ADD_FILES_FROM_CONTRACT_URL } from "../../constants";
 import { SessionResponse } from "../../types";
+import { SelectedOptionValue } from "react-select-search";
 
 type EtherscanInputProps = {
   fetchAndUpdate: (
@@ -29,8 +30,10 @@ const ContractInput = ({
     if (!e.target.value) return setError("");
   };
 
-  const handleChainIdChange = (id: number) => {
-    const chainId = `${id}`;
+  const handleChainIdChange = (
+    selectedOptionValue: SelectedOptionValue | SelectedOptionValue[]
+  ) => {
+    const chainId = `${selectedOptionValue as SelectedOptionValue}`;
     setChainId(chainId);
     if (chainId) return setError("");
   };

--- a/ui/src/pages/Verifier/EtherscanInput.tsx
+++ b/ui/src/pages/Verifier/EtherscanInput.tsx
@@ -5,6 +5,11 @@ import { VERIFY_FROM_ETHERSCAN } from "../../constants";
 import { SessionResponse } from "../../types";
 import { Context } from "../../Context";
 import { isAddress } from "@ethersproject/address";
+import {
+  SelectSearchProps,
+  SelectedOption,
+  SelectedOptionValue,
+} from "react-select-search";
 
 type EtherscanInputProps = {
   fetchAndUpdate: (
@@ -37,8 +42,10 @@ const EtherscanInput = ({
     if (!e.target.value) return setError(""); // reset error
   };
 
-  const handleChainIdChange = (id: number) => {
-    const chainId = `${id}`;
+  const handleChainIdChange: SelectSearchProps["onChange"] = (
+    selectedValue
+  ) => {
+    const chainId = `${selectedValue as SelectedOptionValue}`;
     setChainId(chainId);
   };
 

--- a/ui/src/pages/Verifier/EtherscanInput.tsx
+++ b/ui/src/pages/Verifier/EtherscanInput.tsx
@@ -5,11 +5,7 @@ import { VERIFY_FROM_ETHERSCAN } from "../../constants";
 import { SessionResponse } from "../../types";
 import { Context } from "../../Context";
 import { isAddress } from "@ethersproject/address";
-import {
-  SelectSearchProps,
-  SelectedOption,
-  SelectedOptionValue,
-} from "react-select-search";
+import { SelectSearchProps, SelectedOptionValue } from "react-select-search";
 
 type EtherscanInputProps = {
   fetchAndUpdate: (

--- a/ui/src/pages/Verifier/FileUpload.tsx
+++ b/ui/src/pages/Verifier/FileUpload.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { AiFillFileAdd, AiOutlineGithub, AiOutlinePlus } from "react-icons/ai";
 import { FaEthereum } from "react-icons/fa";
+import { SiSolidity } from "react-icons/si";
 import { HiOutlineExclamation } from "react-icons/hi";
 import Button from "../../components/Button";
 import LoadingOverlay from "../../components/LoadingOverlay";
@@ -145,7 +146,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
             className="text-sm"
           >
             <>
-              <FaEthereum className="inline align-middle mr-1" />
+              <SiSolidity className="inline align-middle mr-1" />
               Import from Solidity JSON
             </>
           </Button>

--- a/ui/src/pages/Verifier/FileUpload.tsx
+++ b/ui/src/pages/Verifier/FileUpload.tsx
@@ -11,6 +11,7 @@ import EtherscanInput from "./EtherscanInput";
 import RemoteInput from "./RemoteInput";
 import GitHubInput from "./GitHubInput";
 import ContractInput from "./ContractInput";
+import SolcJsonInput from "./SolcJsonInput";
 
 enum ImportMethods {
   UPLOAD,
@@ -18,6 +19,7 @@ enum ImportMethods {
   ETHERSCAN,
   GITHUB,
   CONTRACT,
+  SOLIDITY_JSON,
 }
 
 type FileUploadProps = {
@@ -75,72 +77,78 @@ const FileUpload: React.FC<FileUploadProps> = ({
           </p>
         </div>
         <div className="flex flex-row flex-wrap gap-3 mt-4 justify-center md:justify-start">
-          <div className="">
-            <Button
-              type={
-                importMethodSelected === ImportMethods.REMOTE
-                  ? "primary"
-                  : "secondary"
-              }
-              onClick={() => selectImportMethod(ImportMethods.REMOTE)}
-              className="text-sm"
-            >
-              <>
-                <AiOutlinePlus className="inline align-middle mr-1" />
-                Import from remote
-              </>
-            </Button>
-          </div>
-          <div className="">
-            <Button
-              type={
-                importMethodSelected === ImportMethods.ETHERSCAN
-                  ? "primary"
-                  : "secondary"
-              }
-              onClick={() => selectImportMethod(ImportMethods.ETHERSCAN)}
-              className="text-sm"
-            >
-              <>
-                <EtherscanLogo
-                  light={importMethodSelected === ImportMethods.ETHERSCAN}
-                />
-                Import from Etherscan
-              </>
-            </Button>
-          </div>
-          <div className="">
-            <Button
-              type={
-                importMethodSelected === ImportMethods.GITHUB
-                  ? "primary"
-                  : "secondary"
-              }
-              onClick={() => selectImportMethod(ImportMethods.GITHUB)}
-              className="text-sm"
-            >
-              <>
-                <AiOutlineGithub className="inline align-middle mr-1" />
-                Import from GitHub
-              </>
-            </Button>
-          </div>
-          <div className="">
-            <Button
-              type={
-                importMethodSelected === ImportMethods.CONTRACT
-                  ? "primary"
-                  : "secondary"
-              }
-              onClick={() => selectImportMethod(ImportMethods.CONTRACT)}
-              className="text-sm"
-            >
-              <>
-                <FaEthereum className="inline align-middle mr-1" />
-                Import from Contract
-              </>
-            </Button>
-          </div>
+          <Button
+            type={
+              importMethodSelected === ImportMethods.REMOTE
+                ? "primary"
+                : "secondary"
+            }
+            onClick={() => selectImportMethod(ImportMethods.REMOTE)}
+            className="text-sm"
+          >
+            <>
+              <AiOutlinePlus className="inline align-middle mr-1" />
+              Import from remote
+            </>
+          </Button>
+          <Button
+            type={
+              importMethodSelected === ImportMethods.ETHERSCAN
+                ? "primary"
+                : "secondary"
+            }
+            onClick={() => selectImportMethod(ImportMethods.ETHERSCAN)}
+            className="text-sm"
+          >
+            <>
+              <EtherscanLogo
+                light={importMethodSelected === ImportMethods.ETHERSCAN}
+              />
+              Import from Etherscan
+            </>
+          </Button>
+          <Button
+            type={
+              importMethodSelected === ImportMethods.GITHUB
+                ? "primary"
+                : "secondary"
+            }
+            onClick={() => selectImportMethod(ImportMethods.GITHUB)}
+            className="text-sm"
+          >
+            <>
+              <AiOutlineGithub className="inline align-middle mr-1" />
+              Import from GitHub
+            </>
+          </Button>
+          <Button
+            type={
+              importMethodSelected === ImportMethods.CONTRACT
+                ? "primary"
+                : "secondary"
+            }
+            onClick={() => selectImportMethod(ImportMethods.CONTRACT)}
+            className="text-sm"
+          >
+            <>
+              <FaEthereum className="inline align-middle mr-1" />
+              Import from Contract
+            </>
+          </Button>
+          <Button
+            type={
+              importMethodSelected === ImportMethods.SOLIDITY_JSON
+                ? "primary"
+                : "secondary"
+            }
+            onClick={() => selectImportMethod(ImportMethods.SOLIDITY_JSON)}
+            className="text-sm"
+          >
+            <>
+              <FaEthereum className="inline align-middle mr-1" />
+              Import from Solidity JSON
+            </>
+          </Button>
         </div>
         <div className="flex flex-grow flex-col pb-8">
           {importMethodSelected === ImportMethods.REMOTE && (
@@ -191,6 +199,20 @@ const FileUpload: React.FC<FileUploadProps> = ({
               </p>
               <div className="mt-1">
                 <ContractInput
+                  fetchAndUpdate={fetchAndUpdate}
+                  setIsLoading={setIsLoading}
+                  isLoading={isLoading}
+                />
+              </div>
+            </div>
+          )}
+          {importMethodSelected === ImportMethods.SOLIDITY_JSON && (
+            <div className="mt-4">
+              <p className="">
+                Import contracts from Solidity's Standard JSON Input
+              </p>
+              <div className="mt-1">
+                <SolcJsonInput
                   fetchAndUpdate={fetchAndUpdate}
                   setIsLoading={setIsLoading}
                   isLoading={isLoading}

--- a/ui/src/pages/Verifier/GitHubInput.tsx
+++ b/ui/src/pages/Verifier/GitHubInput.tsx
@@ -5,6 +5,7 @@ import GitHubBranchSelect, {
 import Input from "../../components/Input";
 import { ADD_FILES_URL } from "../../constants";
 import { SessionResponse } from "../../types";
+import { SelectSearchProps, SelectedOptionValue } from "react-select-search";
 
 let timeoutId: any;
 
@@ -75,7 +76,10 @@ const GitHubInput = ({
     }, 600)();
   };
 
-  const handleBranchChange = (id: string) => {
+  const handleBranchChange: SelectSearchProps["onChange"] = (
+    selectedOptionValue
+  ) => {
+    const id = `${selectedOptionValue as SelectedOptionValue}`;
     setBranch(id);
     generateUrlAndSubmit(id);
     if (!id) return setError("");

--- a/ui/src/pages/Verifier/SolcJsonInput.tsx
+++ b/ui/src/pages/Verifier/SolcJsonInput.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect, useContext, useCallback } from "react";
+import Input from "../../components/Input";
+import ChainSelect from "../../components/ChainSelect";
+import { ADD_SOLC_JSON_URL } from "../../constants";
+import { SessionResponse } from "../../types";
+import { Context } from "../../Context";
+import { isAddress } from "@ethersproject/address";
+import SelectSearch, {
+  SelectSearchProps,
+  SelectedOptionValue,
+} from "react-select-search";
+import { fuzzySearch } from "react-select-search";
+
+const SOLC_VERSIONS_LIST_URL =
+  "https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.txt";
+
+type SolcJsonInputProps = {
+  fetchAndUpdate: (
+    URL: string,
+    fetchOptions?: RequestInit
+  ) => Promise<SessionResponse | undefined>;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoading: boolean;
+};
+const SolcJsonInput = ({
+  fetchAndUpdate,
+  setIsLoading,
+  isLoading,
+}: SolcJsonInputProps) => {
+  const [chosenCompilerVersion, setChosenCompilerVersion] =
+    useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [officialCompilerVersionsList, setOfficialCompilerVersionsList] =
+    useState<string[]>();
+  const [allCompilerVersionsList, setAllCompilerVersionsList] =
+    useState<string[]>();
+  const [useNightlies, setUseNightlies] = useState<boolean>(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const handleCompilerVersionChange: SelectSearchProps["onChange"] = (
+    selectedOptionValue
+  ) => {
+    const selectedCompilerVersion = `${
+      selectedOptionValue as SelectedOptionValue
+    }`;
+    setChosenCompilerVersion(selectedCompilerVersion);
+  };
+
+  const formatVersionName = (version: string) => {
+    return version.replace("soljson-", "").replace(".js", "");
+  };
+
+  useEffect(() => {
+    if (!chosenCompilerVersion) {
+      return setError("Please select a compiler version");
+    }
+    if (!selectedFile) {
+      return setError("Please select a file");
+    }
+    setIsLoading(true);
+    const formData = new FormData();
+    formData.append("files", selectedFile);
+    formData.append("compilerVersion", chosenCompilerVersion);
+
+    fetchAndUpdate(ADD_SOLC_JSON_URL, {
+      method: "POST",
+      body: formData,
+    }).finally(() => {
+      setIsLoading(false);
+    });
+  }, [chosenCompilerVersion, selectedFile, setIsLoading, fetchAndUpdate]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    fetch(SOLC_VERSIONS_LIST_URL)
+      .then((response) => response.text())
+      .then(async (text) => {
+        const allVersionsList = text
+          .split("\n")
+          .map((line) => formatVersionName(line)); // strip solc- and .js parts
+        setAllCompilerVersionsList(allVersionsList);
+        setOfficialCompilerVersionsList(
+          allVersionsList.filter((version) => !version.includes("nightly"))
+        );
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        console.error(error);
+        setIsLoading(false);
+        setError("Failed to fetch compiler versions");
+      });
+  }, []);
+
+  const returnCompilerOptions = (): { name: string; value: string }[] => {
+    if (useNightlies) {
+      if (!allCompilerVersionsList) {
+        return [];
+      }
+      return allCompilerVersionsList.map((version) => ({
+        name: version,
+        value: version,
+      }));
+    } else {
+      if (!officialCompilerVersionsList) {
+        return [];
+      }
+      return officialCompilerVersionsList.map((version) => ({
+        name: version,
+        value: version,
+      }));
+    }
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    setSelectedFile(file || null);
+  };
+
+  return (
+    <div>
+      <input
+        type="checkbox"
+        id="nightlies"
+        checked={useNightlies}
+        onChange={() => setUseNightlies(!useNightlies)}
+      />{" "}
+      <label htmlFor="nightlies">Use nightlies</label>
+      <SelectSearch
+        onChange={handleCompilerVersionChange}
+        value={chosenCompilerVersion}
+        options={returnCompilerOptions()}
+        search
+        filterOptions={fuzzySearch}
+        emptyMessage="Couldn't fetch compiler versions"
+        placeholder="Choose a compiler version"
+      />
+      <input type="file" onChange={handleFileChange} />
+    </div>
+  );
+};
+
+export default SolcJsonInput;

--- a/ui/src/pages/Verifier/SolcJsonInput.tsx
+++ b/ui/src/pages/Verifier/SolcJsonInput.tsx
@@ -64,6 +64,7 @@ const SolcJsonInput = ({
       body: formData,
     }).finally(() => {
       setIsLoading(false);
+      setError("");
     });
   }, [chosenCompilerVersion, selectedFile, setIsLoading, fetchAndUpdate]);
 
@@ -86,7 +87,7 @@ const SolcJsonInput = ({
         setIsLoading(false);
         setError("Failed to fetch compiler versions");
       });
-  }, []);
+  }, [setIsLoading]);
 
   const returnCompilerOptions = (): { name: string; value: string }[] => {
     if (useNightlies) {
@@ -132,6 +133,7 @@ const SolcJsonInput = ({
         placeholder="Choose a compiler version"
       />
       <input type="file" onChange={handleFileChange} className="mt-2" />
+      <div className="text-red-400">{error}</div>
     </div>
   );
 };

--- a/ui/src/pages/Verifier/SolcJsonInput.tsx
+++ b/ui/src/pages/Verifier/SolcJsonInput.tsx
@@ -1,15 +1,12 @@
-import { useState, useEffect, useContext, useCallback } from "react";
-import Input from "../../components/Input";
-import ChainSelect from "../../components/ChainSelect";
+import { useState, useEffect } from "react";
 import { ADD_SOLC_JSON_URL } from "../../constants";
 import { SessionResponse } from "../../types";
-import { Context } from "../../Context";
-import { isAddress } from "@ethersproject/address";
 import SelectSearch, {
   SelectSearchProps,
   SelectedOptionValue,
 } from "react-select-search";
 import { fuzzySearch } from "react-select-search";
+import InputToggle from "../../components/InputToggle";
 
 const SOLC_VERSIONS_LIST_URL =
   "https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.txt";
@@ -118,13 +115,13 @@ const SolcJsonInput = ({
 
   return (
     <div>
-      <input
-        type="checkbox"
+      <InputToggle
         id="nightlies"
-        checked={useNightlies}
-        onChange={() => setUseNightlies(!useNightlies)}
+        label="Use nightlies"
+        isChecked={useNightlies}
+        onClick={() => setUseNightlies(!useNightlies)}
+        className="mb-2"
       />{" "}
-      <label htmlFor="nightlies">Use nightlies</label>
       <SelectSearch
         onChange={handleCompilerVersionChange}
         value={chosenCompilerVersion}
@@ -134,7 +131,7 @@ const SolcJsonInput = ({
         emptyMessage="Couldn't fetch compiler versions"
         placeholder="Choose a compiler version"
       />
-      <input type="file" onChange={handleFileChange} />
+      <input type="file" onChange={handleFileChange} className="mt-2" />
     </div>
   );
 };

--- a/ui/src/pages/Verifier/index.tsx
+++ b/ui/src/pages/Verifier/index.tsx
@@ -42,7 +42,6 @@ const Verifier: React.FC = () => {
           // mode: "cors",
           ...fetchOptions,
         });
-        console.log(rawRes);
 
         if (!rawRes.ok) {
           const err: IGenericError = await rawRes.json();


### PR DESCRIPTION
Closes #945 

- Adds session and non session endpoints
- Adds tests
- Adds solc json verification to the UI:
  - Remove `CustomSelectSearch` and instead use the `SelectSearch` from the library itself with the correct types. CustomSelectSearch was there for a type workaround of the `onChange` prop: first removes the type, then adds the custom type. With the correct type from the library itself, there's no need for that.
  - Refactor `fuzzySearch` to its own module as it's reused. 
  - Refactor `ChainSelect` `GithubBranchSelect` 
  - Add the new `SolcJsonInput.tsx` with the out-of-the-box `SelectSearch`. 