### PR TITLE
Disable `s3-backup-check`

### DIFF
--- a/.circleci/nightly.yml
+++ b/.circleci/nightly.yml
@@ -50,11 +50,11 @@ workflows:
       - monitor-e2e-holesky
       - verification-e2e-sepolia
       - verification-e2e-holesky
-  s3-backup-check:
-    when:
-      equal: [ master, << pipeline.git.branch >> ]
-    jobs:
-      - check-s3-backup
+  # s3-backup-check:
+  #   when:
+  #     equal: [ master, << pipeline.git.branch >> ]
+  #   jobs:
+  #     - check-s3-backup
   etherscan-instances:
     jobs:
       - check-etherscan-instances


### PR DESCRIPTION
This PR disables `s3-backup-check`. Let's keep this disabled until we implement a fix for the s3 sync script.