### PR TITLE
Rpcs with trace

### DIFF
--- a/packages/lib-sourcify/src/lib/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/lib/SourcifyChain.ts
@@ -299,7 +299,11 @@ export default class SourcifyChain {
       creatorTxHash,
       chainId: this.chainId,
     });
-    return createdContractAddressesInTx.result.code as string;
+    if (createdContractAddressesInTx.action.init) {
+      return createdContractAddressesInTx.action.init as string;
+    } else {
+      throw new Error('.action.init not found in traces');
+    }
   };
 
   /**

--- a/packages/lib-sourcify/src/lib/types.ts
+++ b/packages/lib-sourcify/src/lib/types.ts
@@ -322,8 +322,8 @@ export interface FetchContractCreationTxMethods {
 export type FetchContractCreationTxMethod =
   keyof FetchContractCreationTxMethods;
 
-export type AlchemyInfuraRPC = {
-  type: 'Alchemy' | 'Infura';
+export type APIKeyRPC = {
+  type: 'APIKeyRPC';
   url: string;
   apiKeyEnvName: string;
 };
@@ -342,7 +342,7 @@ export type SourcifyChainExtension = {
     apiKeyEnvName?: string;
   };
   fetchContractCreationTxUsing?: FetchContractCreationTxMethods;
-  rpc?: Array<string | AlchemyInfuraRPC | FetchRequestRPC>;
+  rpc?: Array<string | APIKeyRPC | FetchRequestRPC>;
 };
 
 export interface SourcifyChainsExtensionsObject {

--- a/packages/lib-sourcify/src/lib/types.ts
+++ b/packages/lib-sourcify/src/lib/types.ts
@@ -1,5 +1,6 @@
 import { Abi } from 'abitype';
 import SourcifyChain from './SourcifyChain';
+import { FetchRequest } from 'ethers';
 export interface PathBuffer {
   path: string;
   buffer: Buffer;
@@ -322,16 +323,32 @@ export interface FetchContractCreationTxMethods {
 export type FetchContractCreationTxMethod =
   keyof FetchContractCreationTxMethods;
 
-export type APIKeyRPC = {
-  type: 'APIKeyRPC';
+export type TraceSupport = 'trace_transaction' | 'debug_traceTransaction';
+
+export type BaseRPC = {
   url: string;
+  type: 'BaseRPC';
+  traceSupport?: TraceSupport;
+};
+
+// override the type of BaseRPC to add the type field
+export type APIKeyRPC = Omit<BaseRPC, 'type'> & {
+  type: 'APIKeyRPC';
   apiKeyEnvName: string;
 };
 
-export type FetchRequestRPC = {
+// override the type of BaseRPC to add the type field
+export type FetchRequestRPC = Omit<BaseRPC, 'type'> & {
   type: 'FetchRequest';
-  url: string;
-  headers?: Array<{ headerName: string; headerEnvName: string }>;
+  headers?: Array<{
+    headerName: string;
+    headerEnvName: string;
+  }>;
+};
+
+export type TraceSupportedRPC = {
+  type: TraceSupport;
+  index: number;
 };
 
 export type SourcifyChainExtension = {
@@ -342,7 +359,12 @@ export type SourcifyChainExtension = {
     apiKeyEnvName?: string;
   };
   fetchContractCreationTxUsing?: FetchContractCreationTxMethods;
-  rpc?: Array<string | APIKeyRPC | FetchRequestRPC>;
+  rpc?: Array<string | BaseRPC | APIKeyRPC | FetchRequestRPC>;
+};
+
+export type RPCObjectWithTraceSupport = {
+  rpc: string | FetchRequest;
+  traceSupport?: TraceSupport;
 };
 
 export interface SourcifyChainsExtensionsObject {

--- a/packages/lib-sourcify/src/lib/verification.ts
+++ b/packages/lib-sourcify/src/lib/verification.ts
@@ -688,16 +688,6 @@ export async function matchWithCreationTx(
         abiEncodedConstructorArguments;
     }
 
-    // we need to check if this contract creation tx actually yields the same contract address https://github.com/ethereum/sourcify/issues/887
-    const createdContractAddress = getCreateAddress({
-      from: creatorTx.from,
-      nonce: creatorTx.nonce,
-    });
-    if (createdContractAddress.toLowerCase() !== address.toLowerCase()) {
-      match.creationMatch = null;
-      match.message = `The address being verified ${address} doesn't match the expected ddress of the contract ${createdContractAddress} that will be created by the transaction ${creatorTxHash}.`;
-      return;
-    }
     match.libraryMap = libraryMap;
 
     match.abiEncodedConstructorArguments = abiEncodedConstructorArguments;

--- a/services/server/.env.dev
+++ b/services/server/.env.dev
@@ -46,6 +46,7 @@ SESSION_SECRET=CHANGE_ME
 INFURA_API_KEY=
 # Alchemy used for Arbitrum, Optimism, Polygon, and fallback for Ethereum. See sourcify-chains.ts
 ALCHEMY_API_KEY=
+QUICKNODE_API_KEY=
 # Optional, if not set will use ALCHEMY_API_KEY
 ALCHEMY_API_KEY_OPTIMISM=
 # Optional, if not set will use ALCHEMY_API_KEY

--- a/services/server/README.md
+++ b/services/server/README.md
@@ -26,16 +26,14 @@ See the [Config](#config) section below for details.
 const {
   RWStorageIdentifiers,
 } = require("../server/services/storageServices/identifiers");
-  
+
 module.exports = {
   storage: {
     read: RWStorageIdentifiers.RepositoryV1,
     writeOrWarn: [],
-    writeOrErr: [
-      RWStorageIdentifiers.RepositoryV1
-    ]
-  }
-}
+    writeOrErr: [RWStorageIdentifiers.RepositoryV1],
+  },
+};
 ```
 
 3. Build the monorepo's packages
@@ -188,13 +186,13 @@ A full example of a chain entry is as follows:
         ]
       },
       {
-        "type": "Alchemy", // Alchemy RPCs
-        "url": "https://eth-mainnet.alchemyapi.io/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC", // Alchemy RPCs
+        "url": "https://eth-mainnet.alchemyapi.io/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"
       },
       {
-        "type": "Infura", // Infura RPCs
-        "url": "https://palm-mainnet.infura.io/v3/{INFURA_API_KEY}",
+        "type": "APIKeyRPC", // Infura RPCs
+        "url": "https://palm-mainnet.infura.io/v3/{API_KEY}",
         "apiKeyEnvName": "INFURA_API_KEY"
       }
     ]

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -608,7 +608,7 @@
     },
     "rpc": [
       {
-        "type": "A",
+        "type": "APIKeyRPC",
         "url": "https://palm-testnet.infura.io/v3/{API_KEY}",
         "apiKeyEnvName": "INFURA_API_KEY"
       }

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -35,6 +35,12 @@
         "type": "APIKeyRPC",
         "url": "https://eth-mainnet.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"
+      },
+      {
+        "type": "APIKeyRPC",
+        "url": "https://clean-lingering-meadow.quiknode.pro/{API_KEY}",
+        "apiKeyEnvName": "QUICKNODE_API_KEY",
+        "traceSupport": "trace_transaction"
       }
     ]
   },

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -32,8 +32,8 @@
         ]
       },
       {
-        "type": "Alchemy",
-        "url": "https://eth-mainnet.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://eth-mainnet.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"
       }
     ]
@@ -57,8 +57,8 @@
     "rpc": [
       "https://rpc.holesky.ethpandaops.io",
       {
-        "type": "Alchemy",
-        "url": "https://eth-holesky.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://eth-holesky.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"
       }
     ]
@@ -90,8 +90,8 @@
         ]
       },
       {
-        "type": "Alchemy",
-        "url": "https://eth-sepolia.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://eth-sepolia.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"
       }
     ],
@@ -229,8 +229,8 @@
     },
     "rpc": [
       {
-        "type": "Alchemy",
-        "url": "https://polygon-mainnet.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://polygon-mainnet.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"
       }
     ]
@@ -295,8 +295,8 @@
     },
     "rpc": [
       {
-        "type": "Alchemy",
-        "url": "https://arb-mainnet.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://arb-mainnet.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY_ARBITRUM"
       }
     ]
@@ -443,8 +443,8 @@
     },
     "rpc": [
       {
-        "type": "Alchemy",
-        "url": "https://opt-mainnet.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://opt-mainnet.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY_OPTIMISM"
       }
     ]
@@ -468,8 +468,8 @@
     },
     "rpc": [
       {
-        "type": "Alchemy",
-        "url": "https://opt-sepolia.g.alchemy.com/v2/{ALCHEMY_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://opt-sepolia.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY_OPTIMISM"
       }
     ]
@@ -586,8 +586,8 @@
     },
     "rpc": [
       {
-        "type": "Infura",
-        "url": "https://palm-mainnet.infura.io/v3/{INFURA_API_KEY}",
+        "type": "APIKeyRPC",
+        "url": "https://palm-mainnet.infura.io/v3/{API_KEY}",
         "apiKeyEnvName": "INFURA_API_KEY"
       }
     ]
@@ -602,8 +602,8 @@
     },
     "rpc": [
       {
-        "type": "Infura",
-        "url": "https://palm-testnet.infura.io/v3/{INFURA_API_KEY}",
+        "type": "A",
+        "url": "https://palm-testnet.infura.io/v3/{API_KEY}",
         "apiKeyEnvName": "INFURA_API_KEY"
       }
     ]

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -115,7 +115,7 @@ function buildCustomRpcs(
       }
       return rpc.push(ethersFetchReq);
     }
-    throw new Error(`Invalid rpc type: ${sourcifyRpc}`);
+    throw new Error(`Invalid rpc type: ${JSON.stringify(sourcifyRpc)}`);
   });
   return { rpc, traceSupportedRPCs };
 }

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -94,10 +94,12 @@ function buildCustomRpcs(
     }
     // Fill in the api keys
     else if (sourcifyRpc.type === "APIKeyRPC") {
-      const url = sourcifyRpc.url.replace(
-        "{API_KEY}",
-        process.env[sourcifyRpc.apiKeyEnvName] || process.env["API_KEY"] || "",
-      );
+      const apiKey =
+        process.env[sourcifyRpc.apiKeyEnvName] || process.env["API_KEY"] || "";
+      if (!apiKey) {
+        throw new Error(`API key not found for ${sourcifyRpc.apiKeyEnvName}`);
+      }
+      const url = sourcifyRpc.url.replace("{API_KEY}", apiKey);
       return rpc.push(url);
     }
     // Build ethers.js FetchRequest object for custom rpcs with auth headers

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -3,7 +3,7 @@ import {
   SourcifyChainMap,
   SourcifyChainsExtensionsObject,
   Chain,
-  AlchemyInfuraRPC,
+  APIKeyRPC,
   FetchRequestRPC,
 } from "@ethereum-sourcify/lib-sourcify";
 import { FetchRequest } from "ethers";
@@ -68,24 +68,17 @@ export const LOCAL_CHAINS: SourcifyChain[] = [
  * Function to take the rpc format in sourcify-chains.json and convert it to the format SourcifyChain expects.
  * SourcifyChain expects  url strings or ethers.js FetchRequest objects.
  */
