### PR TITLE
Store found creatorTxHash even if getContractCreationBytecodeAndReceipt fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37421,7 +37421,7 @@
         "gh-pages": "6.1.1",
         "hardhat": "2.22.8",
         "mocha": "10.7.3",
-        "nock": "14.0.0-beta.9",
+        "nock": "^14.0.0-beta.9",
         "npm-run-all2": "5.0.2",
         "open-cli": "8.0.0",
         "solc": "0.8.26",
@@ -37572,6 +37572,7 @@
         "npm-run-all2": "5.0.2",
         "open-cli": "8.0.0",
         "rimraf": "4.4.1",
+        "sinon": "^18.0.0",
         "tree-kill": "1.2.2",
         "typestrict": "1.0.2"
       },

--- a/packages/lib-sourcify/src/lib/verification.ts
+++ b/packages/lib-sourcify/src/lib/verification.ts
@@ -56,6 +56,7 @@ export async function verifyDeployed(
     name: checkedContract.name,
     address,
     chainId: sourcifyChain.chainId,
+    creatorTxHash,
   });
 
   let useEmscripten = forceEmscripten;

--- a/services/server/.mocharc.json
+++ b/services/server/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": ["ts"],
-  "require": ["ts-node/register", "./test/load-env.js"],
+  "require": ["ts-node/register", "./test/load-env.js", "./test/root-hooks.js"],
   "timeout": 60000
 }

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -106,6 +106,7 @@
     "npm-run-all2": "5.0.2",
     "open-cli": "8.0.0",
     "rimraf": "4.4.1",
+    "sinon": "^18.0.0",
     "tree-kill": "1.2.2",
     "typestrict": "1.0.2"
   },

--- a/services/server/src/server/services/VerificationService.ts
+++ b/services/server/src/server/services/VerificationService.ts
@@ -110,10 +110,12 @@ export class VerificationService {
     this.activeVerificationsByChainIdAddress[`${chainId}:${address}`] = true;
 
     const sourcifyChain = this.supportedChainsMap[chainId];
-    const foundCreatorTxHash =
-      creatorTxHash ||
-      (await getCreatorTx(sourcifyChain, address)) ||
-      undefined;
+
+    let foundCreatorTxHash: string | undefined;
+    if (!creatorTxHash) {
+      foundCreatorTxHash =
+        (await getCreatorTx(sourcifyChain, address)) || undefined;
+    }
 
     /* eslint-disable no-useless-catch */
     try {
@@ -121,8 +123,11 @@ export class VerificationService {
         checkedContract,
         sourcifyChain,
         address,
-        foundCreatorTxHash,
+        creatorTxHash || foundCreatorTxHash,
       );
+      if (foundCreatorTxHash && !res.creatorTxHash) {
+        res.creatorTxHash = foundCreatorTxHash;
+      }
       delete this.activeVerificationsByChainIdAddress[`${chainId}:${address}`];
       return res;
     } catch (e) {

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -173,44 +173,22 @@ async function getCreatorTxUsingFetcher(
 
   if (!contractFetchAddressFilled) return null;
 
+  let creatorTx: string | null = null;
   try {
     switch (fetcher.type) {
       case "scrape": {
         if (fetcher?.scrapeRegex) {
-          const creatorTx = await getCreatorTxByScraping(
+          creatorTx = await getCreatorTxByScraping(
             contractFetchAddressFilled,
             fetcher?.scrapeRegex,
           );
-          if (creatorTx) {
-            logger.debug("Fetched and found creator Tx", {
-              fetcher,
-              contractFetchAddressFilled,
-              contractAddress,
-              creatorTx,
-            });
-            return creatorTx;
-          }
-          logger.debug("Fetched but transaction not found", {
-            fetcher,
-            contractFetchAddressFilled,
-            creatorTx,
-          });
         }
         break;
       }
       case "api": {
         if (fetcher?.responseParser) {
           const response = await fetchFromApi(contractFetchAddressFilled);
-          const creatorTx = fetcher?.responseParser(response);
-          logger.debug("Fetched Creator Tx", {
-            fetcher,
-            contractFetchAddressFilled,
-            contractAddress,
-            creatorTx,
-          });
-          if (creatorTx) {
-            return creatorTx;
-          }
+          creatorTx = fetcher.responseParser(response);
         }
         break;
       }
@@ -222,6 +200,21 @@ async function getCreatorTxUsingFetcher(
     return null;
   }
 
+  if (creatorTx) {
+    logger.debug("Fetched and found creator Tx", {
+      fetcher,
+      contractFetchAddressFilled,
+      contractAddress,
+      creatorTx,
+    });
+    return creatorTx;
+  }
+
+  logger.debug("Fetched but transaction not found", {
+    fetcher,
+    contractFetchAddressFilled,
+    creatorTx,
+  });
   return null;
 }
 

--- a/services/server/test/root-hooks.js
+++ b/services/server/test/root-hooks.js
@@ -1,0 +1,8 @@
+const sinon = require("sinon");
+
+// Restores the default sandbox after every test
+exports.mochaHooks = {
+  afterEach() {
+    sinon.restore();
+  },
+};


### PR DESCRIPTION
We found a problem where the server didn't store the creation tx hash for a contract even though it found it before. The problem was there that lib-sourcify does not add it to the match if it was not able to fetch the creation bytecode, for example because of an unresponsive RPC. This PR changes that behavior. The creatorTxHash is always added to the match if the server obtained it itself. If the user provided the creatorTxHash, we don't add it in this case, because it could be the wrong tx hash.