### PR TITLE
Make `compiled_contracts.creation_code_hash` not nullable

### DIFF
--- a/services/database/migrations/20240924163455-make-compiled_contracts-creation-not-null.js
+++ b/services/database/migrations/20240924163455-make-compiled_contracts-creation-not-null.js
@@ -1,0 +1,52 @@
+// Constraints for the `compiled_contracts` table, according to the Verifier Alliance schema https://github.com/verifier-alliance/database-specs/pull/12
+"use strict";
+
+var async = require("async");
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  async.series(
+    [
+      db.runSql.bind(
+        db,
+        `ALTER TABLE compiled_contracts DROP CONSTRAINT compiled_contracts_pseudo_pkey;
+        ALTER TABLE compiled_contracts ADD CONSTRAINT compiled_contracts_pseudo_pkey UNIQUE (compiler, language, creation_code_hash, runtime_code_hash);
+        ALTER TABLE compiled_contracts ALTER COLUMN creation_code_artifacts SET NOT NULL;
+        ALTER TABLE compiled_contracts ALTER COLUMN creation_code_hash SET NOT NULL;`,
+      ),
+    ],
+    callback,
+  );
+};
+
+exports.down = function (db, callback) {
+  async.series(
+    [
+      db.runSql.bind(
+        db,
+        `ALTER TABLE compiled_contracts ALTER COLUMN creation_code_hash DROP NOT NULL;
+        ALTER TABLE compiled_contracts ALTER COLUMN creation_code_artifacts DROP NOT NULL;
+        ALTER TABLE compiled_contracts DROP CONSTRAINT compiled_contracts_pseudo_pkey;
+        ALTER TABLE compiled_contracts ADD CONSTRAINT compiled_contracts_pseudo_pkey UNIQUE NULLS NOT DISTINCT (compiler, language, creation_code_hash, runtime_code_hash);`,
+      ),
+    ],
+    callback,
+  );
+};
+
+exports._meta = {
+  version: 1,
+};


### PR DESCRIPTION
From kaan

> Do these changes make sense? https://github.com/ethereum/sourcify/blob/6156037dde2374260830fd832b6f9831d16bf1fe/services/database/migrations/20231109160023-sourcify.js#L33-L39
> I checked and there are no contracts with null compiled_contracts.creation_code_hash and _artifacts

Indeed those fields can be set as non nullable fields.

This PR sets `creation_code_hash` and `creation_artifacts` as NOT NULL.

I already executed this script on both production and staging.