### PR TITLE
Add support for immutables in Vyper

### DIFF
--- a/packages/lib-sourcify/src/lib/AbstractCheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/AbstractCheckedContract.ts
@@ -1,3 +1,4 @@
+import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 import { VyperOutput } from './IVyperCompiler';
 import {
   CompiledContractCborAuxdata,
@@ -17,6 +18,7 @@ export abstract class AbstractCheckedContract {
   runtimeBytecode?: string;
   metadataRaw!: string;
   abstract compilerOutput?: SolidityOutput | VyperOutput;
+  abstract auxdataStyle: AuxdataStyle;
 
   /** Marks the positions of the CborAuxdata parts in the bytecode */
   creationBytecodeCborAuxdata?: CompiledContractCborAuxdata;

--- a/packages/lib-sourcify/src/lib/SolidityCheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/SolidityCheckedContract.ts
@@ -48,7 +48,7 @@ export class SolidityCheckedContract extends AbstractCheckedContract {
   solcJsonInput: any;
   compilerOutput?: SolidityOutput;
 
-  static readonly auxdataStyle: AuxdataStyle.SOLIDITY = AuxdataStyle.SOLIDITY;
+  readonly auxdataStyle: AuxdataStyle.SOLIDITY = AuxdataStyle.SOLIDITY;
 
   /** Checks whether this contract is valid or not.
    *  This is a static method due to persistence issues.
@@ -113,10 +113,7 @@ export class SolidityCheckedContract extends AbstractCheckedContract {
   ): Promise<SolidityCheckedContract | null> {
     let decodedAuxdata;
     try {
-      decodedAuxdata = decodeBytecode(
-        runtimeBytecode,
-        SolidityCheckedContract.auxdataStyle,
-      );
+      decodedAuxdata = decodeBytecode(runtimeBytecode, this.auxdataStyle);
     } catch (err) {
       // There is no auxdata at all in this contract
       return null;
@@ -292,7 +289,7 @@ export class SolidityCheckedContract extends AbstractCheckedContract {
       // Extract the auxdata from the end of the recompiled runtime bytecode
       const [, runtimeAuxdataCbor, runtimeCborLengthHex] = splitAuxdata(
         this.runtimeBytecode,
-        SolidityCheckedContract.auxdataStyle,
+        this.auxdataStyle,
       );
 
       const auxdataFromRawRuntimeBytecode = `${runtimeAuxdataCbor}${runtimeCborLengthHex}`;
@@ -322,7 +319,7 @@ export class SolidityCheckedContract extends AbstractCheckedContract {
       // Try to extract the auxdata from the end of the recompiled creation bytecode
       const [, creationAuxdataCbor, creationCborLengthHex] = splitAuxdata(
         this.creationBytecode,
-        SolidityCheckedContract.auxdataStyle,
+        this.auxdataStyle,
       );
 
       // If we can find the auxdata at the end of the bytecode return; otherwise continue with `generateEditedContract`

--- a/packages/lib-sourcify/src/lib/VyperCheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/VyperCheckedContract.ts
@@ -1,5 +1,6 @@
 import {
   CompiledContractCborAuxdata,
+  ImmutableReferences,
   MetadataOutput,
   RecompilationResult,
   StringMap,
@@ -13,8 +14,12 @@ import {
 } from './IVyperCompiler';
 import { AbstractCheckedContract } from './AbstractCheckedContract';
 import { id } from 'ethers';
-import { AuxdataStyle, splitAuxdata } from '@ethereum-sourcify/bytecode-utils';
-import semver from 'semver';
+import {
+  AuxdataStyle,
+  decode,
+  splitAuxdata,
+} from '@ethereum-sourcify/bytecode-utils';
+import semver, { gte } from 'semver';
 
 /**
  * Abstraction of a checked vyper contract. With metadata and source (vyper) files.
@@ -29,6 +34,7 @@ export class VyperCheckedContract extends AbstractCheckedContract {
     | AuxdataStyle.VYPER
     | AuxdataStyle.VYPER_LT_0_3_10
     | AuxdataStyle.VYPER_LT_0_3_5;
+  compilerVersionCompatibleWithSemver: string;
 
   generateMetadata(output?: VyperOutput) {
     let outputMetadata: MetadataOutput;
@@ -118,21 +124,23 @@ export class VyperCheckedContract extends AbstractCheckedContract {
     this.compilerVersion = vyperCompilerVersion;
 
     // Vyper beta and rc versions are not semver compliant, so we need to handle them differently
-    let compilerVersionForComparison = this.compilerVersion;
-    if (!semver.valid(this.compilerVersion)) {
+    if (semver.valid(this.compilerVersion)) {
+      this.compilerVersionCompatibleWithSemver = this.compilerVersion;
+    } else {
       // Check for beta or release candidate versions
       if (this.compilerVersion.match(/\d+\.\d+\.\d+(b\d+|rc\d+)/)) {
-        compilerVersionForComparison = `${this.compilerVersion
+        this.compilerVersionCompatibleWithSemver = `${this.compilerVersion
           .split('+')[0]
           .replace(/(b\d+|rc\d+)$/, '')}+${this.compilerVersion.split('+')[1]}`;
       } else {
         throw new Error('Invalid Vyper compiler version');
       }
     }
+
     // Vyper version support for auxdata is different for each version
-    if (semver.lt(compilerVersionForComparison, '0.3.5')) {
+    if (semver.lt(this.compilerVersionCompatibleWithSemver, '0.3.5')) {
       this.auxdataStyle = AuxdataStyle.VYPER_LT_0_3_5;
-    } else if (semver.lt(compilerVersionForComparison, '0.3.10')) {
+    } else if (semver.lt(this.compilerVersionCompatibleWithSemver, '0.3.10')) {
       this.auxdataStyle = AuxdataStyle.VYPER_LT_0_3_10;
     } else {
       this.auxdataStyle = AuxdataStyle.VYPER;
@@ -142,6 +150,38 @@ export class VyperCheckedContract extends AbstractCheckedContract {
     this.sources = sources;
     this.vyperSettings = vyperSettings;
     this.initVyperJsonInput();
+  }
+
+  private getImmutableReferences(): ImmutableReferences {
+    if (!this.creationBytecode || !this.runtimeBytecode) {
+      throw new Error(
+        'Cannot generate immutable references if bytecodes are not set',
+      );
+    }
+    let immutableReferences = {};
+    if (gte(this.compilerVersionCompatibleWithSemver, '0.3.10')) {
+      try {
+        const { immutableSize } = decode(
+          this.creationBytecode,
+          AuxdataStyle.VYPER,
+        );
+        if (immutableSize) {
+          immutableReferences = {
+            '0': [
+              {
+                length: immutableSize,
+                start: this.runtimeBytecode.substring(2).length / 2,
+              },
+            ],
+          };
+        }
+      } catch (e) {
+        logWarn('Cannot decode vyper contract bytecode', {
+          creationBytecode: this.creationBytecode,
+        });
+      }
+    }
+    return immutableReferences;
   }
 
   public async recompile(): Promise<RecompilationResult> {
@@ -207,8 +247,7 @@ export class VyperCheckedContract extends AbstractCheckedContract {
       creationBytecode: this.creationBytecode,
       runtimeBytecode: this.runtimeBytecode,
       metadata: this.metadataRaw,
-      // Sometimes the compiler returns empty object (not falsey). Convert it to undefined (falsey).
-      immutableReferences: {},
+      immutableReferences: this.getImmutableReferences(),
       creationLinkReferences: {},
       runtimeLinkReferences: {},
     };

--- a/packages/lib-sourcify/src/lib/VyperCheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/VyperCheckedContract.ts
@@ -163,7 +163,7 @@ export class VyperCheckedContract extends AbstractCheckedContract {
       try {
         const { immutableSize } = decode(
           this.creationBytecode,
-          AuxdataStyle.VYPER,
+          this.auxdataStyle,
         );
         if (immutableSize) {
           immutableReferences = {

--- a/packages/lib-sourcify/src/lib/types.ts
+++ b/packages/lib-sourcify/src/lib/types.ts
@@ -224,8 +224,9 @@ export const LibraryTransformation = (
 export const ImmutablesTransformation = (
   offset: number,
   id: string,
+  type: 'replace' | 'insert',
 ): Transformation => ({
-  type: 'replace',
+  type,
   reason: 'immutable',
   offset,
   id,

--- a/packages/lib-sourcify/test/sources/Vyper/withImmutables/artifact.json
+++ b/packages/lib-sourcify/test/sources/Vyper/withImmutables/artifact.json
@@ -1,0 +1,32 @@
+{
+  "abi": [
+    {
+      "inputs": [],
+      "name": "get_my_immutable",
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OWNER",
+      "outputs": [{ "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "MY_IMMUTABLE",
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "name": "val", "type": "uint256" }],
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    }
+  ],
+  "bytecode": "0x60e7515034610035573360a75260206100f560003960005160c75266eca7a2f8618d6f60e7526100a761003a6000396101076000f35b600080fd60003560e01c60026005820660011b61009d01601e39600051565b635f284cb3811861009257346100985760206100c760403960206040f35b63117803e3811861009257346100985760206100a760403960206040f35b633bc72e5e811861009257346100985760206100c760403960206040f35b635acb1ac8811861009257346100985760206100e760403960206040f35b60006000fd5b600080fd001a00920038005600748418a7810a1860a1657679706572830004000014"
+}

--- a/packages/lib-sourcify/test/sources/Vyper/withImmutables/test.vy
+++ b/packages/lib-sourcify/test/sources/Vyper/withImmutables/test.vy
@@ -1,0 +1,17 @@
+# pragma version ^0.4.0
+
+OWNER: public(immutable(address))
+MY_IMMUTABLE: public(immutable(uint256))
+MY_IMMUTABLE_2: public(immutable(uint256))
+
+@deploy
+def __init__(val: uint256):
+    OWNER = msg.sender
+    MY_IMMUTABLE = val
+    MY_IMMUTABLE_2 = 66612412897398127
+
+
+@external
+@view
+def get_my_immutable() -> uint256:
+  return MY_IMMUTABLE

--- a/packages/lib-sourcify/test/verification.spec.ts
+++ b/packages/lib-sourcify/test/verification.spec.ts
@@ -667,7 +667,7 @@ describe('lib-sourcify tests', () => {
       });
       expect(match.runtimeTransformations).to.deep.equal([
         {
-          type: 'replace',
+          type: 'insert',
           reason: 'immutable',
           offset: 167,
           id: '0',

--- a/packages/lib-sourcify/test/verification.spec.ts
+++ b/packages/lib-sourcify/test/verification.spec.ts
@@ -569,7 +569,7 @@ describe('lib-sourcify tests', () => {
     });
   });
 
-  describe.only('Vyper', () => {
+  describe('Vyper', () => {
     it('should verify a vyper contract', async () => {
       const contractFolderPath = path.join(
         __dirname,

--- a/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.handlers.ts
+++ b/services/server/src/server/controllers/verification/verify/stateless/verify.stateless.handlers.ts
@@ -18,6 +18,7 @@ import { getMatchStatus, getResponseMatchFromMatch } from "../../../../common";
 import logger from "../../../../../common/logger";
 import { Services } from "../../../../services/services";
 import { ChainRepository } from "../../../../../sourcify-chain-repository";
+import { AuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
 
 export async function legacyVerifyEndpoint(
   req: LegacyVerifyRequest,
@@ -198,6 +199,7 @@ export async function verifyDeprecated(
       generateRuntimeCborAuxdataPositions,
       immutableReferences,
       runtimeLinkReferences,
+      AuxdataStyle.SOLIDITY,
     );
 
     match;


### PR DESCRIPTION
This PR adds support to Vyper immutables. Now Sourcify can handle immutables transformations for Vyper and partial matches with contracts with immutables.

We use the information in the cbor auxdata: `['runtime_size', 'data_sizes', 'immutable_size', 'compiler']`, in particular we use `immutable_size` to extract the immutables from the end of the onchain runtime bytecode.