### PR TITLE
Fix no RPCs available in CI

### DIFF
--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -176,9 +176,22 @@ for (const i in allChains) {
 
   if (chainId in sourcifyChainsExtensions) {
     const sourcifyExtension = sourcifyChainsExtensions[chainId];
-    const { rpc, rpcWithoutApiKeys, traceSupportedRPCs } = buildCustomRpcs(
-      sourcifyExtension.rpc || chain.rpc,
-    );
+
+    let rpc: (string | FetchRequest)[] = [];
+    let rpcWithoutApiKeys: string[] = [];
+    let traceSupportedRPCs: TraceSupportedRPC[] | undefined = undefined;
+    if (sourcifyExtension.rpc) {
+      ({ rpc, rpcWithoutApiKeys, traceSupportedRPCs } = buildCustomRpcs(
+        sourcifyExtension.rpc,
+      ));
+    }
+    // Fallback to rpcs of chains.json
+    if (!rpc.length) {
+      ({ rpc, rpcWithoutApiKeys, traceSupportedRPCs } = buildCustomRpcs(
+        chain.rpc,
+      ));
+    }
+
     // sourcifyExtension is spread later to overwrite chains.json values, rpc specifically
     const sourcifyChain = new SourcifyChain({
       ...chain,


### PR DESCRIPTION
Fixes #1734 

After merging https://github.com/ethereum/sourcify/pull/1732, we were skipping RPCs in the CI, when no environment variables are available. This led to no rpcs being available for some chains. 

With this PR, we first try the rpcs in sourcify-chains.json, and if all were skipped we make use of the ones in chains.json.