### PR TITLE
Add `dryrun` query param to enable verification preview

### DIFF
--- a/services/server/src/server/controllers/verification/session-state/input-files.session-state.paths.yaml
+++ b/services/server/src/server/controllers/verification/session-state/input-files.session-state.paths.yaml
@@ -39,6 +39,13 @@ paths:
             format: uri
           description: Remote file URL
           required: false
+        - name: dryrun
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Dry-run flag. When present and set to true, a successful verification result will not be stored in the repository.
+          required: false
       responses:
         "200":
           description: Response is sent when the upload is successful under different conditions.

--- a/services/server/src/server/controllers/verification/session-state/session-state.handlers.ts
+++ b/services/server/src/server/controllers/verification/session-state/session-state.handlers.ts
@@ -42,6 +42,7 @@ export async function addInputFilesEndpoint(req: Request, res: Response) {
     return { path: pb.path, content: pb.buffer.toString(FILE_ENCODING) };
   });
 
+  const dryRun = Boolean(req.query.dryrun);
   const session = req.session;
   const newFilesCount = saveFilesToSession(pathContents, session);
   if (newFilesCount) {
@@ -50,7 +51,8 @@ export async function addInputFilesEndpoint(req: Request, res: Response) {
       session.contractWrappers,
       session,
       services.verification,
-      services.storage
+      services.storage,
+      dryRun,
     );
   }
   res.send(getSessionJSON(session));

--- a/services/server/src/server/controllers/verification/verification.common.ts
+++ b/services/server/src/server/controllers/verification/verification.common.ts
@@ -345,7 +345,7 @@ export const verifyContractsInSession = async (
   session: Session,
   verificationService: IVerificationService,
   storageService: StorageService,
-  dryRun: boolean = false,
+  dryRun: boolean = false
 ): Promise<void> => {
   logger.debug("verifyContractsInSession", {
     sessionId: session.id,
@@ -456,7 +456,13 @@ export const verifyContractsInSession = async (
     contractWrapper.status = getMatchStatus(match) || "error";
     contractWrapper.statusMessage = match.message;
     contractWrapper.storageTimestamp = match.storageTimestamp;
-    if ((match.runtimeMatch || match.creationMatch) && !dryRun) {
+    if (dryRun) {
+      logger.info("dryRun verification", {
+        sessionId: session.id,
+      });
+      return;
+    }
+    if (match.runtimeMatch || match.creationMatch) {
       await storageService.storeMatch(checkedContract, match);
     }
   }

--- a/services/server/src/server/controllers/verification/verification.common.ts
+++ b/services/server/src/server/controllers/verification/verification.common.ts
@@ -344,7 +344,8 @@ export const verifyContractsInSession = async (
   contractWrappers: ContractWrapperMap = {},
   session: Session,
   verificationService: IVerificationService,
-  storageService: StorageService
+  storageService: StorageService,
+  dryRun: boolean = false,
 ): Promise<void> => {
   logger.debug("verifyContractsInSession", {
     sessionId: session.id,
@@ -455,7 +456,7 @@ export const verifyContractsInSession = async (
     contractWrapper.status = getMatchStatus(match) || "error";
     contractWrapper.statusMessage = match.message;
     contractWrapper.storageTimestamp = match.storageTimestamp;
-    if (match.runtimeMatch || match.creationMatch) {
+    if ((match.runtimeMatch || match.creationMatch) && !dryRun) {
       await storageService.storeMatch(checkedContract, match);
     }
   }

--- a/services/server/src/server/controllers/verification/verify/session/verify.session.handlers.ts
+++ b/services/server/src/server/controllers/verification/verify/session/verify.session.handlers.ts
@@ -20,6 +20,8 @@ export async function verifyContractsInSessionEndpoint(
     throw new BadRequestError("There are currently no pending contracts.");
   }
 
+  const dryRun = Boolean(req.query.dryrun);
+
   const receivedContracts: SendableContract[] = req.body.contracts;
 
   /* eslint-disable indent */
@@ -52,7 +54,8 @@ export async function verifyContractsInSessionEndpoint(
     verifiable,
     session,
     services.verification,
-    services.storage
+    services.storage,
+    dryRun,
   );
   res.send(getSessionJSON(session));
 }

--- a/services/server/src/server/controllers/verification/verify/session/verify.session.paths.yaml
+++ b/services/server/src/server/controllers/verification/verify/session/verify.session.paths.yaml
@@ -31,6 +31,14 @@ paths:
                       verificationId:
                         type: string
                         example: "0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe"
+      parameters:
+        - name: dryrun
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Dry-run flag. When present and set to true, a successful verification result will not be stored in the repository.
+          required: false
       responses:
         "200":
           description: OK


### PR DESCRIPTION
This PR adds a new query parameters to enable verification preview.

Fixes #1319.
