### PR TITLE
Enable writing to the verifier alliance test database in staging

### DIFF
--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -11,7 +11,7 @@ module.exports = {
   storage: {
     read: RWStorageIdentifiers.SourcifyDatabase,
     writeOrWarn: [
-      // WStorageIdentifiers.AllianceDatabase,
+      WStorageIdentifiers.AllianceDatabase,
       RWStorageIdentifiers.RepositoryV1,
     ],
     writeOrErr: [


### PR DESCRIPTION
This PR simply enables the `WStorageIdentifiers.AllianceDatabase` in the staging configuration under `writeOrWarn` storage services.