### PR TITLE
Update repositories and solc repos paths in staging config

### DIFF
--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -25,8 +25,8 @@ module.exports = {
   repositoryV2: {
     path: "/home/app/data/repositoryV2",
   },
-  solcRepo: "/home/app/compilers/solc",
-  solJsonRepo: "/home/app/compilers/soljson",
+  solcRepo: "/home/app/data/compilers/solc",
+  solJsonRepo: "/home/app/data/compilers/soljson",
   session: {
     secure: true, // Set Secure in the Set-Cookie header i.e. require https
     storeType: "database",

--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -19,11 +19,11 @@ module.exports = {
     ],
   },
   repositoryV1: {
-    path: "/home/app/repositoryV1",
+    path: "/home/app/data/repositoryV1",
     serverUrl: "https://repo.staging.sourcify.dev",
   },
   repositoryV2: {
-    path: "/home/app/repositoryV2",
+    path: "/home/app/data/repositoryV2",
   },
   solcRepo: "/home/app/compilers/solc",
   solJsonRepo: "/home/app/compilers/soljson",


### PR DESCRIPTION
On GCP, repositories and solc repos are not mounted under `/home/app/` but under `/home/app/data/` 