### PR TITLE
Fixing Monitor crashing regularly, small additional fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,22 +35,6 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Monitor",
-      "cwd": "${workspaceFolder}/services/monitor",
-      "program": "dist/index.js",
-      "args": ["--chainsPath=chains-dev.json"],
-      "envFile": ".env",
-      "outFiles": [
-        "${workspaceFolder}/services/monitor/dist/**/*.js",
-        "${workspaceFolder}/packages/**/build/**/*.js"
-      ],
-      "smartStep": true,
-      "console": "integratedTerminal",
-      "outputCapture": "std"
-    },
-    {
-      "type": "node",
-      "request": "launch",
       "name": "Monitor - without build",
       "cwd": "${workspaceFolder}/services/monitor",
       "program": "dist/index.js",

--- a/services/monitor/monitorChains.json
+++ b/services/monitor/monitorChains.json
@@ -139,7 +139,7 @@
     "rpc": [
       {
         "type": "ApiKey",
-        "url": "https://ava-mainnet.blastapi.io/{API_KEY}",
+        "url": "https://ava-mainnet.blastapi.io/{API_KEY}/ext/bc/C/rpc",
         "apiKeyEnvName": "BLAST_API_KEY"
       }
     ]
@@ -150,7 +150,7 @@
     "rpc": [
       {
         "type": "ApiKey",
-        "url": "https://ava-testnet.blastapi.io/{API_KEY}",
+        "url": "https://ava-testnet.blastapi.io/{API_KEY}/ext/bc/C/rpc",
         "apiKeyEnvName": "BLAST_API_KEY"
       }
     ]

--- a/services/monitor/src/ChainMonitor.ts
+++ b/services/monitor/src/ChainMonitor.ts
@@ -49,6 +49,7 @@ export default class ChainMonitor extends EventEmitter {
     this.sourceFetchers = sourceFetchers; // TODO: handle multipe
     this.chainLogger = logger.child({
       moduleName: "ChainMonitor #" + this.sourcifyChain.chainId,
+      chainId: this.sourcifyChain.chainId,
     });
 
     this.sourcifyServerURLs = monitorConfig.sourcifyServerURLs;
@@ -344,9 +345,6 @@ export default class ChainMonitor extends EventEmitter {
                   address,
                   sourcifyRequestAttempt,
                 },
-              );
-              throw new Error(
-                "Failed to send contract to Sourcify server after multiple attempts.",
               );
             }
           }


### PR DESCRIPTION
The Monitors were crashing because we were throwing here

https://github.com/ethereum/sourcify/blob/33cc02ec655596b8f1001ec52c2b0c4ab987f91a/services/monitor/src/ChainMonitor.ts#L348-L351

- Removes the throw
- Fixes the Avalanche RPC URLs
- Removes the launch.json built and run Monitor