### PR TITLE
Renovate: require dependencyDashboardApproval for nock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
       "matchUpdateTypes": ["minor"],
       "groupName": "all minor dependencies",
       "groupSlug": "all-minor"
+    },
+    {
+      "matchPackageNames": ["nock"],
+      "dependencyDashboardApproval": true
     }
   ],
   "major": {


### PR DESCRIPTION
The current renovate PR fails, because the newest nock version causes problems. This disables updates for nock until we could fix it.