### PR TITLE
Catch auxdata decode error when checking for perfect match

### DIFF
--- a/packages/lib-sourcify/src/lib/CheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/CheckedContract.ts
@@ -114,7 +114,13 @@ export class CheckedContract {
   async tryToFindPerfectMetadata(
     deployedBytecode: string
   ): Promise<CheckedContract | null> {
-    const decodedAuxdata = decodeBytecode(deployedBytecode);
+    let decodedAuxdata;
+    try {
+      decodedAuxdata = decodeBytecode(deployedBytecode);
+    } catch (err) {
+      // There is no auxdata at all in this contract
+      return null;
+    }
 
     const pathContent: PathContent[] = Object.keys(this.solidity).map(
       (path) => {


### PR DESCRIPTION
This helps when verifying contracts that don't have the CBOR metadata block at the end; currently, an error is thrown rather than making it a partial match.