### PR TITLE
Fix verification logic

### DIFF
--- a/packages/lib-sourcify/src/lib/CheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/CheckedContract.ts
@@ -363,7 +363,6 @@ export class CheckedContract {
             "The creation auxdata from raw bytecode differs from the legacyAssembly's auxdata",
             { name: this.name },
           );
-          return false;
         }
       }
     }

--- a/packages/lib-sourcify/src/lib/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/lib/SourcifyChain.ts
@@ -227,7 +227,7 @@ export default class SourcifyChain {
     }
 
     throw new Error(
-      'None of the RPCs responded fetching tx ' +
+      'None of the RPCs could successfully fetch tx traces for ' +
         creatorTxHash +
         ' on chain ' +
         this.chainId,
@@ -420,7 +420,9 @@ export default class SourcifyChain {
     }
 
     if (!creationBytecode) {
-      throw new Error('Cannot get creation bytecode');
+      throw new Error(
+        `Cannot get the creation bytecode for ${address} from the transaction hash ${transactionHash} on chain ${this.chainId}`,
+      );
     }
 
     return {

--- a/packages/lib-sourcify/src/lib/verification.ts
+++ b/packages/lib-sourcify/src/lib/verification.ts
@@ -188,7 +188,7 @@ export async function verifyDeployed(
         });
         match = await tryToFindPerfectMetadataAndMatch(
           checkedContract,
-          runtimeBytecode,
+          runtimeBytecode, // TODO: This is also weird we pass the runtime bytecode here
           match,
           async (match, recompiled) => {
             await matchWithCreationTx(

--- a/packages/lib-sourcify/src/lib/verification.ts
+++ b/packages/lib-sourcify/src/lib/verification.ts
@@ -179,11 +179,11 @@ export async function verifyDeployed(
         generateCreationCborAuxdataPositions,
         recompiled.creationLinkReferences,
       );
-      if (match.runtimeMatch === 'partial') {
+      if (match.creationMatch === 'partial') {
         logDebug('Matched partial with creation tx', {
           chain: sourcifyChain.chainId,
           address,
-          runtimeMatch: match.runtimeMatch,
+          creationMatch: match.creationMatch,
           creatorTxHash,
         });
         match = await tryToFindPerfectMetadataAndMatch(


### PR DESCRIPTION
This PR adds two changes:

1. https://github.com/ethereum/sourcify/commit/2bf7168edc30416d38b5576552902141c9015373 fixes the incorrect return when a different auxdata was found in the creation bytecode. This became apparent when debugging the "cannot generate artifacts" error in #1562. Here the contract has a different auxdata at the end of the creation code because it returns raw bytecode of the factory contract. The verification logic incorrectly stops when it finds different auxdata, whereas it should've continued to find the auxdatas by editing the contract and recompiling.
2. Fixes the wrong match check (`match.creationBytecode` instead of `match.runtimeBytecode`) in the verification logic.

Also adds small modifications to logs during fetching traces for clarity.