### PR TITLE
Move `servers` dropdown list into its own file

### DIFF
--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -7,12 +7,7 @@ info:
     name: MIT
     url: https://github.com/ethereum/sourcify/blob/master/LICENSE
 servers:
-  - url: https://sourcify.dev/server
-    description: Production server
-  - url: https://staging.sourcify.dev/server
-    description: Staging server
-  - url: http://localhost:5555
-    description: Local development server address on default port 5555.
+  $ref: "servers.yaml"
 tags:
   - name: Stateless Verification
     description: Main verification endpoints

--- a/services/server/src/servers.yaml
+++ b/services/server/src/servers.yaml
@@ -1,0 +1,6 @@
+- url: https://sourcify.dev/server
+  description: Production server
+- url: https://staging.sourcify.dev/server
+  description: Staging server
+- url: http://localhost:5555
+  description: Local development server address on default port 5555.


### PR DESCRIPTION
This PR refactors the OpenAPI docs to separate the endpoints from the `servers` list. It moves the `servers` list into a separate file.

When deploying the server image, the `servers.yaml` can be overridden to provide a custom `servers` list.

Fixes #1345.
