### PR TITLE
Replace axios with fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6916,6 +6916,7 @@
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
       "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -17540,6 +17541,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pseudomap": {
@@ -21281,7 +21283,6 @@
       "dependencies": {
         "@ethereum-sourcify/bytecode-utils": "^1.2.10",
         "@ethereum-sourcify/lib-sourcify": "^1.9.1",
-        "axios": "1.7.5",
         "chalk": "4.1.2",
         "commander": "12.1.0",
         "dotenv": "16.4.5",

--- a/services/monitor/package.json
+++ b/services/monitor/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@ethereum-sourcify/bytecode-utils": "^1.2.10",
     "@ethereum-sourcify/lib-sourcify": "^1.9.1",
-    "axios": "1.7.5",
     "chalk": "4.1.2",
     "commander": "12.1.0",
     "dotenv": "16.4.5",

--- a/services/monitor/src/PendingContract.ts
+++ b/services/monitor/src/PendingContract.ts
@@ -6,7 +6,6 @@ import { KnownDecentralizedStorageFetchers } from "./types";
 import assert from "assert";
 import dotenv from "dotenv";
 import { Logger } from "winston";
-import axios, { AxiosError, AxiosResponse } from "axios";
 
 dotenv.config();
 
@@ -142,17 +141,16 @@ export default class PendingContract {
       formattedSources[sourceUnitName] = source.content;
     }
 
-    let response: AxiosResponse;
+    let response: Response;
     try {
       // Send to Sourcify server.
-      response = await axios({
-        url: sourcifyServerURL,
+      response = await fetch(sourcifyServerURL, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "User-Agent": "sourcify-monitor",
         },
-        data: JSON.stringify({
+        body: JSON.stringify({
           chainId: this.chainId.toString(),
           address: this.address,
           files: {
@@ -162,36 +160,27 @@ export default class PendingContract {
           creatorTxHash,
         }),
       });
-    } catch (error: any) {
-      if (error instanceof AxiosError) {
-        // If the error contains the request's body then it fails to log because of payload size
-        if (error.config?.data) {
-          delete error.config.data;
-        }
-        throw error;
+
+      if (!response.ok) {
+        throw new Error(
+          `Error sending contract ${this.address} to Sourcify server ${sourcifyServerURL} - response status not ok: ${response.statusText} ${await response.text()}`,
+        );
       }
-      throw error;
+    } catch (error: any) {
+      throw new Error(
+        `Error sending contract ${this.address} to Sourcify server ${sourcifyServerURL} - network error: ${error.message}`,
+      );
     }
 
-    if (response.status === 200) {
-      this.contractLogger.info(
-        "[PendingContract.sendToSourcifyServer] Contract sent",
-        {
-          address: this.address,
-          chainId: this.chainId,
-          sourcifyServerURL,
-        },
-      );
-      return response.data;
-    } else {
-      throw new Error(
-        `Error sending contract ${
-          this.address
-        } to Sourcify server ${sourcifyServerURL}: ${
-          response.statusText
-        } ${await response.data}`,
-      );
-    }
+    this.contractLogger.info(
+      "[PendingContract.sendToSourcifyServer] Contract sent",
+      {
+        address: this.address,
+        chainId: this.chainId,
+        sourcifyServerURL,
+      },
+    );
+    return await response.json();
   };
 
   private movePendingToFetchedSources = (sourceUnitName: string) => {


### PR DESCRIPTION
See #1604

I realize now that the `fetch` error handling in the previous implementation was not 100% correct: https://github.com/ethereum/sourcify/compare/aee9b8fc11c3bd9b09c6c313ca941bd1faa7c348..b50e0e273c119b8bb992347fddfd14f30f4b2223#diff-cf9924eaf6b7cf3199fcd10b7003b7c0307ff011921e160c63bc57d88290e541

As you can see fetch was not into a try-catch, you can read more about this here: https://stackoverflow.com/questions/38235715/fetch-reject-promise-and-catch-the-error-if-status-is-not-ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned from `axios` to the native `fetch` API for HTTP requests, enhancing compatibility and reducing external dependencies.
  
- **Bug Fixes**
	- Improved error handling for HTTP responses, providing clearer error messages based on response status.

- **Chores**
	- Removed `axios` from project dependencies to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->