### PR TITLE
Replace fetch with axios in monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11935,7 +11935,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
       "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -30706,7 +30705,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pseudomap": {
@@ -37668,6 +37666,7 @@
       "dependencies": {
         "@ethereum-sourcify/bytecode-utils": "^1.2.9",
         "@ethereum-sourcify/lib-sourcify": "^1.9.0",
+        "axios": "^1.7.2",
         "chalk": "4.1.2",
         "commander": "12.1.0",
         "dotenv": "16.4.5",

--- a/services/monitor/package.json
+++ b/services/monitor/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@ethereum-sourcify/bytecode-utils": "^1.2.9",
     "@ethereum-sourcify/lib-sourcify": "^1.9.0",
+    "axios": "^1.7.2",
     "chalk": "4.1.2",
     "commander": "12.1.0",
     "dotenv": "16.4.5",

--- a/services/monitor/src/PendingContract.ts
+++ b/services/monitor/src/PendingContract.ts
@@ -6,6 +6,7 @@ import { KnownDecentralizedStorageFetchers } from "./types";
 import assert from "assert";
 import dotenv from "dotenv";
 import { Logger } from "winston";
+import axios from "axios";
 
 dotenv.config();
 
@@ -142,13 +143,14 @@ export default class PendingContract {
     }
 
     // Send to Sourcify server.
-    const response = await fetch(sourcifyServerURL, {
+    const response = await axios({
+      url: sourcifyServerURL,
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "sourcify-monitor",
       },
-      body: JSON.stringify({
+      data: JSON.stringify({
         chainId: this.chainId.toString(),
         address: this.address,
         files: {
@@ -168,14 +170,14 @@ export default class PendingContract {
           sourcifyServerURL,
         },
       );
-      return response.json();
+      return response.data;
     } else {
       throw new Error(
         `Error sending contract ${
           this.address
         } to Sourcify server ${sourcifyServerURL}: ${
           response.statusText
-        } ${await response.text()}`,
+        } ${await response.data}`,
       );
     }
   };


### PR DESCRIPTION
The error detail inside "Error sending contract" errors in monitor is just 

```
{
message: "fetch failed"
name: "TypeError"
stack: "TypeError: fetch failed
    at node:internal/deps/undici/undici:13178:13
    at async PendingContract.sendToSourcifyServer (/home/app/services/monitor/dist/PendingContract.js:99:30)
    at async /home/app/services/monitor/dist/ChainMonitor.js:178:25"
}
```

with no additional details. Reading online I found out that is probably a problem with the standard `fetch` API.