### PR TITLE
Fix missing source after match upgrade

### DIFF
--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -560,6 +560,13 @@ export default abstract class AbstractDatabaseService {
             recompiledRuntimeCodeInsertResult.rows[0].bytecode_hash,
         });
 
+      const compiledContractId = compiledContractsInsertResult.rows[0].id;
+
+      await Database.insertCompiledContractsSources(client, {
+        sourcesInformation: databaseColumns.sourcesInformation,
+        compilation_id: compiledContractId,
+      });
+
       // update verified contract with the newly added recompiled contract
       const verifiedContractInsertResult =
         await Database.insertVerifiedContract(client, this.schema, {

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -371,4 +371,20 @@ export async function testPartialUpgrade(
   chai
     .expect(contractIdWithCreatorTransactionHash)
     .to.equal(contractIdWithoutCreatorTransactionHash);
+
+  const sourcesResult = await serverFixture.sourcifyDatabase.query(
+    "SELECT encode(source_hash, 'hex') as source_hash FROM compiled_contracts_sources",
+  );
+
+  chai.expect(sourcesResult?.rows).to.have.length(2);
+  chai.expect(sourcesResult?.rows).to.deep.equal([
+    {
+      source_hash:
+        "fd080cadfc692807b0d856c83148034ab5c47ededd67ea6c93c500a2a0fd4378",
+    },
+    {
+      source_hash:
+        "fb898a1d72892619d00d572bca59a5d98a9664169ff850e2389373e2421af4aa",
+    },
+  ]);
 }

--- a/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
+++ b/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
@@ -412,6 +412,22 @@ describe("/", function () {
         contract_id: contractIdWithCreatorTransactionHash,
       });
 
+    const sourcesResult = await serverFixture.sourcifyDatabase.query(
+      "SELECT encode(source_hash, 'hex') as source_hash FROM compiled_contracts_sources",
+    );
+
+    chai.expect(sourcesResult?.rows).to.have.length(2);
+    chai.expect(sourcesResult?.rows).to.deep.equal([
+      {
+        source_hash:
+          "fd080cadfc692807b0d856c83148034ab5c47ededd67ea6c93c500a2a0fd4378",
+      },
+      {
+        source_hash:
+          "fb898a1d72892619d00d572bca59a5d98a9664169ff850e2389373e2421af4aa",
+      },
+    ]);
+
     await waitSecs(2); // allow server some time to execute the deletion (it started *after* the last response)
 
     res = await chai.request(serverFixture.server.app).get(partialMetadataURL);


### PR DESCRIPTION
Inside the function `AbstractDatabaseService.updateExistingVerifiedContract` we didn't call https://github.com/ethereum/sourcify/blob/c14282cbac1e6d5e407e309c7d7dcf935b78adc6/services/server/src/server/services/storageServices/AbstractDatabaseService.ts#L444-L449

So all match upgrades were not containing sources.