### PR TITLE
Update the release script to avoid merging master back to staging

### DIFF
--- a/scripts/release/git_utils.sh
+++ b/scripts/release/git_utils.sh
@@ -83,15 +83,63 @@ merge_locally() {
   echo "Merged staging into master"
 }
 
-push_to_master_and_staging() {
+switch_to_staging() {
+  echo "Switching to staging..."
+  git checkout staging
+  echo "Checked out staging"
+}
+
+push_to_master() {
   # Push to master
   echo "Pushing to master..."
   git push origin master
-  # Go back to staging and merge fast forward master. Then push to staging
-  echo "Switching to staging..."
-  git checkout staging
-  echo "Merging master into staging..."
-  git merge master
+  echo "Pushed to master"
+}
+
+ask_if_changelog_pr_merged() {
+  echo "Now please review and approve the PR from the changelogs branch to staging."
+}
+
+push_to_staging() {
   echo "Pushing to staging..."
   git push origin staging
+}
+
+switch_to_master() {
+  echo "Switching to master..."
+  git checkout master
+  echo "Checked out master"
+}
+
+create_new_branch() {
+  local branch_name=$1
+  echo "Creating new branch..."
+  git checkout -b "$branch_name"
+  echo "Created new branch $branch_name"
+}
+
+commit_changelogs() {
+  git commit -m "Update changelogs"
+}
+
+publish_branch() {
+  local branch_name=$1
+  echo "Publishing branch..."
+  git push -u origin "$branch_name"
+  echo "Branch $branch_name published"
+}
+
+open_pr_to_staging() {
+  local branch_name=$1
+  echo "Opening PR to staging..."
+  gh pr create --title "Commit changelogs" --body "" --head "$branch_name" --base staging
+  echo "Opened PR to staging"
+}
+
+switch_to_staging_and_pull() {
+  echo "Switching to staging..."
+  git checkout staging
+  echo "Checked out staging"
+  git pull
+  echo "Pulled latest staging"
 }

--- a/scripts/release/git_utils.sh
+++ b/scripts/release/git_utils.sh
@@ -5,8 +5,8 @@ source "${SCRIPT_DIR}/logging_utils.sh"
 check_current_branch() {
   ## Check if the current branch is master
   local current_branch=$(git rev-parse --abbrev-ref HEAD)
-  if [ "$current_branch" != "master" ]; then
-    error_exit "You are not on the master branch. Please switch to the master branch before running this script."
+  if [ "$current_branch" != "staging" ]; then
+    error_exit "You are not on the staging branch. Please switch to the staging branch before running this script."
   fi
 }
 

--- a/scripts/release/main.sh
+++ b/scripts/release/main.sh
@@ -24,8 +24,8 @@ prompt_execute_or_skip "creating GitHub PR" create_gh_pr
 if [ -z "$OPEN_PR_NUMBER" ]; then
   OPEN_PR_NUMBER=$(gh pr list --base master --state open | grep staging | awk '{print $1}')
 fi
- 
-prompt_execute_or_skip "merging locally" merge_locally
+
+prompt_execute_or_skip "switching to staging" switch_to_staging
 
 # Define arrays to hold package directories, names, and versions. These are global and needed
 declare -a directories
@@ -35,9 +35,19 @@ declare -A selected_versions
 
 check_packages_for_update # Must run this because it sets the above variables
 
+prompt_execute_or_skip "creating new branch" create_new_branch "commit-changelogs-$(date +'%Y-%m-%d')"
 prompt_execute_or_skip "choosing versions for each package and writing changelogs" update_packages_and_changelog
 prompt_execute_or_skip "commiting the changelogs" commit_changelogs
+prompt_execute_or_skip "publishing the branch" publish_branch "commit-changelogs-$(date +'%Y-%m-%d')"
+prompt_execute_or_skip "opening PR to staging" open_pr_to_staging "commit-changelogs-$(date +'%Y-%m-%d')"
+
+prompt_execute_or_skip "asking if changelogs PR is merged" ask_if_changelog_pr_merged
+prompt_execute_or_skip "switching to staging and pulling latest" switch_to_staging_and_pull
+
+prompt_execute_or_skip "switching to master" switch_to_master
+prompt_execute_or_skip "merging staging to master locally" merge_locally
+
 prompt_execute_or_skip "choosing same versions in lerna to create git tags and updating dependencies" run_lerna_version
 prompt_execute_or_skip "pushing the tags to GitHub" push_tags_in_order
-prompt_execute_or_skip "pusing the commits to master and back to staging" push_to_master_and_staging
+prompt_execute_or_skip "pushing the commits to master" push_to_master
 prompt_execute_or_skip "creating GitHub releases" create_github_releases

--- a/scripts/release/main.sh
+++ b/scripts/release/main.sh
@@ -25,8 +25,6 @@ if [ -z "$OPEN_PR_NUMBER" ]; then
   OPEN_PR_NUMBER=$(gh pr list --base master --state open | grep staging | awk '{print $1}')
 fi
 
-prompt_execute_or_skip "switching to staging" switch_to_staging
-
 # Define arrays to hold package directories, names, and versions. These are global and needed
 declare -a directories
 declare -a packageNames


### PR DESCRIPTION
Updates the release script to not merge master back to staging after release, as discussed in https://github.com/ethereum/sourcify/pull/1638

Previously we did:
- Open a PR from staging to master
- merge staging to master locally
- choose package versions, write and commit changelogs (on master)
- choose the versions in lerna
- push the tags to the origin
- push the commits to origin/master, this will merge the PR
- create GH releases
- Merge master back to staging (this now requires another PR)

The changes do the following:


- Open a PR from staging to master
- Locally go to staging
- Create a new branch from staging called `commit-changelogs-2024-01-01`
- Choose package versions, write and commit changelogs
- Publish `commit-changelogs-2024-01-01`, and open a PR to staging.
- Approve and merge the PR to staging
- Pull latest staging changes locally
- Switch to master
- Merge staging to master locally
- choose the versions in lerna (this will update inter-dependencies and create tags)
- push the tags to origin
- push the commits to origin/master, this will merge the PR automatically
- create GH releases

In the end we still need an additional PR to push the changelogs to staging, as it is protected. At least now we shouldn't have to merge master back to staging.

Also keep in mind these changes will only be in staging and not in master yet. So https://github.com/ethereum/sourcify/pull/1674/commits/8eaa071cfd22203783f407e6b3c57eacf7004033 makes sure we start the release from the staging branch instead of master.