### PR TITLE
Add fallback and .env entry for project-id for log tracing

### DIFF
--- a/services/server/.env.dev
+++ b/services/server/.env.dev
@@ -82,3 +82,6 @@ CF_ACCESS_CLIENT_SECRET=
 AWS_REGION=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY= 
+
+# Optional, project id for Google Cloud, used for log tracing.
+GOOGLE_CLOUD_PROJECT=

--- a/services/server/src/common/logger.ts
+++ b/services/server/src/common/logger.ts
@@ -101,7 +101,8 @@ const chooseJSONFormat = () => {
       const projectId =
         process.env.GOOGLE_CLOUD_PROJECT ||
         process.env.GCP_PROJECT ||
-        process.env.GCLOUD_PROJECT;
+        process.env.GCLOUD_PROJECT ||
+        "sourcify-project";
 
       const logObject = {
         severity,


### PR DESCRIPTION
Solves `undefined` project id in log trace fields