-function buildCustomRpcs(
-  rpc: Array<string | AlchemyInfuraRPC | FetchRequestRPC>,
-) {
+function buildCustomRpcs(rpc: Array<string | APIKeyRPC | FetchRequestRPC>) {
   return rpc.map((rpc) => {
     // simple url
     if (typeof rpc === "string") {
       return rpc;
     }
     // Fill in the api keys
-    else if (rpc.type === "Alchemy") {
+    else if (rpc.type === "APIKeyRPC") {
       return rpc.url.replace(
-        "{ALCHEMY_API_KEY}",
-        process.env[rpc.apiKeyEnvName] || process.env["ALCHEMY_API_KEY"] || "",
-      );
-    } else if (rpc.type === "Infura") {
-      return rpc.url.replace(
-        "{INFURA_API_KEY}",
-        process.env[rpc.apiKeyEnvName] || "",
+        "{API_KEY}",
+        process.env[rpc.apiKeyEnvName] || process.env["API_KEY"] || "",
       );
     }
     // Build ethers.js FetchRequest object for custom rpcs with auth headers
@@ -101,7 +94,7 @@ function buildCustomRpcs(
       }
       return ethersFetchReq;
     }
-    throw new Error(`Invalid rpc type: ${rpc.type}`);
+    throw new Error(`Invalid rpc type: ${rpc}`);
   });
 }
 


### PR DESCRIPTION
A draft PR to add RPCs with trace support, and refactoring the code related to processing traces. It turned into a larger-than-expected PR as 

1. I had to modify `SourcifyChains` to be able to mark which RPCs have trace support and which type of traces (`trace_transaction` or `debug_traceTransaction`).
2. I've encountered couple critical bugs

The bugs:
1. a10bdce5b44f8360623f4e6499b1b3db8b24f0ba: Turns out we were not extracting the correct field from `trace_transaction` type traces. Previously we were getting `trace.result.code` which was the resulting runtime bytecode of the contract, whereas we had to extract `trace.action.init` for the creation bytecode. 
2. e26aafa00f05285e2e5b186e1df216623cea989d: We were doing a double check on the address that this tx should yield (`keccak(tx.from, tx.nonce)`). This is a correct check since we don't have an inherent way to know that this `creatorTxHash` is indeed for the given address. However this only works and only needed for the contracts created with an EOA, i.e. when we take the tx payload as the creation bytecode. For factory created contracts that are created with `create2` this was causing the creationMatch to fail silently. We already have the yielding address in the trace, so we can use that for double checking if this `creatorTx` is for this contract. 

In fact we didn't need this check since also the EOA created contracts have the created address in the tx receipt:
https://github.com/ethereum/sourcify/blob/a10bdce5b44f8360623f4e6499b1b3db8b24f0ba/packages/lib-sourcify/src/lib/SourcifyChain.ts#L458-L461