### PR TITLE
Re-enable SourcifyEventManager's listeners

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6,6 +6,8 @@ import routes from "./routes";
 import bodyParser from "body-parser";
 import config, { etherscanAPIs } from "../config";
 import { SourcifyEventManager } from "../common/SourcifyEventManager/SourcifyEventManager";
+import "../common/SourcifyEventManager/listeners/matchStored";
+import "../common/SourcifyEventManager/listeners/logger";
 import genericErrorHandler from "./middlewares/GenericErrorHandler";
 import notFoundHandler from "./middlewares/NotFoundError";
 import useApiLogging from "./middlewares/ApiLogging";


### PR DESCRIPTION
See #1002

In particular:
* `matchStored`: a listener for the `Verification.MatchStored` event
* `logger`: a generic listener that pushes all logs to loki