### PR TITLE
Fix multi-contract verification when `dryrun` flag is enabled

### DIFF
--- a/services/server/src/server/controllers/verification/verification.common.ts
+++ b/services/server/src/server/controllers/verification/verification.common.ts
@@ -460,7 +460,7 @@ export const verifyContractsInSession = async (
       logger.info("dryRun verification", {
         sessionId: session.id,
       });
-      return;
+      continue;
     }
     if (match.runtimeMatch || match.creationMatch) {
       await storageService.storeMatch(checkedContract, match);


### PR DESCRIPTION
This PR fixes an issue when verifying multi-contract files with the `dryrun` flag enabled. The `dryrun` flag has been introduced in this PR https://github.com/ethereum/sourcify/pull/1343. When the logs were introduced in https://github.com/ethereum/sourcify/pull/1343/commits/8e78090d2416b3b80cd3a9e8cc34510717d92345, it changed the semantics. This PR fixes that.

### How to reproduce it

Deploy the `SupraOracle` contract from this Hardhat project output [1cd581d3e27dff8cf701d43118fc3bdc.json](https://github.com/ethereum/sourcify/files/15393073/1cd581d3e27dff8cf701d43118fc3bdc.json).

Use the above output artifact in the `input-files?dryrun=true` endpoint.

Then the `verify-checked?dryrun=true` endpoint returns the contracts with `status: "error"`, but the `SupraOracle` should have `status: "perfect"`.
