### PR TITLE
Init compilers

### DIFF
--- a/packages/lib-sourcify/src/lib/CheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/CheckedContract.ts
@@ -15,7 +15,7 @@ import {
   StringMap,
 } from './types';
 import semver from 'semver';
-import { fetchWithTimeout } from './utils';
+import { fetchWithBackoff } from './utils';
 import { storeByHash } from './validation';
 import {
   decode as decodeBytecode,
@@ -28,7 +28,6 @@ import { ISolidityCompiler } from './ISolidityCompiler';
 
 // TODO: find a better place for these constants. Reminder: this sould work also in the browser
 const IPFS_PREFIX = 'dweb:/ipfs/';
-const FETCH_TIMEOUT = parseInt(process.env.FETCH_TIMEOUT || '') || 3000; // ms
 /**
  * Abstraction of a checked solidity contract. With metadata and source (solidity) files.
  */
@@ -573,18 +572,7 @@ export async function performFetch(
     hash,
     fileName,
   });
-  const res = await fetchWithTimeout(url, { timeout: FETCH_TIMEOUT }).catch(
-    (err) => {
-      if (err.type === 'aborted')
-        logWarn('Timeout fetching the file', {
-          url,
-          hash,
-          fileName,
-          timeout: FETCH_TIMEOUT,
-        });
-      else logError(err);
-    },
-  );
+  const res = await fetchWithBackoff(url);
 
   if (res) {
     if (res.status === 200) {

--- a/packages/lib-sourcify/src/lib/CheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/CheckedContract.ts
@@ -572,7 +572,9 @@ export async function performFetch(
     hash,
     fileName,
   });
-  const res = await fetchWithBackoff(url);
+  const res = await fetchWithBackoff(url).catch((err) => {
+    logError(err);
+  });
 
   if (res) {
     if (res.status === 200) {

--- a/packages/lib-sourcify/src/lib/utils.ts
+++ b/packages/lib-sourcify/src/lib/utils.ts
@@ -1,26 +1,57 @@
-import { logWarn } from './logger';
+import { logDebug, logError } from './logger';
 
-interface RequestInitTimeout extends RequestInit {
-  timeout?: number;
-}
-
-export async function fetchWithTimeout(
+/**
+ * Fetches a resource with an exponential timeout.
+ * 1) Send req, wait backoff * 2^0 ms, abort if doesn't resolve
+ * 2) Send req, wait backoff * 2^1 ms, abort if doesn't resolve
+ * 3) Send req, wait backoff * 2^2 ms, abort if doesn't resolve...
+ * ...
+ * ...
+ */
+export async function fetchWithBackoff(
   resource: string,
-  options: RequestInitTimeout = {},
+  backoff: number = 10000,
+  retries: number = 4,
 ) {
-  const { timeout = 10000 } = options;
+  let timeout = backoff;
 
-  const controller = new AbortController();
-  const id = setTimeout(() => {
-    logWarn('Aborting request', { resource, timeout });
-    controller.abort();
-  }, timeout);
-  const response = await fetch(resource, {
-    ...options,
-    signal: controller.signal,
-  });
-  clearTimeout(id);
-  return response;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      logDebug('Start fetchWithBackoff', { resource, timeout, attempt });
+      const controller = new AbortController();
+      const id = setTimeout(() => {
+        logDebug('Aborting request', { resource, timeout, attempt });
+        controller.abort();
+      }, timeout);
+      const response = await fetch(resource, {
+        signal: controller.signal,
+      });
+      logDebug('Success fetchWithBackoff', { resource, timeout, attempt });
+      clearTimeout(id);
+      return response;
+    } catch (error) {
+      if (attempt === retries) {
+        logError('Failed fetchWithBackoff', {
+          resource,
+          attempt,
+          retries,
+          timeout,
+          error,
+        });
+        throw new Error(`Failed fetching ${resource}: ${error}`);
+      } else {
+        timeout *= 2; // exponential backoff
+        logDebug('Retrying fetchWithBackoff', {
+          resource,
+          attempt,
+          timeout,
+          error,
+        });
+        continue;
+      }
+    }
+  }
+  throw new Error(`Failed fetching ${resource}`);
 }
 
 export const replaceBytecodeAuxdatasWithZeros = (

--- a/serverless/compiler-lambda/index.js
+++ b/serverless/compiler-lambda/index.js
@@ -6,20 +6,45 @@ const solc = require("solc");
 const pipeline = require("util").promisify(require("stream").pipeline);
 const { Blob } = require("buffer");
 
-async function fetchWithTimeout(resource, options = {}) {
-  const { timeout = 30000 } = options;
+/**
+ * Fetches a resource with an exponential timeout.
+ * 1) Send req, wait backoff * 2^0 ms, abort if doesn't resolve
+ * 2) Send req, wait backoff * 2^1 ms, abort if doesn't resolve
+ * 3) Send req, wait backoff * 2^2 ms, abort if doesn't resolve...
+ * ...
+ * ...
+ */
+export async function fetchWithBackoff(resource, backoff = 10000, retries = 4) {
+  let timeout = backoff;
 
-  const controller = new AbortController();
-  const id = setTimeout(() => {
-    console.warn(`Aborting request ${resource} because of timout ${timeout}`);
-    controller.abort();
-  }, timeout);
-  const response = await fetch(resource, {
-    ...options,
-    signal: controller.signal,
-  });
-  clearTimeout(id);
-  return response;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const id = setTimeout(() => {
+        controller.abort();
+      }, timeout);
+      const response = await fetch(resource, {
+        signal: controller.signal,
+      });
+      clearTimeout(id);
+      return response;
+    } catch (error) {
+      if (attempt === retries) {
+        console.error("Failed fetchWithBackoff", {
+          resource,
+          attempt,
+          retries,
+          timeout,
+          error,
+        });
+        throw new Error(`Failed fetching ${resource}: ${error}`);
+      } else {
+        timeout *= 2; // exponential backoff
+        continue;
+      }
+    }
+  }
+  throw new Error(`Failed fetching ${resource}`);
 }
 
 const HOST_SOLC_REPO = " https://binaries.soliditylang.org/";
@@ -89,11 +114,11 @@ async function useCompiler(version, solcJsonInput, forceEmscripten = false) {
   }
   const compiledJSON = JSON.parse(compiled);
   const errorMessages = compiledJSON?.errors?.filter(
-    (e) => e.severity === "error"
+    (e) => e.severity === "error",
   );
   if (errorMessages && errorMessages.length > 0) {
     const error = new Error(
-      "Compiler error:\n " + JSON.stringify(errorMessages)
+      "Compiler error:\n " + JSON.stringify(errorMessages),
     );
     console.error(error.message);
     throw error;
@@ -104,7 +129,7 @@ async function useCompiler(version, solcJsonInput, forceEmscripten = false) {
 async function getAllMetadataAndSourcesFromSolcJson(solcJson, compilerVersion) {
   if (solcJson.language !== "Solidity")
     throw new Error(
-      "Only Solidity is supported, the json has language: " + solcJson.language
+      "Only Solidity is supported, the json has language: " + solcJson.language,
     );
 
   const outputSelection = {
@@ -145,17 +170,17 @@ async function getSolcExecutable(platform, version) {
   const solcPath = path.join(repoPath, fileName);
   if (fs.existsSync(solcPath) && validateSolcPath(solcPath)) {
     console.debug(
-      `Found solc ${version} with platform ${platform} at ${solcPath}`
+      `Found solc ${version} with platform ${platform} at ${solcPath}`,
     );
     return solcPath;
   }
 
   console.debug(
-    `Downloading solc ${version} with platform ${platform} at ${solcPath}`
+    `Downloading solc ${version} with platform ${platform} at ${solcPath}`,
   );
   const success = await fetchAndSaveSolc(platform, solcPath, version, fileName);
   console.debug(
-    `Downloaded solc ${version} with platform ${platform} at ${solcPath}`
+    `Downloaded solc ${version} with platform ${platform} at ${solcPath}`,
   );
   if (success && !validateSolcPath(solcPath)) {
     console.error(`Cannot validate solc ${version}.`);
@@ -189,9 +214,9 @@ async function fetchAndSaveSolc(platform, solcPath, version, fileName) {
   const encodedURIFilename = encodeURIComponent(fileName);
   const githubSolcURI = `${HOST_SOLC_REPO}${platform}/${encodedURIFilename}`;
   console.debug(
-    `Fetching solc ${version} on platform ${platform}: ${githubSolcURI}`
+    `Fetching solc ${version} on platform ${platform}: ${githubSolcURI}`,
   );
-  let res = await fetchWithTimeout(githubSolcURI);
+  let res = await fetchWithBackoff(githubSolcURI);
   let status = res.status;
   let buffer;
 
@@ -203,7 +228,7 @@ async function fetchAndSaveSolc(platform, solcPath, version, fileName) {
       /^([\w-]+)-v(\d+\.\d+\.\d+)\+commit\.([a-fA-F0-9]+).*$/.test(responseText)
     ) {
       const githubSolcURI = `${HOST_SOLC_REPO}${platform}/${responseText}`;
-      res = await fetchWithTimeout(githubSolcURI);
+      res = await fetchWithBackoff(githubSolcURI);
       status = res.status;
       buffer = await res.arrayBuffer();
     }
@@ -211,7 +236,7 @@ async function fetchAndSaveSolc(platform, solcPath, version, fileName) {
 
   if (status === 200 && buffer) {
     console.debug(
-      `Fetched solc ${version} on platform ${platform}: ${githubSolcURI}`
+      `Fetched solc ${version} on platform ${platform}: ${githubSolcURI}`,
     );
     fs.mkdirSync(path.dirname(solcPath), { recursive: true });
 
@@ -282,12 +307,12 @@ function asyncExecSolc(inputStringified, solcPath) {
           reject(error);
         } else if (stderr) {
           reject(
-            new Error(`Compiler process returned with errors:\n ${stderr}`)
+            new Error(`Compiler process returned with errors:\n ${stderr}`),
           );
         } else {
           resolve(stdout);
         }
-      }
+      },
     );
     if (!child.stdin) {
       throw new Error("No stdin on child process");
@@ -309,7 +334,7 @@ exports.handler = awslambda.streamifyResponse(
       output = await useCompiler(
         event.version,
         event.solcJsonInput,
-        event.forceEmscripten
+        event.forceEmscripten,
       );
     } catch (e) {
       output = { error: e.message };
@@ -326,7 +351,7 @@ exports.handler = awslambda.streamifyResponse(
     }
 
     await pipeline(outputBlob.stream(), responseStream);
-  }
+  },
 );
 
 /* exports

--- a/services/server/.env.test
+++ b/services/server/.env.test
@@ -8,7 +8,6 @@ NODE_CONFIG_ENV=test
 NODE_CONFIG_DIR=./src/config
 IPFS_GATEWAY=http://ipfs-mock/ipfs/
 # instantiated http-gateway takes a little longer
-FETCH_TIMEOUT=8000
 ALLIANCE_POSTGRES_HOST=
 
 SOURCIFY_POSTGRES_HOST="localhost"

--- a/services/server/src/config/default.js
+++ b/services/server/src/config/default.js
@@ -45,6 +45,8 @@ module.exports = {
     enabled: false,
     // functionName: "compile",
   },
+  // If true, downloads all production version compilers and saves them.
+  initCompilers: false,
   corsAllowedOrigins: [
     /^https?:\/\/(?:.+\.)?sourcify.dev$/, // sourcify.dev and subdomains
     /^https?:\/\/(?:.+\.)?sourcify.eth$/, // sourcify.eth and subdomains

--- a/services/server/src/config/migration.js
+++ b/services/server/src/config/migration.js
@@ -34,6 +34,7 @@ module.exports = {
     functionName: "compile",
     // credentials as env vars
   },
+  initCompilers: true,
   rateLimit: {
     enabled: false,
     windowMs: 1 * 1000, // 1 sec

--- a/services/server/src/server/controllers/verification/verification.common.ts
+++ b/services/server/src/server/controllers/verification/verification.common.ts
@@ -19,7 +19,7 @@ import {
 import { Session } from "express-session";
 import { AbiConstructor, AbiParameter } from "abitype";
 import QueryString from "qs";
-import { IVerificationService } from "../../services/VerificationService";
+import { VerificationService } from "../../services/VerificationService";
 import { ContractMeta, ContractWrapper, getMatchStatus } from "../../common";
 import { ISolidityCompiler } from "@ethereum-sourcify/lib-sourcify";
 import { SolcLambdaWithLocalFallback } from "../../services/compiler/lambda-with-fallback/SolcLambdaWithLocalFallback";
@@ -343,7 +343,7 @@ export function isVerifiable(contractWrapper: ContractWrapper) {
 export const verifyContractsInSession = async (
   contractWrappers: ContractWrapperMap = {},
   session: Session,
-  verificationService: IVerificationService,
+  verificationService: VerificationService,
   storageService: StorageService,
   dryRun: boolean = false,
 ): Promise<void> => {

--- a/services/server/src/server/services/StorageService.ts
+++ b/services/server/src/server/services/StorageService.ts
@@ -212,33 +212,18 @@ export class StorageService {
       ...this.getWriteOrErrServices(),
     ].filter((service) => service !== undefined) as WStorageService[];
 
-    // Create object: StorageIdentifier => Storage
-    const enabledServices = enabledServicesArray.reduce(
-      (
-        services: { [key in StorageIdentifiers]: WStorageService },
-        service: WStorageService,
-      ) => {
-        services[service.IDENTIFIER] = service;
-        return services;
-      },
-      {} as { [key in StorageIdentifiers]: WStorageService },
-    );
-
     logger.debug("Initializing used storage services", {
-      storageServices: Object.keys(enabledServices),
+      storageServices: enabledServicesArray.map(
+        (service) => service.IDENTIFIER,
+      ),
     });
 
     // Try to initialize used storage services
-    for (const serviceIdentifier of Object.keys(
-      enabledServices,
-    ) as RWStorageIdentifiers[]) {
-      if (
-        !(await { ...this.rwServices, ...this.wServices }[
-          serviceIdentifier
-        ].init())
-      ) {
+    for (const service of enabledServicesArray) {
+      logger.debug(`Initializing storage service: ${service.IDENTIFIER}`);
+      if (!(await service.init())) {
         throw new Error(
-          "Cannot initialize default storage service: " + serviceIdentifier,
+          "Cannot initialize default storage service: " + service.IDENTIFIER,
         );
       }
     }

--- a/services/server/src/server/services/VerificationService.ts
+++ b/services/server/src/server/services/VerificationService.ts
@@ -7,25 +7,75 @@ import {
 import { getCreatorTx } from "./utils/contract-creation-util";
 import { ContractIsAlreadyBeingVerifiedError } from "../../common/errors/ContractIsAlreadyBeingVerifiedError";
 import logger from "../../common/logger";
+import {
+  findSolcPlatform,
+  getSolcExecutable,
+  getSolcJs,
+} from "./compiler/local/solidityCompiler";
 
-export interface IVerificationService {
+export interface VerificationServiceOptions {
+  initCompilers: boolean;
   supportedChainsMap: SourcifyChainMap;
-  verifyDeployed(
-    checkedContract: CheckedContract,
-    chainId: string,
-    address: string,
-    creatorTxHash?: string,
-  ): Promise<Match>;
 }
 
-export class VerificationService implements IVerificationService {
+export class VerificationService {
+  initCompilers: boolean;
   supportedChainsMap: SourcifyChainMap;
   activeVerificationsByChainIdAddress: {
     [chainIdAndAddress: string]: boolean;
   } = {};
 
-  constructor(supportedChainsMap: SourcifyChainMap) {
-    this.supportedChainsMap = supportedChainsMap;
+  constructor(options: VerificationServiceOptions) {
+    this.supportedChainsMap = options.supportedChainsMap;
+    this.initCompilers = options.initCompilers;
+  }
+
+  // All of the solidity compilation actually run outside the VerificationService but this is an OK place to init everything.
+  public async init() {
+    const HOST_SOLC_REPO = "https://binaries.soliditylang.org/";
+
+    if (this.initCompilers) {
+      const platform = findSolcPlatform() || "bin"; // fallback to emscripten binaries "bin"
+      logger.info(`Initializing compilers for platform ${platform}`);
+
+      // solc binary and solc-js downloads are handled with different helpers
+      const downLoadFunc =
+        platform === "bin"
+          ? (version: string) => getSolcJs(version)
+          : (version: string) => getSolcExecutable(platform, version);
+
+      // get the list of compiler versions
+      const solcList = await fetch(`${HOST_SOLC_REPO}${platform}/list.json`)
+        .then((response) => response.json())
+        .then((data) =>
+          (Object.values(data.releases) as string[])
+            .map((str) => str.split("-v")[1]) // e.g. soljson-v0.8.26+commit.8a97fa7a.js or solc-linux-amd64-v0.8.26+commit.8a97fa7a
+            .map(
+              (str) => (str.endsWith(".js") ? str.slice(0, -3) : str), // remove .js extension
+            ),
+        );
+
+      const chunkSize = 10; // Download in chunks to not overload the Solidity server all at once
+      for (let i = 0; i < solcList.length; i += chunkSize) {
+        const chunk = solcList.slice(i, i + chunkSize);
+        const promises = chunk.map((solcVer) => {
+          const now = Date.now();
+          return downLoadFunc(solcVer).then(() => {
+            logger.debug(
+              `Downloaded compiler ${solcVer} in ${Date.now() - now}ms`,
+            );
+          });
+        });
+
+        await Promise.all(promises);
+        logger.debug(
+          `Batch ${i / chunkSize + 1} - Downloaded ${promises.length} - Total ${i + chunkSize}/${solcList.length}`,
+        );
+      }
+
+      logger.info("Initialized compilers");
+    }
+    return true;
   }
 
   private throwIfContractIsAlreadyBeingVerified(

--- a/services/server/src/server/services/VerificationService.ts
+++ b/services/server/src/server/services/VerificationService.ts
@@ -62,7 +62,7 @@ export class VerificationService {
           const now = Date.now();
           return downLoadFunc(solcVer).then(() => {
             logger.debug(
-              `Downloaded compiler ${solcVer} in ${Date.now() - now}ms`,
+              `Downloaded (or found existing) compiler ${solcVer} in ${Date.now() - now}ms`,
             );
           });
         });

--- a/services/server/src/server/services/VerificationService.ts
+++ b/services/server/src/server/services/VerificationService.ts
@@ -14,7 +14,7 @@ import {
 } from "./compiler/local/solidityCompiler";
 
 export interface VerificationServiceOptions {
-  initCompilers: boolean;
+  initCompilers?: boolean;
   supportedChainsMap: SourcifyChainMap;
 }
 
@@ -27,7 +27,7 @@ export class VerificationService {
 
   constructor(options: VerificationServiceOptions) {
     this.supportedChainsMap = options.supportedChainsMap;
-    this.initCompilers = options.initCompilers;
+    this.initCompilers = options.initCompilers || false;
   }
 
   // All of the solidity compilation actually run outside the VerificationService but this is an OK place to init everything.

--- a/services/server/src/server/services/compiler/local/solidityCompiler.ts
+++ b/services/server/src/server/services/compiler/local/solidityCompiler.ts
@@ -13,35 +13,63 @@ import {
 import config from "config";
 import logger from "../../../../common/logger";
 
-interface RequestInitTimeout extends RequestInit {
-  timeout?: number;
-}
-
-export async function fetchWithTimeout(
+/**
+ * Fetches a resource with an exponential timeout.
+ * 1) Send req, wait backoff * 2^0 ms, abort if doesn't resolve
+ * 2) Send req, wait backoff * 2^1 ms, abort if doesn't resolve
+ * 3) Send req, wait backoff * 2^2 ms, abort if doesn't resolve...
+ * ...
+ * ...
+ */
+export async function fetchWithBackoff(
   resource: string,
-  options: RequestInitTimeout = {},
+  backoff: number = 10000,
+  retries: number = 4,
 ) {
-  const { timeout = 10000 } = options;
+  let timeout = backoff;
 
-  logger.debug("Start fetchWithTimeout", { resource, options });
-  const controller = new AbortController();
-  const id = setTimeout(() => {
-    logger.warn("Aborting request", { resource, options });
-    controller.abort();
-  }, timeout);
-  const response = await fetch(resource, {
-    ...options,
-    signal: controller.signal,
-  });
-  logger.debug("Success fetchWithTimeout", { resource, options });
-  clearTimeout(id);
-  return response;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      logger.debug("Start fetchWithBackoff", { resource, timeout, attempt });
+      const controller = new AbortController();
+      const id = setTimeout(() => {
+        logger.debug("Aborting request", { resource, timeout, attempt });
+        controller.abort();
+      }, timeout);
+      const response = await fetch(resource, {
+        signal: controller.signal,
+      });
+      logger.debug("Success fetchWithBackoff", { resource, timeout, attempt });
+      clearTimeout(id);
+      return response;
+    } catch (error) {
+      if (attempt === retries) {
+        logger.error("Failed fetchWithBackoff", {
+          resource,
+          attempt,
+          retries,
+          timeout,
+          error,
+        });
+        throw new Error(`Failed fetching ${resource}: ${error}`);
+      } else {
+        timeout *= 2; // exponential backoff
+        logger.debug("Retrying fetchWithBackoff", {
+          resource,
+          attempt,
+          timeout,
+          error,
+        });
+        continue;
+      }
+    }
+  }
+  throw new Error(`Failed fetching ${resource}`);
 }
-
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const solc = require("solc");
 
-const HOST_SOLC_REPO = " https://binaries.soliditylang.org/";
+const HOST_SOLC_REPO = "https://binaries.soliditylang.org/";
 
 export function findSolcPlatform(): string | false {
   if (process.platform === "darwin" && process.arch === "x64") {
@@ -237,7 +265,7 @@ async function fetchAndSaveSolc(
   const encodedURIFilename = encodeURIComponent(fileName);
   const githubSolcURI = `${HOST_SOLC_REPO}${platform}/${encodedURIFilename}`;
   logger.info("Fetching solc", { version, platform, githubSolcURI });
-  let res = await fetchWithTimeout(githubSolcURI);
+  let res = await fetchWithBackoff(githubSolcURI);
   let status = res.status;
   let buffer;
 
@@ -249,7 +277,7 @@ async function fetchAndSaveSolc(
       /^([\w-]+)-v(\d+\.\d+\.\d+)\+commit\.([a-fA-F0-9]+).*$/.test(responseText)
     ) {
       const githubSolcURI = `${HOST_SOLC_REPO}${platform}/${responseText}`;
-      res = await fetchWithTimeout(githubSolcURI);
+      res = await fetchWithBackoff(githubSolcURI);
       status = res.status;
       buffer = await res.arrayBuffer();
     }

--- a/services/server/src/server/services/services.ts
+++ b/services/server/src/server/services/services.ts
@@ -1,16 +1,18 @@
-import { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
 import { StorageService, StorageServiceOptions } from "./StorageService";
-import { VerificationService } from "./VerificationService";
+import {
+  VerificationService,
+  VerificationServiceOptions,
+} from "./VerificationService";
 
 export class Services {
   private _verification?: VerificationService;
   private _storage?: StorageService;
 
   constructor(
-    verificationServiceOption: SourcifyChainMap,
+    verificationServiceOptions: VerificationServiceOptions,
     storageServiceOptions: StorageServiceOptions,
   ) {
-    this._verification = new VerificationService(verificationServiceOption);
+    this._verification = new VerificationService(verificationServiceOptions);
     this._storage = new StorageService(storageServiceOptions);
   }
 
@@ -26,5 +28,6 @@ export class Services {
 
   public async init() {
     await this.storage.init();
+    await this.verification.init();
   }
 }

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -63,6 +63,8 @@ export default abstract class AbstractDatabaseService {
       return true;
     }
 
+    logger.debug(`Initializing database pool for ${this.IDENTIFIER}`);
+
     if (this.googleCloudSqlInstanceName) {
       const connector = new Connector();
       const clientOpts = await connector.getOptions({
@@ -90,6 +92,7 @@ export default abstract class AbstractDatabaseService {
 
     // Checking pool health before continuing
     try {
+      logger.debug(`Checking database pool health for ${this.IDENTIFIER}`);
       await this.databasePool.query("SELECT 1;");
     } catch (error) {
       logger.error(`Cannot connect to ${this.IDENTIFIER}`, {

--- a/services/server/test/helpers/ServerFixture.ts
+++ b/services/server/test/helpers/ServerFixture.ts
@@ -77,33 +77,37 @@ export class ServerFixture {
         throw new Error("Not all required environment variables set");
       }
 
-      this._server = new Server(options.port!, supportedChainsMap, {
-        enabledServices: {
-          read: options.read,
-          writeOrWarn: options.writeOrWarn,
-          writeOrErr: options.writeOrErr,
-        },
-        repositoryV1ServiceOptions: {
-          ipfsApi: process.env.IPFS_API as string,
-          repositoryPath: config.get("repositoryV1.path"),
-          repositoryServerUrl: config.get("repositoryV1.serverUrl") as string,
-        },
-        repositoryV2ServiceOptions: {
-          ipfsApi: process.env.IPFS_API as string,
-          repositoryPath: config.has("repositoryV2.path")
-            ? config.get("repositoryV2.path")
-            : undefined,
-        },
-        sourcifyDatabaseServiceOptions: {
-          postgres: {
-            host: process.env.SOURCIFY_POSTGRES_HOST as string,
-            database: process.env.SOURCIFY_POSTGRES_DB as string,
-            user: process.env.SOURCIFY_POSTGRES_USER as string,
-            password: process.env.SOURCIFY_POSTGRES_PASSWORD as string,
-            port: parseInt(process.env.SOURCIFY_POSTGRES_PORT),
+      this._server = new Server(
+        options.port!,
+        { supportedChainsMap },
+        {
+          enabledServices: {
+            read: options.read,
+            writeOrWarn: options.writeOrWarn,
+            writeOrErr: options.writeOrErr,
+          },
+          repositoryV1ServiceOptions: {
+            ipfsApi: process.env.IPFS_API as string,
+            repositoryPath: config.get("repositoryV1.path"),
+            repositoryServerUrl: config.get("repositoryV1.serverUrl") as string,
+          },
+          repositoryV2ServiceOptions: {
+            ipfsApi: process.env.IPFS_API as string,
+            repositoryPath: config.has("repositoryV2.path")
+              ? config.get("repositoryV2.path")
+              : undefined,
+          },
+          sourcifyDatabaseServiceOptions: {
+            postgres: {
+              host: process.env.SOURCIFY_POSTGRES_HOST as string,
+              database: process.env.SOURCIFY_POSTGRES_DB as string,
+              user: process.env.SOURCIFY_POSTGRES_USER as string,
+              password: process.env.SOURCIFY_POSTGRES_PASSWORD as string,
+              port: parseInt(process.env.SOURCIFY_POSTGRES_PORT),
+            },
           },
         },
-      });
+      );
 
       await this._server.services.init();
 


### PR DESCRIPTION
Adds the optional init functin to VerificationService to download all compilers ahead. This is useful for the migration server because when we start hitting the server with a lot of verification requests, they translate into solc download requests and the solc server gets overloaded (like 20 req per chain x 100s chains). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added exponential backoff retry logic for fetching resources to improve reliability.
  - Introduced a new configuration option to control the initialization of compilers.

- **Improvements**
  - Enhanced error handling and logging for fetching resources.
  - Improved clarity and efficiency in the initialization of storage services.
  - Added detailed logging for database pool setup and health checks.

- **Bug Fixes**
  - Removed redundant configuration settings to streamline test environments.

- **Refactor**
  - Updated multiple functions to incorporate exponential backoff strategy.
  - Refined the `VerificationService` to use new options for better configurability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->