### PR TITLE
Do not update manifest.json for every new match stored

### DIFF
--- a/services/server/src/server/services/storageServices/RepositoryV1Service.ts
+++ b/services/server/src/server/services/storageServices/RepositoryV1Service.ts
@@ -370,7 +370,6 @@ export class RepositoryV1Service implements RWStorageService {
     await fs.promises.mkdir(Path.dirname(abolsutePath), { recursive: true });
     await fs.promises.writeFile(abolsutePath, content);
     logger.silly("Saved file to repositoryV1", { abolsutePath });
-    await this.updateRepositoryTag();
   }
 
   public async storeMatch(
@@ -480,15 +479,6 @@ export class RepositoryV1Service implements RWStorageService {
     if (await exists(absolutePath)) {
       await fs.promises.rm(absolutePath, { recursive: true });
     }
-  }
-
-  async updateRepositoryTag() {
-    const filePath: string = Path.join(this.repositoryPath, "manifest.json");
-    const timestamp = new Date().getTime();
-    const tag: RepositoryTag = {
-      timestamp: timestamp,
-    };
-    await fs.promises.writeFile(filePath, JSON.stringify(tag));
   }
 
   /**

--- a/services/server/src/server/services/storageServices/RepositoryV2Service.ts
+++ b/services/server/src/server/services/storageServices/RepositoryV2Service.ts
@@ -97,7 +97,6 @@ export class RepositoryV2Service implements WStorageService {
     await fs.promises.mkdir(Path.dirname(abolsutePath), { recursive: true });
     await fs.promises.writeFile(abolsutePath, content);
     logger.silly("Saved file to repositoryV2", { abolsutePath });
-    this.updateRepositoryTag();
   }
 
   public async storeMatch(
@@ -207,15 +206,6 @@ export class RepositoryV2Service implements WStorageService {
     if (await exists(absolutePath)) {
       await fs.promises.rm(absolutePath, { recursive: true });
     }
-  }
-
-  async updateRepositoryTag() {
-    const filePath: string = Path.join(this.repositoryPath, "manifest.json");
-    const timestamp = new Date().getTime();
-    const tag: RepositoryTag = {
-      timestamp: timestamp,
-    };
-    await fs.promises.writeFile(filePath, JSON.stringify(tag));
   }
 
   /**


### PR DESCRIPTION
I think it's best if only the `stats-gen` job updates `manifest.json`, so that we know the exact timestamp of `stats.json`.

Let's remove `manifest.json` updates in `sourcify-server`.

https://github.com/ethereum/sourcify/blob/e3ae40c3a57989554d4cd3f75132bbc507185446/services/server/src/server/services/storageServices/RepositoryV1Service.ts#L485-L492

https://github.com/ethereum/sourcify/blob/e3ae40c3a57989554d4cd3f75132bbc507185446/services/server/src/server/services/storageServices/RepositoryV2Service.ts#L212-L219