### PR TITLE
Use traceparent instead of x-cloud-trace-context, replace `requestId` with `traceId` everywhere

### DIFF
--- a/services/server/src/common/async-context.ts
+++ b/services/server/src/common/async-context.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
 
 export const asyncLocalStorage = new AsyncLocalStorage<{
-  [requestId: string]: string;
+  [traceId: string]: string;
 }>();

--- a/services/server/src/common/logger.ts
+++ b/services/server/src/common/logger.ts
@@ -31,10 +31,8 @@ const loggerInstance: Logger = createLogger({
 
 // 2024-03-06T17:04:16.375Z [warn]: [RepositoryV2Service] Storing contract address=0x5FbDB2315678afecb367f032d93F642f64180aa3, chainId=1337, matchQuality=0.5
 const rawlineFormat = format.printf(
-  ({ level, message, timestamp, service, requestId, ...metadata }: any) => {
-    const requestIdMsg = requestId
-      ? chalk.grey(`[requestId=${requestId}]`)
-      : "";
+  ({ level, message, timestamp, service, traceId, ...metadata }: any) => {
+    const traceIdMsg = traceId ? chalk.grey(`[traceId=${traceId}]`) : "";
 
     let msg = `${timestamp} [${level}] ${service ? service : ""} ${chalk.bold(
       message,
@@ -54,7 +52,7 @@ const rawlineFormat = format.printf(
         })
         .join(" | ");
       msg += chalk.grey(metadataMsg);
-      msg += requestIdMsg && " - " + requestIdMsg;
+      msg += traceIdMsg && " - " + traceIdMsg;
     }
     return msg;
   },
@@ -77,19 +75,19 @@ const errorFormatter = format((info) => {
   return info;
 });
 
-// Inject the requestId into the log message
-const injectRequestId = format((info) => {
-  const requestId = asyncLocalStorage.getStore()?.requestId;
-  return requestId ? { ...info, requestId } : info;
+// Inject the traceId into the log message
+const injectTraceId = format((info) => {
+  const traceId = asyncLocalStorage.getStore()?.traceId;
+  return traceId ? { ...info, traceId } : info;
 });
 
 // Choose between the GCP and the standard JSON format.
 const chooseJSONFormat = () => {
   const isOnGCP = process.env.K_SERVICE || process.env.GOOGLE_CLOUD_PROJECT;
 
-  // Google Cloud uses a different field for indicating severity. Map `level` to `severity`
   const gcpFormat = format.printf(
-    ({ level, message, timestamp, service, ...metadata }) => {
+    ({ level, message, timestamp, service, traceId, ...metadata }) => {
+      // Google Cloud uses a different field for indicating severity. Map `level` to `severity`
       const severityMap: { [key: string]: string } = {
         error: "ERROR",
         warn: "WARNING",
@@ -105,6 +103,8 @@ const chooseJSONFormat = () => {
         message,
         service,
         timestamp,
+        // Add the trace under this field to allow easy correction of traces https://cloud.google.com/run/docs/logging#correlate-logs
+        logging: { "googleapis.com/trace": traceId },
         ...metadata,
       };
 
@@ -115,14 +115,14 @@ const chooseJSONFormat = () => {
   return format.combine(
     errorFormatter(),
     format.timestamp(),
-    injectRequestId(),
+    injectTraceId(),
     isOnGCP ? gcpFormat : format.json(),
   );
 };
 
 const jsonFormat = chooseJSONFormat();
 const lineFormat = format.combine(
-  injectRequestId(),
+  injectTraceId(),
   errorFormatter(),
   format.timestamp(),
   format.colorize(),


### PR DESCRIPTION
GCP apparently advises usign the W3C standard `traceparent` header instead of the legacy `x-cloud-trace` header for traces: https://cloud.google.com/trace/docs/trace-context#legacy-http-header

These changes uses `traceparent` instead.

Additionally we extract the `traceId` portion of the whole header, instead of writing the whole identifier that includes other stuff. If we are in a GCP context, we now log these `traceId`s under `logging.googleapis.com/trace` as advised [here](https://cloud.google.com/run/docs/logging#correlate-logs) to enable automatic correlation in GCP.
