### PR TITLE
Publish sourcify-server and only publish the package in its own CI run

### DIFF
--- a/.circleci/scripts/publish_to_npm.sh
+++ b/.circleci/scripts/publish_to_npm.sh
@@ -1,35 +1,56 @@
 #!/bin/bash
 
-BYTECODE_UTILS_LOCAL_VERSION=$(cat packages/bytecode-utils/package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g' \
-  | tr -d '[[:space:]]')
-
-BYTECODE_UTILS_NPM_VERSION=$(npm view @ethereum-sourcify/bytecode-utils dist-tags.latest)
-
-LIB_SOURCIFY_LOCAL_VERSION=$(cat packages/lib-sourcify/package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g' \
-  | tr -d '[[:space:]]')
-
-LIB_SOURCIFY_NPM_VERSION=$(npm view @ethereum-sourcify/lib-sourcify dist-tags.latest)
-
+# Set npm auth token
 npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 
-if [ $BYTECODE_UTILS_LOCAL_VERSION = $BYTECODE_UTILS_NPM_VERSION ]; then
-    echo "@ethereum-sourcify/bytecode-utils:"
-    echo "Latest npm version is equal to current package version. Up the version to publish to npm."
-else
-    npm publish packages/bytecode-utils/ --verbose --access=public
-fi
+# Define package directories and their corresponding npm package names, e.g.
+# packages/bytecode-utils:@ethereum-sourcify/bytecode-utils
+packages=(
+  "packages/bytecode-utils:@ethereum-sourcify/bytecode-utils"
+  "packages/lib-sourcify:@ethereum-sourcify/lib-sourcify"
+  "services/server:@ethereum-sourcify/server"
+)
 
-if [ $LIB_SOURCIFY_LOCAL_VERSION = $LIB_SOURCIFY_NPM_VERSION ]; then
-    echo "@ethereum-sourcify/lib-sourcify:"
+# Publish packages
+for package in "${packages[@]}"; do
+  IFS=':' read -r local_path npm_package <<<"$package"
+  if [[ $CIRCLE_TAG == ${npm_package}* ]]; then # Only publish if tag starts with package name. Otherwise it will publish all at once.
+    echo "$CIRCLE_TAG matches $npm_package, publishing $npm_package"
+  else
+    echo "Skipping $npm_package as CIRCLE_TAG doesn't start with $npm_package"
+    continue
+  fi
+
+  publish_if_new_version "$local_path" "$npm_package"
+done
+
+# Helper Functions
+# ----------------
+
+# Function to get local version
+get_local_version() {
+  cat "$1/package.json" |
+    grep version |
+    head -1 |
+    awk -F: '{ print $2 }' |
+    sed 's/[",]//g' |
+    tr -d '[[:space:]]'
+}
+
+# Function to get npm version
+get_npm_version() {
+  npm view "$1" dist-tags.latest
+}
+
+# Function to publish package if versions differ
+publish_if_new_version() {
+  local_version=$(get_local_version "$1")
+  npm_version=$(get_npm_version "$2")
+
+  if [ "$local_version" = "$npm_version" ]; then
+    echo "$2:"
     echo "Latest npm version is equal to current package version. Up the version to publish to npm."
-else
-    npm publish packages/lib-sourcify/ --verbose --access=public
-fi
+  else
+    npm publish -w "$2" --verbose --access=public
+  fi
+}


### PR DESCRIPTION
The changes adds the sourcify-server package to be published to npm.

It also adds a check to only publish the packages in their own tagged CI runs. Previously e.g.  when there was a new tag for theese packages, both lib-sourcify and bytecode-utils's CI runs tried to publish both packages. This results in the first one succeeding and publishing both packages but the second one to fail.

Now we check to only publish the package in their corresponding tag CI builds.

Related to #1661. Still need to add the docs how to use the server package.

Edit: TBH I'd skip adding the docs because it's rather complicated to set up a `new Server()` with options. I tried to do the fixes and it takes a lot of time. I'd postpone it until someone requests it and also until #1665 