### PR TITLE
Disable rate limiting on the application level

### DIFF
--- a/services/server/src/config/master.js
+++ b/services/server/src/config/master.js
@@ -37,7 +37,7 @@ module.exports = {
     // credentials as env vars
   },
   rateLimit: {
-    enabled: true,
+    enabled: false,
     windowMs: 1 * 1000, // 1 sec
     max: 2,
   },

--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -37,7 +37,7 @@ module.exports = {
     // credentials as env vars
   },
   rateLimit: {
-    enabled: true,
+    enabled: false,
     windowMs: 1 * 1000, // 1 sec
     max: 2,
   },


### PR DESCRIPTION
Since we have rate limiting on our reverse proxy now by default, and now the deployment should be able to handle more requests, we can disable the rate limiting IMO