### PR TITLE
Support custom schema in AbstractDatabaseService and database session

### DIFF
--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -356,6 +356,7 @@ if (require.main === module) {
           password: process.env.SOURCIFY_POSTGRES_PASSWORD as string,
           port: parseInt(process.env.SOURCIFY_POSTGRES_PORT || "5432"),
         },
+        schema: process.env.SOURCIFY_POSTGRES_SCHEMA as string,
       },
       allianceDatabaseServiceOptions: {
         postgres: {
@@ -365,6 +366,7 @@ if (require.main === module) {
           password: process.env.ALLIANCE_POSTGRES_PASSWORD as string,
           port: parseInt(process.env.ALLIANCE_POSTGRES_PORT || "5432"),
         },
+        schema: process.env.ALLIANCE_POSTGRES_SCHEMA as string,
       },
     },
   );

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -114,6 +114,7 @@ export default abstract class AbstractDatabaseService {
       host: this.postgresHost,
       port: this.postgresPort,
       database: this.postgresDatabase,
+      schema: this.schema,
     });
     return true;
   }

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -72,6 +72,7 @@ export class SourcifyDatabaseService
     const existingVerifiedContractResult =
       await Database.getSourcifyMatchByChainAddress(
         this.databasePool,
+        this.schema,
         parseInt(chainId),
         bytesFromString(address)!,
         onlyPerfectMatches,
@@ -103,6 +104,7 @@ export class SourcifyDatabaseService
     const matchAddressesCountResult =
       await Database.countSourcifyMatchAddresses(
         this.databasePool,
+        this.schema,
         parseInt(chainId),
       );
 
@@ -132,6 +134,7 @@ export class SourcifyDatabaseService
       const perfectMatchAddressesResult =
         await Database.getSourcifyMatchAddressesByChainAndMatch(
           this.databasePool,
+          this.schema,
           parseInt(chainId),
           "full_match",
           0,
@@ -152,6 +155,7 @@ export class SourcifyDatabaseService
       const partialMatchAddressesResult =
         await Database.getSourcifyMatchAddressesByChainAndMatch(
           this.databasePool,
+          this.schema,
           parseInt(chainId),
           "partial_match",
           0,
@@ -198,6 +202,7 @@ export class SourcifyDatabaseService
     const matchAddressesCountResult =
       await Database.countSourcifyMatchAddresses(
         this.databasePool,
+        this.schema,
         parseInt(chainId),
       );
 
@@ -230,6 +235,7 @@ export class SourcifyDatabaseService
     const matchAddressesResult =
       await Database.getSourcifyMatchAddressesByChainAndMatch(
         this.databasePool,
+        this.schema,
         parseInt(chainId),
         match,
         page,
@@ -263,6 +269,7 @@ export class SourcifyDatabaseService
 
     const sourcifyMatchResult = await Database.getSourcifyMatchByChainAddress(
       this.databasePool,
+      this.schema,
       parseInt(chainId),
       bytesFromString(address)!,
     );
@@ -535,7 +542,7 @@ export class SourcifyDatabaseService
           "VerifiedContractId undefined before inserting sourcify match",
         );
       }
-      await Database.insertSourcifyMatch(this.databasePool, {
+      await Database.insertSourcifyMatch(this.databasePool, this.schema, {
         verified_contract_id: verifiedContractId,
         creation_match: match.creationMatch,
         runtime_match: match.runtimeMatch,
@@ -566,6 +573,7 @@ export class SourcifyDatabaseService
       }
       await Database.updateSourcifyMatch(
         this.databasePool,
+        this.schema,
         {
           verified_contract_id: verifiedContractId,
           creation_match: match.creationMatch,

--- a/services/server/src/server/session.ts
+++ b/services/server/src/server/session.ts
@@ -43,6 +43,7 @@ function initDatabaseStore() {
     pool: pool,
     // Pruning expired sessions every 12 hours
     pruneSessionInterval: 12 * 60 * 60,
+    schemaName: process.env.SOURCIFY_POSTGRES_SCHEMA as string,
   });
 }
 


### PR DESCRIPTION
With the new Verifier Alliance database schema naming system, the schemas are named `v0`, `v1`,...  We should add support to custom schemas in AbstractDatabaseService.

This PR adds the support to custom schemas also to the database session

Open questions: 
- Manually adding `"schema"."table"` before every table is the only way I found to implement this. I'm open to suggestions