### PR TITLE
Add `/files/contracts/partial/{chain}` endpoint and explicit ordering, resolve SQL NULL comparison bug

### DIFF
--- a/services/server/src/server/controllers/repository/get-contract-addresses-paginated-full.stateless.paths.yaml
+++ b/services/server/src/server/controllers/repository/get-contract-addresses-paginated-full.stateless.paths.yaml
@@ -26,6 +26,14 @@ paths:
             type: number
             minimum: 1
             maximum: 200
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+          description: Order of the results. Default is "asc" (earliest verified contract first)
+
       responses:
         "200":
           description: Chain is available as a full match in the repository

--- a/services/server/src/server/controllers/repository/get-contract-addresses-paginated-partial.stateless.paths.yaml
+++ b/services/server/src/server/controllers/repository/get-contract-addresses-paginated-partial.stateless.paths.yaml
@@ -1,10 +1,10 @@
 openapi: "3.0.0"
 
 paths:
-  /files/contracts/any/{chain}:
+  /files/contracts/partial/{chain}:
     get:
-      summary: Get the contract addresses verified on a chain (full or partial match)
-      description: Returns the verified contracts from the repository for the desired chain. Searches for full and partial matches. API is paginated. Limit must be a number between 1 and 200.
+      summary: Get the contract addresses partially verified on a chain
+      description: Returns the partially verified contracts from the repository for the desired chain. API is paginated. Limit must be a number between 1 and 200.
       tags:
         - Repository
       parameters:
@@ -35,7 +35,7 @@ paths:
           description: Order of the results. Default is "asc" (earliest verified contract first)
       responses:
         "200":
-          description: Chain is available as a full match or partial match in the repository
+          description: Chain is available as a full match in the repository
           content:
             application/json:
               schema:

