### PR TITLE
stats gen: fix for when a partial_match dir doesn't exist for a chain id

### DIFF
--- a/services/ipfs/server/publish.sh
+++ b/services/ipfs/server/publish.sh
@@ -12,7 +12,7 @@ OUTPUT="{ "
 for chainId in ${CHAINS}; do
    OUTPUT="$OUTPUT  \"$chainId\": {"
    OUTPUT="$OUTPUT    \"full_match\": $(find $REPOSITORY_PATH/contracts/full_match/$chainId/ -mindepth 1 -maxdepth 1 -type d | wc -l),"
-   OUTPUT="$OUTPUT    \"partial_match\": $(find $REPOSITORY_PATH/contracts/partial_match/$chainId/ -mindepth 1 -maxdepth 1 -type d | wc -l)"
+   OUTPUT="$OUTPUT    \"partial_match\": $(find $REPOSITORY_PATH/contracts/partial_match/$chainId/ -mindepth 1 -maxdepth 1 -type d | wc -l || echo '0')"
    
    if [[ $chainId == $(echo $CHAINS | rev | cut -d " " -f1 | rev) ]]
     then


### PR DESCRIPTION
Example: 

`find: /data/contracts/partial_match/641230/: No such file or directory`
