### PR TITLE
Fix wrong tag name for sourcify-server in the npm publish script

### DIFF
--- a/.circleci/scripts/publish_to_npm.sh
+++ b/.circleci/scripts/publish_to_npm.sh
@@ -8,7 +8,7 @@ npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 packages=(
   "packages/bytecode-utils:@ethereum-sourcify/bytecode-utils"
   "packages/lib-sourcify:@ethereum-sourcify/lib-sourcify"
-  "services/server:@ethereum-sourcify/server"
+  "services/server:sourcify-server"
 )
 
 # Publish packages


### PR DESCRIPTION
Publishing the `sourcify-server` on npm failed on CI because of the wrong package name: https://app.circleci.com/pipelines/github/ethereum/sourcify/7227/workflows/fc503e37-673d-42a6-b69e-c318145e95b3/jobs/43733

Fixes this by giving the correct package name