### PR TITLE
Add .nx to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 **/tmp
 **/Dockerfile*
 **/.DS_Store
+.nx


### PR DESCRIPTION
When building the containers locally, nx and lerna will encounter a mismatch in device ids because the .nx folder containing the build cache is copied in the building container.

Ignore .nx to do a clean lerna build when building the Docker images locally