--- a/services/server/src/server/controllers/repository/repository.handlers.ts
+++ b/services/server/src/server/controllers/repository/repository.handlers.ts
@@ -21,7 +21,8 @@ type PaginatedConractRetrieveMethod = (
   chain: string,
   match: MatchLevel,
   page: number,
-  limit: number
+  limit: number,
+  descending: boolean
 ) => Promise<PaginatedContractData>;
 
 export function createEndpoint(
@@ -75,7 +76,8 @@ export function createPaginatedContractEndpoint(
         req.params.chain,
         match,
         parseInt((req.query.page as string) || "0"),
-        parseInt((req.query.limit as string) || "200")
+        parseInt((req.query.limit as string) || "200"),
+        req.query.order === "desc" // default is asc
       );
     } catch (err: any) {
       return next(new NotFoundError(err.message));

--- a/services/server/src/server/controllers/repository/repository.routes.ts
+++ b/services/server/src/server/controllers/repository/repository.routes.ts
@@ -52,23 +52,52 @@ const router: Router = Router();
   {
     prefix: "/contracts/full",
     method: createPaginatedContractEndpoint(
-      (chain, match, page, limit) =>
-        services.storage.getPaginatedContracts(chain, match, page, limit),
+      (chain, match, page, limit, descending) =>
+        services.storage.getPaginatedContracts(
+          chain,
+          match,
+          page,
+          limit,
+          descending
+        ),
       "full_match"
+    ),
+  },
+  {
+    prefix: "/contracts/partial",
+    method: createPaginatedContractEndpoint(
+      (chain, match, page, limit, descending) =>
+        services.storage.getPaginatedContracts(
+          chain,
+          match,
+          page,
+          limit,
+          descending
+        ),
+      "partial_match"
     ),
   },
   {
     prefix: "/contracts/any",
     method: createPaginatedContractEndpoint(
-      (chain, match, page, limit) =>
-        services.storage.getPaginatedContracts(chain, match, page, limit),
+      (chain, match, page, limit, descending) =>
+        services.storage.getPaginatedContracts(
+          chain,
+          match,
+          page,
+          limit,
+          descending
+        ),
       "any_match"
     ),
   },
   {
     prefix: "",
     method: createEndpoint(
-      (chain, address, match) => services.storage.getContent(chain, address, match), "full_match"),
+      (chain, address, match) =>
+        services.storage.getContent(chain, address, match),
+      "full_match"
+    ),
   },
 ].forEach((pair) => {
   router

--- a/services/server/src/server/services/StorageService.ts
+++ b/services/server/src/server/services/StorageService.ts
@@ -277,14 +277,16 @@ export class StorageService {
     chainId: string,
     match: MatchLevel,
     page: number,
-    limit: number
+    limit: number,
+    descending: boolean = false
   ): Promise<PaginatedContractData> => {
     try {
       return this.sourcifyDatabase!.getPaginatedContracts(
         chainId,
         match,
         page,
-        limit
+        limit,
+        descending
       );
     } catch (error) {
       logger.error("Error while getting paginated contracts from database", {
@@ -292,6 +294,7 @@ export class StorageService {
         match,
         page,
         limit,
+        descending,
         error,
       });
       throw new Error("Error while getting paginated contracts from database");

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -426,52 +426,6 @@ export async function insertSourcifyMatch(
   );
 }
 
-export async function insertSourcifySync(
-  pool: Pool,
-  { chain_id, address, match_type }: Tables.SourcifySync
-) {
-  // I'm doing this because before passing the match_type I'm calling getMatchStatus(match)
-  // but then I need to convert the status to full_match | partial_match
-  let matchType;
-  switch (match_type) {
-    case "perfect":
-      matchType = "full_match";
-      break;
-    case "partial":
-      matchType = "partial_match";
-      break;
-  }
-  await pool.query(
-    `INSERT INTO sourcify_sync 
-      (chain_id, address, match_type, synced)
-      VALUES ($1, $2, $3, true)`,
-    [chain_id, address, match_type]
-  );
-}
-
-export async function updateSourcifySync(
-  pool: Pool,
-  { chain_id, address, match_type }: Tables.SourcifySync
-) {
-  // I'm doing this because before passing the match_type I'm calling getMatchStatus(match)
-  // but then I need to convert the status to full_match | partial_match
-  let matchType;
-  switch (match_type) {
-    case "perfect":
-      matchType = "full_match";
-      break;
-    case "partial":
-      matchType = "partial_match";
-      break;
-  }
-  await pool.query(
-    `UPDATE sourcify_sync SET
-      match_type=$3
-    WHERE chain_id=$1 AND address=$2;`,
-    [chain_id, address, match_type]
-  );
-}
-
 // Update sourcify_matches to the latest (and better) match in verified_contracts,
 // you need to pass the old verified_contract_id to be updated.
 // The old verified_contracts are not deleted from the verified_contracts table.

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -595,7 +595,8 @@ export async function getSourcifyMatchAddressesByChainAndMatch(
   chain: number,
   match: "full_match" | "partial_match" | "any_match",
   page: number,
-  paginationSize: number
+  paginationSize: number,
+  descending: boolean = false
 ) {
   let queryWhere = "";
   switch (match) {
@@ -617,6 +618,13 @@ export async function getSourcifyMatchAddressesByChainAndMatch(
       throw new Error("Match type not supported");
     }
   }
+
+  if (descending) {
+    queryWhere += " ORDER BY verified_contracts.id DESC";
+  } else {
+    queryWhere += " ORDER BY verified_contracts.id ASC";
+  }
+
   return await pool.query(
     `
     SELECT

--- a/services/server/src/server/types.ts
+++ b/services/server/src/server/types.ts
@@ -1,9 +1,9 @@
 // Types used internally by the server.
 
 /**
- * A type for specfifying the strictness level of querying (only full or any kind of matches)
+ * A type for specfifying the strictness level of querying (only full, partial or any kind of matches)
  */
-export type MatchLevel = "full_match" | "any_match";
+export type MatchLevel = "full_match" | "partial_match" | "any_match";
 
 /**
  * An array wrapper with info properties.

--- a/services/server/test/helpers/LocalChainFixture.ts
+++ b/services/server/test/helpers/LocalChainFixture.ts
@@ -8,6 +8,7 @@ import { LOCAL_CHAINS } from "../../src/sourcify-chains";
 import nock from "nock";
 import storageContractArtifact from "../testcontracts/Storage/Storage.json";
 import storageContractMetadata from "../testcontracts/Storage/metadata.json";
+import storageContractMetadataModified from "../testcontracts/Storage/metadataModified.json";
 
 const storageContractSourcePath = path.join(
   __dirname,
@@ -30,7 +31,10 @@ export class LocalChainFixture {
   defaultContractMetadata = Buffer.from(
     JSON.stringify(storageContractMetadata)
   );
-  defaultContractModifiedIpfsMetadata = getModifiedIpfsMetadata();
+  defaultContractModifiedMetadata = Buffer.from(
+    JSON.stringify(storageContractMetadataModified)
+  );
+  defaultContractModifiedSourceIpfs = getModifiedSourceIpfs();
   defaultContractArtifact = storageContractArtifact;
 
   private _chainId?: string;
@@ -111,7 +115,8 @@ export class LocalChainFixture {
   }
 }
 
-function getModifiedIpfsMetadata(): Buffer {
+// Changes the IPFS hash inside the metadata file to make the source unfetchable
+function getModifiedSourceIpfs(): Buffer {
   const ipfsAddress =
     storageContractMetadata.sources["project:/contracts/Storage.sol"].urls[1];
   // change the last char in ipfs hash of the source file

--- a/services/server/test/helpers/ServerFixture.ts
+++ b/services/server/test/helpers/ServerFixture.ts
@@ -83,6 +83,7 @@ export class ServerFixture {
     beforeEach(async () => {
       rimraf.sync(this.server.repository);
       await resetDatabase(this.storageService);
+      console.log("Resetting the StorageService");
     });
 
     after(() => {

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -71,7 +71,8 @@ export async function deployFromAbiAndBytecodeForCreatorTxHash(
 export async function deployAndVerifyContract(
   chai: Chai.ChaiStatic,
   chainFixture: LocalChainFixture,
-  serverFixture: ServerFixture
+  serverFixture: ServerFixture,
+  partial: boolean = false
 ) {
   const contractAddress = await deployFromAbiAndBytecode(
     chainFixture.localSigner,
@@ -84,7 +85,13 @@ export async function deployAndVerifyContract(
     .post("/")
     .field("address", contractAddress)
     .field("chain", chainFixture.chainId)
-    .attach("files", chainFixture.defaultContractMetadata, "metadata.json")
+    .attach(
+      "files",
+      partial
+        ? chainFixture.defaultContractModifiedMetadata
+        : chainFixture.defaultContractMetadata,
+      "metadata.json"
+    )
     .attach("files", chainFixture.defaultContractSource);
   return contractAddress;
 }

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -17,6 +17,7 @@ import { promises as fs } from "fs";
 import { StorageService } from "../../src/server/services/StorageService";
 import { ServerFixture } from "./ServerFixture";
 import type { Done } from "mocha";
+import { LocalChainFixture } from "./LocalChainFixture";
 
 chai.use(chaiHttp);
 
@@ -66,6 +67,28 @@ export async function deployFromAbiAndBytecodeForCreatorTxHash(
 
   return { contractAddress, txHash: creationTx.hash };
 }
+
+export async function deployAndVerifyContract(
+  chai: Chai.ChaiStatic,
+  chainFixture: LocalChainFixture,
+  serverFixture: ServerFixture
+) {
+  const contractAddress = await deployFromAbiAndBytecode(
+    chainFixture.localSigner,
+    chainFixture.defaultContractArtifact.abi,
+    chainFixture.defaultContractArtifact.bytecode,
+    []
+  );
+  await chai
+    .request(serverFixture.server.app)
+    .post("/")
+    .field("address", contractAddress)
+    .field("chain", chainFixture.chainId)
+    .attach("files", chainFixture.defaultContractMetadata, "metadata.json")
+    .attach("files", chainFixture.defaultContractSource);
+  return contractAddress;
+}
+
 /**
  * Function to deploy contracts from an external account with private key
  */

--- a/services/server/test/integration/repository-handlers/files.spec.ts
+++ b/services/server/test/integration/repository-handlers/files.spec.ts
@@ -40,7 +40,7 @@ describe("Verify repository endpoints", function () {
     chai.expect(res4.body.full).has.a.lengthOf(1);
   });
 
-  describe.only(`Pagination in /files/contracts/{full|any|partial}/${chainFixture.chainId}`, async function () {
+  describe(`Pagination in /files/contracts/{full|any|partial}/${chainFixture.chainId}`, async function () {
     const endpointMatchTypes = ["full", "any", "partial"];
     for (const endpointMatchType of endpointMatchTypes) {
       it(`should handle pagination in /files/contracts/${endpointMatchType}/${chainFixture.chainId}`, async function () {

--- a/services/server/test/integration/verification-handlers/verify.session.spec.ts
+++ b/services/server/test/integration/verification-handlers/verify.session.spec.ts
@@ -297,7 +297,7 @@ describe("/session", function () {
     const agent = chai.request.agent(serverFixture.server.app);
     agent
       .post("/session/input-files")
-      .attach("files", chainFixture.defaultContractModifiedIpfsMetadata)
+      .attach("files", chainFixture.defaultContractModifiedSourceIpfs)
       .then((res) => {
         assertAddressAndChainMissing(res, [], {
           "project:/contracts/Storage.sol": {

--- a/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
+++ b/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
@@ -137,7 +137,7 @@ describe("/", function () {
       .field("chain", chainFixture.chainId)
       .attach(
         "files",
-        chainFixture.defaultContractModifiedIpfsMetadata,
+        chainFixture.defaultContractModifiedSourceIpfs,
         "metadata.json"
       )
       .end((err, res) => {


### PR DESCRIPTION
This PR was intended to add the `/files/contracts/partial/{chain}` endpoint that is missing to list all contracts under a certain chain.

However during the process, specifically when adding proper tests, I've noticed the `partial` and `any` endpoints not working as expected, and some other potential issues explained below for further investigation. 

TLDR;
- Adding the `/files/contracts/partial/{chain}` endpoint as specified in #1415 with an option to sort `asc` and `desc`
- Adding tests
- [SQL NULL comparison bug](#sql-null-comparison-bug)
- Potential issues:
  - [Deduplication not working in `compiled_contracts`](#deduplication-not-working-in-compiled_contracts)
  - [`matchType` not used in `database-utils.ts`](#matchtype-not-used-in-database-utils-ts)

## SQL NULL comparison bug
This was due to the queries being used in `countSourcifyMatchAddresses` and `getSourcifyMatchAddressesByChainAndMatch`. 

Both SQL queries count the number of perfect matches with `creation_match = 'perfect' OR runtime_match = 'perfect'` and the partial matches with the logical inverse `creation_match != 'perfect' AND runtime_match != 'perfect'`. However this does not work as expected in SQL because the `creation_match` field in our case can be `NULL` and any comparison with `NULL` resolves to `NULL`, and not to `true` as expected. 

This can also be seen by comparing the contract numbers in `stats.json` vs the API output:

`/stats.json` for Mainnet:
```js
  "1": {
    ...
    "full_match": 131482,
    "partial_match": 529877,
  },
  // total: 661,359
```

`/files/contracts/full/1/`:
```
"pagination": {
    ...
    "totalResults": 132056
  }
```

`/files/contracts/any/1/`:
```
"pagination": {
    ...
    "totalResults": 273320
  }
```

The difference (i.e. partial count) gives 141,264 whereas from stats.json we've got 529,877. 

The bug can be resolved by adding a `COALESCE(creation_match, '')` to make the `NULL` values `''` for comparisons. 


# Potential issues

## Deduplication not working in `compiled_contracts`

When debugging the tests I've noticed the identical test contracts are getting added to the `compiled_contracts` table multiple times. I'd have expected them to be deduplicated because the table has a unique key property in the schema definition:
https://github.com/ethereum/sourcify/blob/653952de199123406cea9c3ebda4eda88cc0652a/services/database/migrations/20231109160022-create-alliance-schema.js#L204

However during testing the contracts get added multiple times:
```SQL
SELECT compiler, "language", creation_code_hash, runtime_code_hash FROM public.compiled_contracts x
```
<img width="757" alt="image" src="https://github.com/ethereum/sourcify/assets/13069972/ce877a1f-5e6a-48de-a1e4-2127b67fb8f2">

Am I missing something or is there something wrong?

### To reproduce

1) add a breakpoint at
https://github.com/ethereum/sourcify/blob/653952de199123406cea9c3ebda4eda88cc0652a/services/server/test/integration/repository-handlers/files.spec.ts#L56

2) Add an `.only` modifier to describe:
https://github.com/ethereum/sourcify/blob/653952de199123406cea9c3ebda4eda88cc0652a/services/server/test/integration/repository-handlers/files.spec.ts#L43

3) run the `Mocha - Server Integration`, deploy and verify multiple contracts, and connect to the test database at `localhost:5431`.


### `matchType` in `database_utils.ts` 

While looking at the `database_utils.ts` code I've noticed the `matchType` variable is not used in functions:
https://github.com/ethereum/sourcify/blob/eeec8244c25db361f2f94981268118b188c1f53a/services/server/src/server/services/utils/database-util.ts#L429

https://github.com/ethereum/sourcify/blob/eeec8244c25db361f2f94981268118b188c1f53a/services/server/src/server/services/utils/database-util.ts#L452

But it seems these functions themselves are not used at all. Can they be removed?