### PR TITLE
Changes to the database sync script

### DIFF
--- a/services/database/scripts.mjs
+++ b/services/database/scripts.mjs
@@ -199,48 +199,68 @@ program
     });
 
     // Get chains from database
-    let chains = [];
+    let chainsFromDB = [];
     const query = "SELECT DISTINCT chain_id FROM sourcify_sync";
     const chainsResult = await executeQueryWithRetry(databasePool, query);
     if (chainsResult.rowCount > 0) {
-      chains = chainsResult.rows.map(({ chain_id }) => chain_id);
+      chainsFromDB = chainsResult.rows.map(({ chain_id }) => chain_id);
     }
 
+    let chainsToSync = [];
     // Specify which chain to sync
     if (options.chains) {
-      chains = chains.filter((chain) =>
+      chainsToSync = chainsFromDB.filter((chain) =>
         options.chains.split(",").includes(`${chain}`),
       );
     }
 
+    let deprecatedChains = [];
     if (options.deprecated?.length > 0) {
-      chains = chains.filter((chain) =>
+      deprecatedChains = chainsFromDB.filter((chain) =>
         options.deprecated?.split(",").includes(`${chain}`),
       );
-    } else {
-      // Remove exceptions using --chainsException and 0
-      chains = chains.filter(
-        (chain) => !options.chainsExceptions?.split(",").includes(`${chain}`),
-      );
     }
+
+    // Remove exceptions using --chainsException and 0
+    chainsToSync = chainsToSync.filter(
+      (chain) => !options.chainsExceptions?.split(",").includes(`${chain}`),
+    );
 
     let monitoring = {
       totalSynced: 0,
       startedAt: Date.now(),
     };
-    // For each chain start a parallel process
-    await Promise.all(
-      chains.map((chainId) =>
-        startSyncChain(
-          sourcifyInstance,
-          repositoryV1Path,
-          chainId,
-          JSON.parse(JSON.stringify(options)),
-          databasePool,
-          monitoring,
-        ),
+
+    console.log(
+      `Syncing chains: ${chainsToSync.join(",")} and deprecated chains: ${deprecatedChains.join(",")}`,
+    );
+
+    // Sync in parallel
+    const syncPromises = chainsToSync.map((chainId) =>
+      startSyncChain(
+        sourcifyInstance,
+        repositoryV1Path,
+        chainId,
+        JSON.parse(JSON.stringify(options)),
+        databasePool,
+        monitoring,
       ),
     );
+
+    // Also sync deprecated in parallel
+    const deprecatedSyncPromises = deprecatedChains.map((chainId) =>
+      startSyncChain(
+        sourcifyInstance,
+        repositoryV1Path,
+        chainId,
+        JSON.parse(JSON.stringify(options)),
+        databasePool,
+        monitoring,
+        true,
+      ),
+    );
+
+    await Promise.all([...syncPromises, ...deprecatedSyncPromises]);
 
     databasePool.end();
   });
@@ -252,19 +272,17 @@ const startSyncChain = async (
   options,
   databasePool,
   monitoring,
+  deprecated = false,
 ) => {
   let activePromises = 0;
   let maxLimit = options.limit ? options.limit : 1; // Maximum allowed parallel requests
-  let currentLimit = 1; // Starting with 1 request at a time
 
   let processedContracts = 0;
-  while (true) {
-    while (activePromises >= currentLimit) {
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
 
-    // Helps to reduce the rpc hit limit error
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+  while (true) {
+    while (activePromises >= maxLimit) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
 
     // Fetch next contract
     let optionsSafe = JSON.parse(JSON.stringify(options));
@@ -285,7 +303,7 @@ const startSyncChain = async (
       sourcifyInstance,
       repositoryV1Path,
       databasePool,
-      options.deprecated?.length > 0,
+      deprecated,
       {
         address: nextContract.address.toString(),
         chain_id: nextContract.chain_id,
@@ -307,16 +325,6 @@ const startSyncChain = async (
           console.error(`Failed to sync ${[res[1]]}`);
         }
         activePromises--;
-
-        // Increment currentLimit after a successful process and if it hasn't reached the max limit yet
-        if (currentLimit < maxLimit) {
-          currentLimit++;
-          logToFile(
-            chainId,
-            `Slow start: Increasing chain #${chainId}'s currentLimit to ${currentLimit}`,
-          );
-        }
-
         processedContracts++;
       })
       .catch((e) => {
@@ -339,65 +347,64 @@ const processContract = async (
   deprecated = false,
   contract,
 ) => {
-  return new Promise(async (resolve) => {
-    try {
-      const address = contract.address;
-      const chainId = contract.chain_id;
-      const matchType = contract.match_type;
+  try {
+    const address = contract.address;
+    const chainId = contract.chain_id;
+    const matchType = contract.match_type;
 
-      const repoPath = path.join(
-        repositoryV1Path,
-        matchType,
-        chainId,
-        address,
-        "/",
-      );
+    const repoPath = path.join(
+      repositoryV1Path,
+      matchType,
+      chainId,
+      address,
+      "/",
+    );
 
-      const files = {};
-      for await (const entry of readdirp(repoPath, {
-        fileFilter: ["*.sol", "metadata.json"],
-      })) {
-        files[entry.path] = await readFile(entry.fullPath, "utf8");
+    const files = {};
+    for await (const entry of readdirp(repoPath, {
+      fileFilter: ["*.sol", "metadata.json"],
+    })) {
+      files[entry.path] = await readFile(entry.fullPath, "utf8");
+    }
+
+    const body = {
+      address: address,
+      chain: chainId,
+      files,
+    };
+
+    const headers = {
+      "Content-Type": "application/json",
+    };
+    if (process.env.BEARER_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.BEARER_TOKEN}`;
+    }
+    let url = `${sourcifyInstance}/verify`;
+    if (deprecated) {
+      url = `${sourcifyInstance}/verify-deprecated`;
+      switch (matchType) {
+        case "full_match":
+          body.match = "perfect";
+          break;
+        case "partial_match":
+          body.match = "partial";
+          break;
+        default:
+          throw new Error("Cannot infer match type");
       }
+    }
+    const request = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers,
+    });
 
-      const body = {
-        address: address,
-        chain: chainId,
-        files,
-      };
-
-      const headers = {
-        "Content-Type": "application/json",
-      };
-      if (process.env.BEARER_TOKEN) {
-        headers.Authorization = `Bearer ${process.env.BEARER_TOKEN}`;
-      }
-      let url = `${sourcifyInstance}/verify`;
-      if (deprecated) {
-        url = `${sourcifyInstance}/verify-deprecated`;
-        switch (matchType) {
-          case "full_match":
-            body.match = "perfect";
-            break;
-          case "partial_match":
-            body.match = "partial";
-            break;
-          default:
-            throw new Error("Cannot infer match type");
-        }
-      }
-      const request = await fetch(url, {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers,
-      });
-
-      if (request.status === 200) {
-        const response = await request.json();
-        if (response.result[0].status !== null) {
-          await executeQueryWithRetry(
-            databasePool,
-            `
+    if (request.status === 200) {
+      const response = await request.json();
+      if (response.result[0].status !== null) {
+        await executeQueryWithRetry(
+          databasePool,
+          `
           UPDATE sourcify_sync
           SET 
             synced = true
@@ -406,34 +413,30 @@ const processContract = async (
             AND address = $2
             AND match_type = $3   
           `,
-            [contract.chain_id, contract.address, contract.match_type],
-          );
-        }
-        resolve([
-          true,
           [contract.chain_id, contract.address, contract.match_type],
-        ]);
-      } else {
-        resolve([
-          false,
-          `${[
-            contract.chain_id,
-            contract.address,
-            contract.match_type,
-          ]} with error: ${await request.text()}`,
-        ]);
+        );
       }
-    } catch (e) {
-      resolve([
+      return [true, [contract.chain_id, contract.address, contract.match_type]];
+    } else {
+      return [
         false,
         `${[
           contract.chain_id,
           contract.address,
           contract.match_type,
-        ]} with error: ${e}`,
-      ]);
+        ]} with error: ${await request.text()}`,
+      ];
     }
-  });
+  } catch (e) {
+    return [
+      false,
+      `${[
+        contract.chain_id,
+        contract.address,
+        contract.match_type,
+      ]} with error: ${e}`,
+    ];
+  }
 };
 
 function logToFile(chainId, message) {
@@ -454,7 +457,7 @@ function logToFile(chainId, message) {
   console.log(timestampedMessage);
 }
 
-const fetchNextContract = async (databasePool, options, chainId) => {
+const fetchNextContract = async (databasePool, options, chainId, limit = 1) => {
   try {
     const query = `
       SELECT
@@ -465,7 +468,7 @@ const fetchNextContract = async (databasePool, options, chainId) => {
         AND chain_id = $2
         AND synced = false
       ORDER BY id ASC
-      LIMIT 1
+      LIMIT ${limit}
     `;
     const contractResult = await executeQueryWithRetry(databasePool, query, [
       options.startFrom ? options.startFrom : 0,

--- a/services/database/scripts.mjs
+++ b/services/database/scripts.mjs
@@ -206,9 +206,13 @@ program
       chainsFromDB = chainsResult.rows.map(({ chain_id }) => chain_id);
     }
 
-    let chainsToSync = [];
+    console.log(
+      `Chains to sync from sourciy_sync table: ${chainsFromDB.join(",")}`,
+    );
+
+    let chainsToSync = chainsFromDB;
     // Specify which chain to sync
-    if (options.chains) {
+    if (options.chains?.length > 0) {
       chainsToSync = chainsFromDB.filter((chain) =>
         options.chains.split(",").includes(`${chain}`),
       );
@@ -218,6 +222,9 @@ program
     if (options.deprecated?.length > 0) {
       deprecatedChains = chainsFromDB.filter((chain) =>
         options.deprecated?.split(",").includes(`${chain}`),
+      );
+      chainsToSync = chainsToSync.filter(
+        (chain) => !options.deprecated.split(",").includes(`${chain}`),
       );
     }
 
@@ -281,7 +288,7 @@ const startSyncChain = async (
 
   while (true) {
     while (activePromises >= maxLimit) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     }
 
     // Fetch next contract

--- a/services/database/scripts.mjs
+++ b/services/database/scripts.mjs
@@ -368,9 +368,7 @@ const processContract = async (
     );
 
     const files = {};
-    for await (const entry of readdirp(repoPath, {
-      fileFilter: ["*.sol", "metadata.json"],
-    })) {
+    for await (const entry of readdirp(repoPath)) {
       files[entry.path] = await readFile(entry.fullPath, "utf8");
     }
 

--- a/services/server/src/config/default.js
+++ b/services/server/src/config/default.js
@@ -54,6 +54,8 @@ module.exports = {
     /^https?:\/\/(?:.+\.)?ipfs.dweb.link$/, // dweb links used by Brave browser etc.
     process.env.NODE_ENV !== "production" && /^https?:\/\/localhost(?::\d+)?$/, // localhost on any port
   ],
+  // verify-deprecated endpoint used in services/database/scripts.mjs. Used when recreating the DB with deprecated chains that don't have an RPC.
+  verifyDeprecated: false,
   rateLimit: {
     enabled: false,
     // Check done with "startsWith"

--- a/services/server/src/config/migration.js
+++ b/services/server/src/config/migration.js
@@ -35,6 +35,7 @@ module.exports = {
     // credentials as env vars
   },
   initCompilers: true,
+  verifyDeprecated: true,
   rateLimit: {
     enabled: false,
     windowMs: 1 * 1000, // 1 sec

--- a/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.handlers.ts
+++ b/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.handlers.ts
@@ -7,7 +7,9 @@ import {
 } from "../../verification.common";
 import {
   CheckedContract,
+  Match,
   checkFiles,
+  matchWithRuntimeBytecode,
   useAllSources,
 } from "@ethereum-sourcify/lib-sourcify";
 import {
@@ -16,7 +18,7 @@ import {
   ValidationError,
 } from "../../../../../common/errors";
 import { StatusCodes } from "http-status-codes";
-import { getResponseMatchFromMatch } from "../../../../common";
+import { getMatchStatus, getResponseMatchFromMatch } from "../../../../common";
 import logger from "../../../../../common/logger";
 
 export async function legacyVerifyEndpoint(
@@ -114,6 +116,133 @@ export async function legacyVerifyEndpoint(
       await req.services.storage.storeMatch(contract, match);
     }
     return res.send({ result: [getResponseMatchFromMatch(match)] }); // array is an old expected behavior (e.g. by frontend)
+  } catch (error: any) {
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .send({ error: error.message });
+  }
+}
+
+export async function verifyDeprecated(
+  req: LegacyVerifyRequest,
+  res: Response,
+): Promise<any> {
+  const { services } = req;
+
+  const result = await services.storage.performServiceOperation(
+    "checkByChainAndAddress",
+    [req.body.address, req.body.chain],
+  );
+
+  if (result.length != 0) {
+    return res.send({ result: [getResponseMatchFromMatch(result[0])] });
+  }
+
+  const inputFiles = extractFiles(req);
+  if (!inputFiles) {
+    const msg =
+      "Couldn't extract files from the request. Please make sure you have added files";
+    throw new NotFoundError(msg);
+  }
+
+  let checkedContracts: CheckedContract[];
+  try {
+    checkedContracts = await checkFiles(solc, inputFiles);
+  } catch (error: any) {
+    throw new BadRequestError(error.message);
+  }
+
+  const errors = checkedContracts
+    .filter((contract) => !CheckedContract.isValid(contract, true))
+    .map(stringifyInvalidAndMissing);
+  if (errors.length) {
+    throw new BadRequestError(
+      "Invalid or missing sources in:\n" + errors.join("\n"),
+    );
+  }
+
+  if (checkedContracts.length !== 1 && !req.body.chosenContract) {
+    const contractNames = checkedContracts.map((c) => c.name).join(", ");
+    const msg = `Detected ${checkedContracts.length} contracts (${contractNames}), but can only verify 1 at a time. Please choose a main contract and click Verify again.`;
+    const contractsToChoose = checkedContracts.map((contract) => ({
+      name: contract.name,
+      path: contract.compiledPath,
+    }));
+    return res
+      .status(StatusCodes.BAD_REQUEST)
+      .send({ error: msg, contractsToChoose });
+  }
+
+  const contract: CheckedContract = req.body.chosenContract
+    ? checkedContracts[req.body.chosenContract]
+    : checkedContracts[0];
+
+  if (!contract) {
+    throw new NotFoundError(
+      "Chosen contract not found. Received chosenContract: " +
+        req.body.chosenContract,
+    );
+  }
+
+  const match: Match = {
+    address: req.body.address,
+    chainId: req.body.chain,
+    runtimeMatch: null,
+    creationMatch: null,
+    runtimeTransformations: [],
+    creationTransformations: [],
+    runtimeTransformationValues: {},
+    creationTransformationValues: {},
+  };
+
+  const generateRuntimeCborAuxdataPositions = async () => {
+    if (!contract.runtimeBytecodeCborAuxdata) {
+      await contract.generateCborAuxdataPositions();
+    }
+    return contract.runtimeBytecodeCborAuxdata || {};
+  };
+
+  try {
+    const {
+      runtimeBytecode: recompiledRuntimeBytecode,
+      immutableReferences,
+      runtimeLinkReferences,
+      creationLinkReferences,
+    } = await contract.recompile();
+
+    // we are running also matchWithRuntimeBytecode to extract transformations
+    await matchWithRuntimeBytecode(
+      match,
+      recompiledRuntimeBytecode,
+      recompiledRuntimeBytecode, // onchainBytecode
+      generateRuntimeCborAuxdataPositions,
+      immutableReferences,
+      runtimeLinkReferences,
+    );
+
+    match;
+    const matchStatus = getMatchStatus(match);
+    if (matchStatus !== "perfect") {
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .send({ error: "Match is neither partial or perfect" });
+    }
+
+    // Override match properties
+    match.runtimeMatch = req.body.match;
+    match.creationMatch = req.body.match;
+    // hex for !!!!!!!!!!! - chain was deprecated at the time of verification";
+    match.onchainRuntimeBytecode =
+      "0x2121212121212121212121202d20636861696e207761732064657072656361746564206174207468652074696d65206f6620766572696669636174696f6e";
+    match.onchainCreationBytecode =
+      "0x2121212121212121212121202d20636861696e207761732064657072656361746564206174207468652074696d65206f6620766572696669636174696f6e";
+    match.blockNumber = -1;
+    match.creatorTxHash = undefined; // null bytea
+    match.txIndex = -1;
+    match.deployer = undefined; // null bytea
+
+    await services.storage.storeMatch(contract, match);
+    return res.send({ result: [getResponseMatchFromMatch(match)] });
   } catch (error: any) {
     res
       .status(StatusCodes.INTERNAL_SERVER_ERROR)

--- a/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.paths.yaml
+++ b/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.paths.yaml
@@ -165,3 +165,133 @@ paths:
                 Deployed and recompiled mismatch:
                   value:
                     error: "The deployed and recompiled bytecode don't match."
+  /verify-deprecated:
+    post:
+      description: |
+        Sends provided files for verification
+      tags:
+        - Stateless Verification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - address
+                - chain
+                - files
+              properties:
+                address:
+                  type: string
+                  format: address
+                  example: "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+                chain:
+                  type: string
+                  format: supported-chainId
+                  example: "1"
+                files:
+                  type: object
+                  example:
+                    metadata.json: "{...}"
+                    SimpleStorage.sol: "// file"
+                creatorTxHash:
+                  type: string
+                chosenContract:
+                  type: string
+                match:
+                  type: string
+      responses:
+        "200":
+          description: The contract has been successfully checked or sourcified
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        address:
+                          type: string
+                        chainId:
+                          type: string
+                        status:
+                          type: string
+                        message:
+                          type: string
+                        libraryMap:
+                          type: object
+              examples:
+                Perfect Match:
+                  value:
+                    result:
+                      - address: "0x123f681646d4a755815f9cb19e1acc8565a0c2ac"
+                        chainId: "1"
+                        status: "perfect"
+                        libraryMap:
+                          lib1: "0x3f681646d4a755815f9cb19e1acc8565a0c2ac"
+                          lib2: "0x4f681646d4a755815f9cb19e1acc8565a0c2ac"
+                Partial Match:
+                  value:
+                    result:
+                      - address: "0x123f681646d4a755815f9cb19e1acc8565a0c2ac"
+                        chainId: "1"
+                        status: "partial"
+                        libraryMap:
+                          lib1: "0x3f681646d4a755815f9cb19e1acc8565a0c2ac"
+                          lib2: "0x4f681646d4a755815f9cb19e1acc8565a0c2ac"
+                Not Deployed:
+                  value:
+                    result:
+                      - address: "0x123f681646d4a755815f9cb19e1acc8565a0c2ac"
+                        chainId: "1"
+                        status: "null"
+                        message: "Chain #1 does not have a contract deployed at 0x...."
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              examples:
+                Metadata not found:
+                  value:
+                    error: 'Metadata file not found. Did you include "metadata.json"?'
+                Bad Formatted Json:
+                  value:
+                    error: "Unexpected token ' in JSON at position 107"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              examples:
+                File Not Found:
+                  value:
+                    error: "Couldn't extract files from the request. Please make sure you have added files"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              examples:
+                Resource Missing:
+                  value:
+                    error: "Resource missing; unsuccessful fetching: contracts/SingleFile.sol"
+                Deployed and recompiled mismatch:
+                  value:
+                    error: "The deployed and recompiled bytecode don't match."

--- a/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.routes.ts
+++ b/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.routes.ts
@@ -4,11 +4,19 @@ import {
   verifyDeprecated,
 } from "./verify.stateless.handlers";
 import { safeHandler } from "../../../controllers.common";
+import config from "config";
 
 const router: Router = Router();
 
 router.route("/verify").post(safeHandler(legacyVerifyEndpoint));
-router.route("/verify-deprecated").post(safeHandler(verifyDeprecated));
+
+if (config.get("verifyDeprecated")) {
+  router.route("/verify-deprecated").post(safeHandler(verifyDeprecated));
+} else {
+  router.route("/verify-deprecated").all((req, res) => {
+    res.status(400).send("Not found");
+  });
+}
 
 export const deprecatedRoutesVerifyStateless = {
   "/": {

--- a/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.routes.ts
+++ b/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.routes.ts
@@ -1,10 +1,14 @@
 import { Router } from "express";
-import { legacyVerifyEndpoint } from "./verify.stateless.handlers";
+import {
+  legacyVerifyEndpoint,
+  verifyDeprecated,
+} from "./verify.stateless.handlers";
 import { safeHandler } from "../../../controllers.common";
 
 const router: Router = Router();
 
 router.route("/verify").post(safeHandler(legacyVerifyEndpoint));
+router.route("/verify-deprecated").post(safeHandler(verifyDeprecated));
 
 export const deprecatedRoutesVerifyStateless = {
   "/": {


### PR DESCRIPTION
Introduces changes to the DB sync script:
- Adds a `--deprecated` option to mark some chains deprecated and to send them to the `/verify-deprecated` endpoint instead.
- For more max concurrency, Removes the 1s wait between calls and reduces the `await` time inside the while loop
- Refactors `processContract` to remove the ineffective Promise. Prev. it was an `async` function returning a Promise, so it was a double Promise. Async functions should not return Promises.
- Conditionally enable `/verify-deprecated` in config
- Don't only send files with `.sol` and the `metadata.json` but all files. This is needed as some contract files don't have a file extension in our legacy repository.