### PR TITLE
Throw before if compiled bytecode empty instead of later in creation bytecode

### DIFF
--- a/packages/lib-sourcify/src/lib/verification.ts
+++ b/packages/lib-sourcify/src/lib/verification.ts
@@ -47,6 +47,15 @@ export async function verifyDeployed(
   };
   const recompiled = await checkedContract.recompile();
 
+  if (
+    recompiled.deployedBytecode === '0x' ||
+    recompiled.creationBytecode === '0x'
+  ) {
+    throw new Error(
+      `The compiled contract bytecode is "0x". Are you trying to verify an abstract contract?`
+    );
+  }
+
   const deployedBytecode = await getBytecode(sourcifyChain, address);
 
   // Can't match if there is no deployed bytecode
@@ -364,11 +373,6 @@ export async function matchWithCreationTx(
   creatorTxHash: string,
   recompiledMetadata: Metadata
 ) {
-  if (recompiledCreationBytecode === '0x') {
-    match.status = null;
-    match.message = `Failed to match with creation bytecode: recompiled contract's creation bytecode is empty`;
-    return;
-  }
   const creatorTx = await getTx(creatorTxHash, sourcifyChain);
   const creatorTxData = creatorTx.input;
 

--- a/packages/lib-sourcify/src/lib/verification.ts
+++ b/packages/lib-sourcify/src/lib/verification.ts
@@ -373,6 +373,12 @@ export async function matchWithCreationTx(
   creatorTxHash: string,
   recompiledMetadata: Metadata
 ) {
+  if (recompiledCreationBytecode === '0x') {
+    match.status = null;
+    match.message = `Failed to match with creation bytecode: recompiled contract's creation bytecode is empty`;
+    return;
+  }
+
   const creatorTx = await getTx(creatorTxHash, sourcifyChain);
   const creatorTxData = creatorTx.input;
 


### PR DESCRIPTION
I was looking at some other contracts and noticed that for abstract contracts the compiler returns empty bytecode.

I believe we should immediately throw if the user is trying to verify an abstract contract or for some reason, the compiler returns an empty bytecode.