### PR TITLE
fix build - add optional title type

### DIFF
--- a/packages/lib-sourcify/src/lib/types.ts
+++ b/packages/lib-sourcify/src/lib/types.ts
@@ -196,6 +196,7 @@ export type SourcifyChainExtension = {
 // TODO: Double check against ethereum-lists/chains type
 export type Chain = {
   name: string;
+  title?: string;
   chainId: number;
   shortName: string;
   network?: string;


### PR DESCRIPTION
Currently the repo attemps to read the title type which should be an optional string on chain, but is omitted in the type definitions for chain in this repo.

This diff fixes that issue and can be confirmed with this link to the original schema:

https://github.com/ethereum-lists/chains/blob/master/tools/schema/chainSchema.json

