### PR TITLE
Fix filename collusion

### DIFF
--- a/packages/lib-sourcify/src/lib/validation.ts
+++ b/packages/lib-sourcify/src/lib/validation.ts
@@ -102,6 +102,11 @@ export async function checkFiles(
   metadataFiles.forEach((metadata) => {
     const { foundSources, missingSources, invalidSources, metadata2provided } =
       rearrangeSources(metadata, byHash);
+    logDebug(`Checking contract`, {
+      foundSourcesCount: Object.keys(foundSources).length,
+      missingSources: Object.keys(missingSources),
+      invalidSources: Object.keys(invalidSources),
+    });
     const currentUsedFiles = Object.values(metadata2provided);
     usedFiles.push(...currentUsedFiles);
     const checkedContract = new CheckedContract(

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -1731,18 +1731,22 @@ describe("Test Supported Chains", function () {
 function readFilesRecursively(
   directoryPath: string,
   files: Record<string, string>,
+  baseDirectory?: string,
 ) {
+  // If baseDirectory is not provided, set it to directoryPath
+  baseDirectory = baseDirectory || directoryPath;
+
   const filesInDirectory = fs.readdirSync(directoryPath);
 
   filesInDirectory.forEach((file) => {
     const filePath = path.join(directoryPath, file);
 
     if (fs.statSync(filePath).isDirectory()) {
-      // Recursively call the function for subdirectories
-      readFilesRecursively(filePath, files);
+      readFilesRecursively(filePath, files, baseDirectory);
     } else {
-      // Read and store the content of the file
-      files[file] = fs.readFileSync(filePath).toString();
+      // Use the relativePath as key instead of `file` which is just the filename. Needed when there are files with the same name in the directory.
+      const relativeFilePath = path.relative(baseDirectory, filePath);
+      files[relativeFilePath] = fs.readFileSync(filePath).toString();
     }
   });
 }

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -1731,22 +1731,16 @@ describe("Test Supported Chains", function () {
 function readFilesRecursively(
   directoryPath: string,
   files: Record<string, string>,
-  baseDirectory?: string,
 ) {
-  // If baseDirectory is not provided, set it to directoryPath
-  baseDirectory = baseDirectory || directoryPath;
-
   const filesInDirectory = fs.readdirSync(directoryPath);
 
   filesInDirectory.forEach((file) => {
     const filePath = path.join(directoryPath, file);
 
     if (fs.statSync(filePath).isDirectory()) {
-      readFilesRecursively(filePath, files, baseDirectory);
+      readFilesRecursively(filePath, files);
     } else {
-      // Use the relativePath as key instead of `file` which is just the filename. Needed when there are files with the same name in the directory.
-      const relativeFilePath = path.relative(baseDirectory, filePath);
-      files[relativeFilePath] = fs.readFileSync(filePath).toString();
+      files[filePath] = fs.readFileSync(filePath).toString();
     }
   });
 }


### PR DESCRIPTION
Found in the [failin CI chain test (6119)](https://app.circleci.com/pipelines/github/ethereum/sourcify/6708/workflows/691eabb9-fba5-4a94-a762-a9344bc32471/jobs/40656), where it was unexpectedly fetching files from IPFS when the files are already provided.

Turns out when there are files with the same name, the files get overwritten by the `readFilesRecursively` function. Fixed by using a relative path as the key in the `files` object.

Also adds a log line to debug easier missing files when checking contracts