### PR TITLE
Oasis chains: add Nexus API fetcher

### DIFF
--- a/packages/lib-sourcify/src/lib/types.ts
+++ b/packages/lib-sourcify/src/lib/types.ts
@@ -295,6 +295,10 @@ export interface FetchContractCreationTxMethods {
     url: string;
   };
   avalancheApi?: boolean;
+  nexusApi?: {
+    url: string;
+    runtime: string;
+  };
 }
 
 export type AlchemyInfuraRPC = {

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -830,8 +830,9 @@
     "sourcifyName": "Oasis Emerald Mainnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://old-explorer.emerald.oasis.dev/"
+      "nexusApi": {
+        "url": "https://nexus.oasis.io/",
+        "runtime": "emerald"
       }
     }
   },
@@ -839,8 +840,9 @@
     "sourcifyName": "Oasis Emerald Testnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://testnet.old-explorer.emerald.oasis.dev/"
+      "nexusApi": {
+        "url": "https://testnet.nexus.oasis.io/",
+        "runtime": "emerald"
       }
     }
   },
@@ -848,8 +850,9 @@
     "sourcifyName": "Oasis Sapphire Mainnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://old-explorer.sapphire.oasis.io/"
+      "nexusApi": {
+        "url": "https://nexus.oasis.io/",
+        "runtime": "sapphire"
       }
     }
   },
@@ -857,8 +860,9 @@
     "sourcifyName": "Oasis Sapphire Testnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://testnet.old-explorer.sapphire.oasis.io/"
+      "nexusApi": {
+        "url": "https://testnet.nexus.oasis.io/",
+        "runtime": "sapphire"
       }
     }
   },

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -129,4 +129,22 @@ describe("contract creation util", function () {
         "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
       );
   });
+
+  it("should run getCreatorTx with nexusApi for Nexus", async function () {
+    const sourcifyChain = sourcifyChainsArray.find(
+      (sourcifyChain) => sourcifyChain.chainId === 23294,
+    );
+    if (!sourcifyChain) {
+      chai.assert.fail("No chain for chainId 23294 configured");
+    }
+    const creatorTx = await getCreatorTx(
+      sourcifyChain,
+      "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
+    );
+    chai
+      .expect(creatorTx)
+      .equals(
+        "0xce775b521cc6e1341020560441d77cd634b0972fc34bf96f79e9fab81caa8ab7",
+      );
+  });
 });


### PR DESCRIPTION
# Update Chains 42261, 42262, 23294, 23295

Oasis chains, namely Sapphire and Emerald are migrating from blockscout to a new explorer backend called Nexus. This adds support for Nexus's API URLs and switches the chain definition to use that.

Oasis Sapphire and Oasis Emerald are "runtimes" (sometimes referred to as ParaTimes in marketing materials) on the Oasis network, so the runtime name is specified as part of the API configuration.

The Oasis Protocol Foundation runs official installations of Nexus at https://nexus.oasis.io (mainnet) and https://testnet.nexus.oasis.io (testnet).