### PR TITLE
Improve platform architecture management for Vyper compiler

### DIFF
--- a/packages/lib-sourcify/test/compiler/vyperCompiler.ts
+++ b/packages/lib-sourcify/test/compiler/vyperCompiler.ts
@@ -102,11 +102,13 @@ export async function getVyperExecutable(
     version,
     fileName,
   );
-  logDebug('Downloaded vyper', {
-    version,
-    vyperPath,
-    platform,
-  });
+  if (success) {
+    logDebug('Downloaded vyper', {
+      version,
+      vyperPath,
+      platform,
+    });
+  }
   if (success && !validateVyperPath(vyperPath)) {
     logError('Cannot validate vyper', {
       version,

--- a/packages/lib-sourcify/test/compiler/vyperCompiler.ts
+++ b/packages/lib-sourcify/test/compiler/vyperCompiler.ts
@@ -10,7 +10,10 @@ import { logDebug, logError, logWarn } from '../../src/lib/logger';
 const HOST_VYPER_REPO = 'https://github.com/vyperlang/vyper/releases/download/';
 
 export function findVyperPlatform(): string | false {
-  if (process.platform === 'darwin') {
+  if (
+    process.platform === 'darwin' &&
+    (process.arch === 'x64' || process.arch === 'arm64')
+  ) {
     return 'darwin';
   }
   if (process.platform === 'linux' && process.arch === 'x64') {
@@ -37,13 +40,20 @@ export async function useVyperCompiler(
   vyperJsonInput: VyperJsonInput,
 ): Promise<VyperOutput> {
   const vyperPlatform = findVyperPlatform();
-  let vyperPath;
-  if (vyperPlatform) {
-    vyperPath = await getVyperExecutable(vyperRepoPath, vyperPlatform, version);
+  if (!vyperPlatform) {
+    throw new Error('Vyper is not supported on this machine.');
   }
 
+  const vyperPath = await getVyperExecutable(
+    vyperRepoPath,
+    vyperPlatform,
+    version,
+  );
+
   if (!vyperPath) {
-    throw new Error('Vyper path not found');
+    throw new Error(
+      'Vyper path not found. Maybe an incorrect version was provided.',
+    );
   }
 
   let compiled: string | undefined;

--- a/services/server/src/server/services/compiler/local/vyperCompiler.ts
+++ b/services/server/src/server/services/compiler/local/vyperCompiler.ts
@@ -10,7 +10,10 @@ import { asyncExec, fetchWithBackoff } from "./common";
 const HOST_VYPER_REPO = "https://github.com/vyperlang/vyper/releases/download/";
 
 export function findVyperPlatform(): string | false {
-  if (process.platform === "darwin") {
+  if (
+    process.platform === "darwin" &&
+    (process.arch === "x64" || process.arch === "arm64")
+  ) {
     return "darwin";
   }
   if (process.platform === "linux" && process.arch === "x64") {
@@ -37,13 +40,20 @@ export async function useVyperCompiler(
   vyperJsonInput: VyperJsonInput,
 ): Promise<VyperOutput> {
   const vyperPlatform = findVyperPlatform();
-  let vyperPath;
-  if (vyperPlatform) {
-    vyperPath = await getVyperExecutable(vyperRepoPath, vyperPlatform, version);
+  if (!vyperPlatform) {
+    throw new Error("Vyper is not supported on this machine.");
   }
 
+  const vyperPath = await getVyperExecutable(
+    vyperRepoPath,
+    vyperPlatform,
+    version,
+  );
+
   if (!vyperPath) {
-    throw new Error("Vyper path not found");
+    throw new Error(
+      "Vyper path not found. Maybe an incorrect version was provided.",
+    );
   }
 
   let compiled: string | undefined;

--- a/services/server/src/server/services/compiler/local/vyperCompiler.ts
+++ b/services/server/src/server/services/compiler/local/vyperCompiler.ts
@@ -112,11 +112,13 @@ export async function getVyperExecutable(
     version,
     fileName,
   );
-  logger.debug("Downloaded vyper", {
-    version,
-    vyperPath,
-    platform,
-  });
+  if (success) {
+    logger.debug("Downloaded vyper", {
+      version,
+      vyperPath,
+      platform,
+    });
+  }
   if (success && !validateVyperPath(vyperPath)) {
     logger.error("Cannot validate vyper", {
       version,


### PR DESCRIPTION
I investigated which architectures the binaries are built for. I only had to add a check for Mac binary. I also improved the logging a bit because it was confusing when I tried to run a vyper verification.
