### PR TITLE
Turn off DBs

### DIFF
--- a/services/server/src/config/master.js
+++ b/services/server/src/config/master.js
@@ -1,6 +1,22 @@
+const {
+  RWStorageIdentifiers,
+  WStorageIdentifiers,
+} = require("../server/services/storageServices/identifiers");
+
 module.exports = {
   server: {
     port: 80,
+  },
+  storage: {
+    read: RWStorageIdentifiers.RepositoryV1,
+    writeOrWarn: [
+      // WStorageIdentifiers.AllianceDatabase,
+      RWStorageIdentifiers.RepositoryV1,
+    ],
+    writeOrErr: [
+      WStorageIdentifiers.RepositoryV2,
+      // RWStorageIdentifiers.SourcifyDatabase,
+    ],
   },
   repositoryV1: {
     path: "/home/app/repository",

--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -8,7 +8,7 @@ module.exports = {
     port: 80,
   },
   storage: {
-    read: RWStorageIdentifiers.SourcifyDatabase,
+    read: RWStorageIdentifiers.RepositoryV1,
     writeOrWarn: [
       // WStorageIdentifiers.AllianceDatabase,
       RWStorageIdentifiers.RepositoryV1,

--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -1,6 +1,22 @@
+const {
+  RWStorageIdentifiers,
+  WStorageIdentifiers,
+} = require("../server/services/storageServices/identifiers");
+
 module.exports = {
   server: {
     port: 80,
+  },
+  storage: {
+    read: RWStorageIdentifiers.SourcifyDatabase,
+    writeOrWarn: [
+      // WStorageIdentifiers.AllianceDatabase,
+      RWStorageIdentifiers.RepositoryV1,
+    ],
+    writeOrErr: [
+      WStorageIdentifiers.RepositoryV2,
+      // RWStorageIdentifiers.SourcifyDatabase,
+    ],
   },
   repositoryV1: {
     path: "/home/app/repositoryV1",


### PR DESCRIPTION
Turning off writing to DBs to be able to do a release because the DB schema on prod. is not updated and the release would fail to write contracts. The repo writing logic must be unaffected by the latest changes. We are doing an earlier release to add new chains. The contracts after this change will get written to repoV1/2 and we will add them later during the migration.

And using repoV1 as the read source since writing to the DB is turned off.

Similarly the VerA DB schemas are still not ready. It is ok to have writing to VerA turned off on staging but it would be nice if we could get the VerA schema ready before the prod. migration so that we write everything simulatanously to Sourcify and VerA and don't have to move rows from Sourcify DB to VerA

- [ ] After merge, double check if indeed the staging instance stops writing to the DB