### PR TITLE
Add sourcify request retry mechanism in Monitor

### DIFF
--- a/services/monitor/README.md
+++ b/services/monitor/README.md
@@ -66,6 +66,12 @@ The structure of the file is as such:
   },
   // Sourcify instances to verify the contracts on. Can be multiple
   sourcifyServerURLs: ["https://sourcify.dev/server/", "http://localhost:5555/"],
+  sourcifyRequest: {
+    // Maximum number of retry attempts for contract verification requests after encountering an error
+    maxRetries: 3,
+    // Delay in milliseconds between each retry attempt for verification requests to Sourcify
+    retryDelay: 30000,
+  },
   defaultChainConfig: {
     // Block to start monitoring from. If undefined, it will start from the latest block by asking the RPC `eth_blockNumber`
     startBlock: undefined,

--- a/services/monitor/README.md
+++ b/services/monitor/README.md
@@ -66,7 +66,7 @@ The structure of the file is as such:
   },
   // Sourcify instances to verify the contracts on. Can be multiple
   sourcifyServerURLs: ["https://sourcify.dev/server/", "http://localhost:5555/"],
-  sourcifyRequest: {
+  sourcifyRequestOptions: {
     // Maximum number of retry attempts for contract verification requests after encountering an error
     maxRetries: 3,
     // Delay in milliseconds between each retry attempt for verification requests to Sourcify

--- a/services/monitor/src/defaultConfig.js
+++ b/services/monitor/src/defaultConfig.js
@@ -9,6 +9,10 @@ const defaultConfig = {
     },
   },
   sourcifyServerURLs: ["https://sourcify.dev/server/"],
+  sourcifyRequestOptions: {
+    maxRetries: 3,
+    retryDelay: 30000,
+  },
   defaultChainConfig: {
     startBlock: undefined,
     blockInterval: 10000,

--- a/services/monitor/src/types.ts
+++ b/services/monitor/src/types.ts
@@ -45,9 +45,15 @@ export type DefatultChainMonitorConfig = {
   bytecodeNumberOfTries: number;
 };
 
+export type SourcifyRequestOptions = {
+  maxRetries: number;
+  retryDelay: number;
+};
+
 export type MonitorConfig = {
   decentralizedStorages: DecentralizedStorageConfigMap;
   sourcifyServerURLs: string[];
+  sourcifyRequestOptions: SourcifyRequestOptions;
   defaultChainConfig: DefatultChainMonitorConfig;
   chainConfigs?: {
     [chainId: number]: ChainMonitorConfig;
@@ -57,6 +63,7 @@ export type MonitorConfig = {
 export type PassedMonitorConfig = {
   decentralizedStorages?: DecentralizedStorageConfig;
   sourcifyServerURLs?: string[];
+  sourcifyRequestOptions?: Partial<SourcifyRequestOptions>;
   defaultChainConfig?: DefatultChainMonitorConfig;
   chainConfigs?: {
     [chainId: number]: ChainMonitorConfig;


### PR DESCRIPTION
Some of the /verify requests in the monitor running on GCP are failing with ECONNRESET error. We already tried debugging the problem but with no luck. Until we find a better solution we need to implement a retry mechanism in Monitor.

This PR implements a retry mechanism in Monitor configurable with: 

```
  sourcifyRequestOptions: {
    // Maximum number of retry attempts for contract verification requests after encountering an error
    maxRetries: 3,
    // Delay in milliseconds between each retry attempt for verification requests to Sourcify
    retryDelay: 30000,
  },
```