### PR TITLE
Stream lambda function compiler responses

### DIFF
--- a/services/server/src/config/master.js
+++ b/services/server/src/config/master.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   lambdaCompiler: {
     enabled: true,
-    functionName: "compile-production",
+    functionName: "compile-production:2",
     // credentials as env vars
   },
   rateLimit: {

--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   lambdaCompiler: {
     enabled: true,
-    functionName: "compile",
+    functionName: "compile:2",
     // credentials as env vars
   },
   rateLimit: {

--- a/services/server/src/server/controllers/verification/verification.common.ts
+++ b/services/server/src/server/controllers/verification/verification.common.ts
@@ -23,7 +23,7 @@ import fetch from "node-fetch";
 import { IVerificationService } from "../../services/VerificationService";
 import { ContractMeta, ContractWrapper, getMatchStatus } from "../../common";
 import { ISolidityCompiler } from "@ethereum-sourcify/lib-sourcify";
-import { SolcLambda } from "../../services/compiler/lambda/SolcLambda";
+import { SolcLambdaWithLocalFallback } from "../../services/compiler/lambda-with-fallback/SolcLambdaWithLocalFallback";
 import { SolcLocal } from "../../services/compiler/local/SolcLocal";
 import { StorageService } from "../../services/StorageService";
 import logger from "../../../common/logger";
@@ -32,8 +32,8 @@ import { createHash } from "crypto";
 
 let selectedSolidityCompiler: ISolidityCompiler;
 if (config.get("lambdaCompiler.enabled")) {
-  logger.info("Using lambda solidity compiler");
-  selectedSolidityCompiler = new SolcLambda();
+  logger.info("Using lambda solidity compiler with local fallback");
+  selectedSolidityCompiler = new SolcLambdaWithLocalFallback();
 } else {
   logger.info("Using local solidity compiler");
   selectedSolidityCompiler = new SolcLocal();

--- a/services/server/src/server/services/compiler/lambda-with-fallback/SolcLambdaWithLocalFallback.ts
+++ b/services/server/src/server/services/compiler/lambda-with-fallback/SolcLambdaWithLocalFallback.ts
@@ -1,0 +1,38 @@
+import {
+  CompilerOutput,
+  ISolidityCompiler,
+  JsonInput,
+} from "@ethereum-sourcify/lib-sourcify";
+import logger from "../../../../common/logger";
+import { SolcLambda } from "../lambda/SolcLambda";
+import { SolcLocal } from "../local/SolcLocal";
+
+export class SolcLambdaWithLocalFallback implements ISolidityCompiler {
+  private solcLambda = new SolcLambda();
+  private solcLocal = new SolcLocal();
+
+  public async compile(
+    version: string,
+    solcJsonInput: JsonInput,
+    forceEmscripten: boolean = false
+  ): Promise<CompilerOutput> {
+    let compilerOutput: CompilerOutput;
+    try {
+      compilerOutput = await this.solcLambda.compile(
+        version,
+        solcJsonInput,
+        forceEmscripten
+      );
+    } catch (e) {
+      logger.error(
+        "Lambda compilation error - Falling back to local compilation"
+      );
+      compilerOutput = await this.solcLocal.compile(
+        version,
+        solcJsonInput,
+        forceEmscripten
+      );
+    }
+    return compilerOutput;
+  }
+}

--- a/services/server/src/server/services/compiler/lambda-with-fallback/SolcLambdaWithLocalFallback.ts
+++ b/services/server/src/server/services/compiler/lambda-with-fallback/SolcLambdaWithLocalFallback.ts
@@ -25,7 +25,7 @@ export class SolcLambdaWithLocalFallback implements ISolidityCompiler {
       );
     } catch (e) {
       if (e instanceof LambdaResponseLimitExceeded) {
-        logger.error(
+        logger.warn(
           "Lambda compilation exceeded stream response limit - Falling back to local compilation"
         );
         compilerOutput = await this.solcLocal.compile(

--- a/services/server/src/server/services/compiler/lambda/SolcLambda.ts
+++ b/services/server/src/server/services/compiler/lambda/SolcLambda.ts
@@ -101,11 +101,18 @@ export class SolcLambda implements ISolidityCompiler {
         error: output.error,
         lambdaRequestId: response.$metadata.requestId,
       });
-      throw new Error(
-        `AWS Lambda error: ${output.error} - lamdbaRequestId: ${response.$metadata.requestId}`
-      );
+      const errorMessage = `AWS Lambda error: ${output.error} - lamdbaRequestId: ${response.$metadata.requestId}`;
+      if (output.error === "Stream response limit exceeded") {
+        throw new LambdaResponseLimitExceeded(errorMessage);
+      } else {
+        throw new Error(errorMessage);
+      }
     }
 
     return output;
   }
+}
+
+export class LambdaResponseLimitExceeded extends Error {
+  name = "LambdaResponseLimitExceeded";
 }

--- a/services/server/src/server/services/compiler/lambda/SolcLambda.ts
+++ b/services/server/src/server/services/compiler/lambda/SolcLambda.ts
@@ -1,7 +1,7 @@
 import {
   LambdaClient,
-  InvokeCommand,
-  InvokeCommandInput,
+  InvokeWithResponseStreamCommand,
+  InvokeWithResponseStreamCommandInput,
 } from "@aws-sdk/client-lambda";
 import {
   CompilerOutput,
@@ -44,45 +44,56 @@ export class SolcLambda implements ISolidityCompiler {
     logger.debug("Compiling with Lambda", { version });
     const response = await this.invokeLambdaFunction(param);
     logger.debug("Compiled with Lambda", { version });
-    const responseObj = this.parseCompilerOutput(response);
-    logger.silly("Lambda function response", { responseObj });
-    return responseObj;
+    logger.silly("Lambda function response", { response });
+    return response;
   }
 
-  private async invokeLambdaFunction(payload: string): Promise<any> {
-    const params: InvokeCommandInput = {
+  private async invokeLambdaFunction(payload: string): Promise<CompilerOutput> {
+    const params: InvokeWithResponseStreamCommandInput = {
       FunctionName: config.get("lambdaCompiler.functionName") || "compile",
       Payload: payload,
     };
 
-    const command = new InvokeCommand(params);
+    const command = new InvokeWithResponseStreamCommand(params);
     const response = await this.lambdaClient.send(command);
 
-    if (!response.Payload) {
+    if (!response.EventStream) {
       throw new Error(
-        "Error: No response payload received from Lambda function"
+        "Error: No response stream received from Lambda function"
       );
     }
 
-    if (response.FunctionError) {
-      const errorObj: { errorMessage: string; errorType: string } = JSON.parse(
-        Buffer.from(response.Payload).toString("utf8")
-      );
-      logger.error("Error invoking Lambda function", {
-        errorObj,
+    let streamResult = "";
+    for await (const event of response.EventStream) {
+      if (event.InvokeComplete?.ErrorCode) {
+        logger.error("Error invoking Lambda function", {
+          errorCode: event.InvokeComplete.ErrorCode,
+          errorDetails: event.InvokeComplete.ErrorDetails,
+          logResult: event.InvokeComplete.LogResult,
+          lambdaRequestId: response.$metadata.requestId,
+        });
+        throw new Error(
+          `AWS Lambda error: ${event.InvokeComplete.ErrorCode} - ${event.InvokeComplete.ErrorDetails} - lamdbaRequestId: ${response.$metadata.requestId}`
+        );
+      } else if (event.PayloadChunk?.Payload) {
+        streamResult += Buffer.from(event.PayloadChunk.Payload).toString(
+          "utf8"
+        );
+      }
+    }
+    logger.silly("Received stream response", { streamResult });
+
+    const output = JSON.parse(streamResult);
+    if (output.error) {
+      logger.error("Error received from Lambda function", {
+        error: output.error,
         lambdaRequestId: response.$metadata.requestId,
-        functionError: response.FunctionError,
       });
       throw new Error(
-        `AWS Lambda error: ${errorObj.errorType} - ${errorObj.errorMessage} - lamdbaRequestId: ${response.$metadata.requestId}`
+        `AWS Lambda error: ${output.error} - lamdbaRequestId: ${response.$metadata.requestId}`
       );
     }
 
-    return response;
-  }
-
-  private parseCompilerOutput(response: any): CompilerOutput {
-    const res = JSON.parse(Buffer.from(response.Payload).toString("utf8"));
-    return res.body as CompilerOutput;
+    return output;
   }
 }

--- a/services/server/src/server/services/compiler/lambda/SolcLambda.ts
+++ b/services/server/src/server/services/compiler/lambda/SolcLambda.ts
@@ -83,7 +83,19 @@ export class SolcLambda implements ISolidityCompiler {
     }
     logger.silly("Received stream response", { streamResult });
 
-    const output = JSON.parse(streamResult);
+    let output;
+    try {
+      output = JSON.parse(streamResult);
+    } catch (e) {
+      logger.error("Error parsing Lambda function result", {
+        error: e,
+        lambdaRequestId: response.$metadata.requestId,
+      });
+      throw new Error(
+        `AWS Lambda error: ${e} - lamdbaRequestId: ${response.$metadata.requestId}`
+      );
+    }
+
     if (output.error) {
       logger.error("Error received from Lambda function", {
         error: output.error,


### PR DESCRIPTION
See #1326

I didn't implement any chunking myself. Instead I used the `pipeline` function because the docs recommend to do so. AWS's `responseStream` will just take care of chunking it.

Note that that streamed responses also have a limit of 20 MB (usual payload response was 6 MB). Maybe it could make sense to fallback to local compilation if an error is received from the lambda function?

TODO:
- [x] Add a dashboard to Grafana when fallback is used