### PR TITLE
Add binary search for creator tx hash

### DIFF
--- a/packages/lib-sourcify/src/lib/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/lib/SourcifyChain.ts
@@ -407,7 +407,10 @@ export default class SourcifyChain {
    * @param {SourcifyChain} sourcifyChain - chain object with rpc's
    * @param {string} address - contract address
    */
-  getBytecode = async (address: string): Promise<string> => {
+  getBytecode = async (
+    address: string,
+    blockNumber?: number,
+  ): Promise<string> => {
     address = getAddress(address);
 
     // Request sequentially. Custom node is always before ALCHEMY so we don't waste resources if succeeds.
@@ -417,6 +420,7 @@ export default class SourcifyChain {
       try {
         logDebug('Fetching bytecode', {
           address,
+          blockNumber,
           providerUrl: provider.url,
           chainId: this.chainId,
           currentProviderIndex,
@@ -424,11 +428,12 @@ export default class SourcifyChain {
         });
         // Race the RPC call with a timeout
         const bytecode = await Promise.race([
-          provider.getCode(address),
+          provider.getCode(address, blockNumber),
           this.rejectInMs(RPC_TIMEOUT, provider.url),
         ]);
         logInfo('Fetched bytecode', {
           address,
+          blockNumber,
           providerUrl: provider.url,
           chainId: this.chainId,
         });
@@ -437,6 +442,7 @@ export default class SourcifyChain {
         if (err instanceof Error) {
           logWarn('Failed to fetch bytecode', {
             address,
+            blockNumber,
             providerUrl: provider.url,
             chainId: this.chainId,
             error: err.message,
@@ -450,6 +456,7 @@ export default class SourcifyChain {
     throw new Error(
       'None of the RPCs responded fetching bytecode for ' +
         address +
+        (blockNumber ? ` at block ${blockNumber}` : '') +
         ' on chain ' +
         this.chainId,
     );

--- a/services/server/test/helpers/LocalChainFixture.ts
+++ b/services/server/test/helpers/LocalChainFixture.ts
@@ -56,6 +56,8 @@ export class LocalChainFixture {
   private _localSigner?: JsonRpcSigner;
   private _defaultContractAddress?: string;
   private _defaultContractCreatorTx?: string;
+  private _defaultContractBlockNumber?: number;
+  private _defaultContractTxIndex?: number;
 
   private hardhatNodeProcess?: ChildProcess;
 
@@ -78,6 +80,16 @@ export class LocalChainFixture {
     if (!this._defaultContractCreatorTx)
       throw new Error("defaultContractCreatorTx not initialized!");
     return this._defaultContractCreatorTx;
+  }
+  get defaultContractBlockNumber(): number {
+    if (this._defaultContractBlockNumber === undefined)
+      throw new Error("defaultContractBlockNumber not initialized!");
+    return this._defaultContractBlockNumber;
+  }
+  get defaultContractTxIndex(): number {
+    if (this._defaultContractTxIndex === undefined)
+      throw new Error("defaultContractTxIndex not initialized!");
+    return this._defaultContractTxIndex;
   }
 
   /**
@@ -116,7 +128,7 @@ export class LocalChainFixture {
       console.log("Initialized Provider");
 
       // Deploy the test contract
-      const { contractAddress, txHash } =
+      const { contractAddress, txHash, blockNumber, txIndex } =
         await deployFromAbiAndBytecodeForCreatorTxHash(
           this._localSigner,
           storageContractArtifact.abi,
@@ -124,6 +136,8 @@ export class LocalChainFixture {
         );
       this._defaultContractAddress = contractAddress;
       this._defaultContractCreatorTx = txHash;
+      this._defaultContractBlockNumber = blockNumber;
+      this._defaultContractTxIndex = txIndex;
     });
 
     after(async () => {

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -61,19 +61,20 @@ export async function deployFromAbiAndBytecodeForCreatorTxHash(
   if (!creationTx) {
     throw new Error(`No deployment transaction found for ${contractAddress}`);
   }
+  if (creationTx.blockNumber === null) {
+    throw new Error(
+      `No block number found for deployment transaction ${creationTx.hash}. Block number: ${creationTx.blockNumber}`,
+    );
+  }
   console.log(
     `Deployed contract at ${contractAddress} with tx ${creationTx.hash}`,
-  );
-
-  const txReceipt = await signer.provider.getTransactionReceipt(
-    creationTx.hash,
   );
 
   return {
     contractAddress,
     txHash: creationTx.hash,
     blockNumber: creationTx.blockNumber,
-    txIndex: txReceipt?.index,
+    txIndex: creationTx.index,
   };
 }
 

--- a/services/server/test/integration/repository-handlers/files.spec.ts
+++ b/services/server/test/integration/repository-handlers/files.spec.ts
@@ -60,6 +60,11 @@ describe("Verify repository endpoints", function () {
             path: `contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
             content: chainFixture.defaultContractMetadata.toString(),
           },
+          {
+            name: "creator-tx-hash.txt",
+            path: `contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
+            content: chainFixture.defaultContractCreatorTx,
+          },
         ]);
         const res1 = await agent.get(
           `/files/tree/any/${
@@ -72,6 +77,7 @@ describe("Verify repository endpoints", function () {
           .to.have.members([
             `${serverUrl}/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/sources/project:/contracts/Storage.sol`,
             `${serverUrl}/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
+            `${serverUrl}/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
           ]);
         const res2 = await agent.get(
           `/files/any/${
@@ -90,6 +96,11 @@ describe("Verify repository endpoints", function () {
             path: `contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
             content: chainFixture.defaultContractMetadata.toString(),
           },
+          {
+            name: "creator-tx-hash.txt",
+            path: `contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
+            content: chainFixture.defaultContractCreatorTx,
+          },
         ]);
         const res3 = await agent.get(
           `/files/tree/${
@@ -101,6 +112,7 @@ describe("Verify repository endpoints", function () {
           .to.have.members([
             `${serverUrl}/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/sources/project:/contracts/Storage.sol`,
             `${serverUrl}/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
+            `${serverUrl}/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
           ]);
         const res4 = await agent.get(
           `/files/contracts/${chainFixture.chainId}`,
@@ -135,6 +147,17 @@ describe("Verify repository endpoints", function () {
           `/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
         );
         chai.expect(res8.status).to.equal(404);
+
+        const res9 = await agent.get(
+          `/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
+        );
+
+        chai.expect(res9.text).to.equal(chainFixture.defaultContractCreatorTx);
+
+        const res10 = await agent.get(
+          `/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/constructor-args.txt`,
+        );
+        chai.expect(res10.status).to.equal(404);
       });
 
       it(`should fetch files of partial match contract. Storage type: ${serverFixture.identifier}`, async function () {
@@ -175,6 +198,7 @@ describe("Verify repository endpoints", function () {
           .to.have.members([
             `${serverUrl}/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/sources/contracts/StorageModified.sol`,
             `${serverUrl}/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
+            `${serverUrl}/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
           ]);
         const res2 = await agent.get(
           `/files/any/${
@@ -192,6 +216,11 @@ describe("Verify repository endpoints", function () {
             name: "metadata.json",
             path: `contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
             content: chainFixture.defaultContractModifiedMetadata.toString(),
+          },
+          {
+            name: "creator-tx-hash.txt",
+            path: `contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
+            content: chainFixture.defaultContractCreatorTx,
           },
         ]);
         const res3 = await agent.get(
@@ -211,6 +240,7 @@ describe("Verify repository endpoints", function () {
           partial: [chainFixture.defaultContractAddress],
         });
 
+        // Check the sources/contracts/StorageModified.sol
         const res5 = await agent.get(
           `/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/sources/contracts/StorageModified.sol`,
         );
@@ -223,6 +253,7 @@ describe("Verify repository endpoints", function () {
         );
         chai.expect(res6.status).to.equal(404);
 
+        // Check the metadata.json
         const res7 = await agent.get(
           `/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
         );
@@ -236,6 +267,17 @@ describe("Verify repository endpoints", function () {
           `/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/metadata.json`,
         );
         chai.expect(res8.status).to.equal(404);
+
+        // Check the creator tx hash
+        const res9 = await agent.get(
+          `/repository/contracts/partial_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/creator-tx-hash.txt`,
+        );
+        chai.expect(res9.text).to.equal(chainFixture.defaultContractCreatorTx);
+
+        const res10 = await agent.get(
+          `/repository/contracts/full_match/${chainFixture.chainId}/${chainFixture.defaultContractAddress}/constructor-args.txt`,
+        );
+        chai.expect(res10.status).to.equal(404);
       });
 
       it(`should fetch a .sol file of specific address. Storage type: ${serverFixture.identifier}`, async function () {

--- a/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
+++ b/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
@@ -29,7 +29,7 @@ import nock from "nock";
 
 chai.use(chaiHttp);
 
-describe("/", function () {
+describe.only("/", function () {
   const chainFixture = new LocalChainFixture();
   const serverFixture = new ServerFixture();
 
@@ -356,7 +356,7 @@ describe("/", function () {
           ];
         }
 
-        return [404]; // This response won't be used since the interceptor is removed
+        return nock.restore(); // Else let pass
       });
 
     let res = await chai

--- a/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
+++ b/services/server/test/integration/verification-handlers/verify.stateless.spec.ts
@@ -338,7 +338,7 @@ describe("/", function () {
 
     // Intercept only eth_getTransactionReceipt calls but allow other RPC calls
     // This will block the binary search for the creation tx hash and creationMatch will be set to null
-    nock("http://localhost:8545")
+    const scope = nock("http://localhost:8545")
       .post("/")
       .reply(function (uri, requestBody) {
         const body =
@@ -355,8 +355,7 @@ describe("/", function () {
             },
           ];
         }
-        // Remove all interceptors and let this request pass through to the real endpoint
-        nock.cleanAll();
+
         return [404]; // This response won't be used since the interceptor is removed
       });
 
@@ -368,8 +367,8 @@ describe("/", function () {
       .attach("files", partialMetadataBuffer, "metadata.json")
       .attach("files", partialSourceBuffer);
 
-    // Clean up nock interceptors
-    nock.cleanAll();
+    // Remove only this specific interceptor instead of all
+    scope.done();
 
     await assertVerification(
       serverFixture,

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -3,6 +3,9 @@ import { getCreatorTx } from "../../../src/server/services/utils/contract-creati
 import { sourcifyChainsMap } from "../../../src/sourcify-chains";
 import { ChainRepository } from "../../../src/sourcify-chain-repository";
 import { FetchContractCreationTxMethod } from "@ethereum-sourcify/lib-sourcify";
+import sinon from "sinon";
+import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
+import { findContractCreationTxByBinarySearch } from "../../../src/server/services/utils/contract-creation-util";
 
 describe("contract creation util", function () {
   it("should run getCreatorTx with chainId 40", async function () {
@@ -195,4 +198,185 @@ describe("contract creation util", function () {
         );
     });
   }
+
+  describe("findContractCreationTxByBinarySearch", function () {
+    let mockSourcifyChain: SourcifyChain;
+
+    beforeEach(() => {
+      // Create a mock SourcifyChain instance
+      mockSourcifyChain = {
+        getBlockNumber: sinon.stub(),
+        getBytecode: sinon.stub(),
+        getBlock: sinon.stub(),
+        getTxReceipt: sinon.stub(),
+        chainId: 1,
+      } as any;
+    });
+
+    // Not a unit test fetches from live chain, but it's useful for debugging
+    it("should find contract creation transaction using binary search for a live chain", async function () {
+      // Create a copy of the mainnet chain
+      const mainnetChain = Object.create(
+        Object.getPrototypeOf(sourcifyChainsMap[1]),
+        Object.getOwnPropertyDescriptors(sourcifyChainsMap[1]),
+      );
+      // remove all creation tx fetching methods
+      mainnetChain.fetchContractCreationTxUsing = undefined;
+
+      const sourcifyChain = new SourcifyChain(mainnetChain);
+
+      const creatorTx = await findContractCreationTxByBinarySearch(
+        sourcifyChain,
+        "0xdAC17F958D2ee523a2206206994597C13D831ec7", // Tether contract
+      );
+
+      chai
+        .expect(creatorTx)
+        .to.equal(
+          "0x2f1c5c2b44f771e942a8506148e256f94f1a464babc938ae0690c6e34cd79190",
+        );
+    });
+
+    it("should find contract creation transaction using binary search", async function () {
+      const contractAddress = "0x1234567890123456789012345678901234567890";
+      const creationTxHash =
+        "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+      const LATEST_BLOCK = 288031060;
+      const CONTRACT_BLOCK = 4341321;
+
+      // Mock chain responses
+      (mockSourcifyChain.getBlockNumber as sinon.SinonStub).resolves(
+        LATEST_BLOCK,
+      );
+
+      // Mock getBytecode to simulate contract deployment at block 500
+      (mockSourcifyChain.getBytecode as sinon.SinonStub).callsFake(
+        async (address, blockNumber) => {
+          return blockNumber >= CONTRACT_BLOCK ? "0x1234" : "0x";
+        },
+      );
+
+      // Mock block data
+      const mockBlock = {
+        prefetchedTransactions: [
+          { hash: "0xother1", to: "0xsomeaddress" },
+          { hash: "0xother2", to: "0xsomeaddress" },
+          { hash: creationTxHash, to: null },
+          { hash: "0xother3", to: "0xsomeaddress" },
+        ],
+        number: CONTRACT_BLOCK,
+      };
+      (mockSourcifyChain.getBlock as sinon.SinonStub).resolves(mockBlock);
+
+      // Mock transaction receipt
+      (mockSourcifyChain.getTxReceipt as sinon.SinonStub).resolves({
+        contractAddress: contractAddress,
+      });
+
+      const result = await findContractCreationTxByBinarySearch(
+        mockSourcifyChain,
+        contractAddress,
+      );
+
+      // Verify the result
+      chai.expect(result).to.equal(creationTxHash);
+
+      // Verify binary search was performed correctly
+      const bytecodeCalls = (
+        mockSourcifyChain.getBytecode as sinon.SinonStub
+      ).getCalls();
+      chai.expect(bytecodeCalls.length).to.be.greaterThan(1); // Should make multiple calls during binary search
+
+      // Verify the block at deployment was checked
+      chai.expect(
+        (mockSourcifyChain.getBlock as sinon.SinonStub).calledWith(
+          CONTRACT_BLOCK,
+          true,
+        ),
+      ).to.be.true;
+    });
+
+    it("should return null if contract creation transaction is not found", async function () {
+      const contractAddress = "0x1234567890123456789012345678901234567890";
+
+      // Mock chain responses
+      (mockSourcifyChain.getBlockNumber as sinon.SinonStub).resolves(1000);
+      (mockSourcifyChain.getBytecode as sinon.SinonStub).resolves("0x1234");
+
+      // Mock block with no matching creation transaction
+      const mockBlock = {
+        prefetchedTransactions: [
+          { hash: "0xtx1", to: "0xsomeaddress" },
+          { hash: "0xtx2", to: "0xsomeaddress" },
+        ],
+        number: 500,
+      };
+      (mockSourcifyChain.getBlock as sinon.SinonStub).resolves(mockBlock);
+      (mockSourcifyChain.getTxReceipt as sinon.SinonStub).resolves({
+        contractAddress: "0xdifferentaddress",
+      });
+
+      const result = await findContractCreationTxByBinarySearch(
+        mockSourcifyChain,
+        contractAddress,
+      );
+
+      chai.expect(result).to.be.null;
+    });
+
+    it("should handle errors gracefully", async function () {
+      const contractAddress = "0x1234567890123456789012345678901234567890";
+
+      // Mock chain responses to throw error
+      (mockSourcifyChain.getBlockNumber as sinon.SinonStub).rejects(
+        new Error("Network error"),
+      );
+
+      const result = await findContractCreationTxByBinarySearch(
+        mockSourcifyChain,
+        contractAddress,
+      );
+
+      chai.expect(result).to.be.null;
+    });
+
+    it("should handle case where contract does not exist in any block", async function () {
+      const contractAddress = "0x1234567890123456789012345678901234567890";
+
+      // Mock chain responses
+      (mockSourcifyChain.getBlockNumber as sinon.SinonStub).resolves(1000);
+      // Contract never exists in any block
+      (mockSourcifyChain.getBytecode as sinon.SinonStub).resolves("0x");
+
+      const result = await findContractCreationTxByBinarySearch(
+        mockSourcifyChain,
+        contractAddress,
+      );
+
+      chai.expect(result).to.be.null;
+    });
+
+    it("should handle case where block has no transactions", async function () {
+      const contractAddress = "0x1234567890123456789012345678901234567890";
+
+      // Mock chain responses
+      (mockSourcifyChain.getBlockNumber as sinon.SinonStub).resolves(1000);
+      (mockSourcifyChain.getBytecode as sinon.SinonStub).resolves("0x1234");
+
+      // Mock empty block
+      const mockBlock = {
+        prefetchedTransactions: [],
+        number: 500,
+      };
+      (mockSourcifyChain.getBlock as sinon.SinonStub).resolves(mockBlock);
+
+      const result = await findContractCreationTxByBinarySearch(
+        mockSourcifyChain,
+        contractAddress,
+      );
+
+      chai.expect(result).to.be.null;
+    });
+  });
 });


### PR DESCRIPTION
Adds a new function `findContractCreationTxByBinarySearch` to do a lower bound binary search for the transaction that created the contract.

Calls `eth_getCode` on the middle blocks to see if the contract has code. If yes, the contract should be created before this block. If no code, the contract should be created after this block.
Once the block is found, searches through all the tx's of the block to see if any of them created this contract.
Only supports EOA contract creations (tx.to === null). Tracing every single tx would've been quite expensive.


Adds unit tests and an integration test for the Mainnet Tether contract to test the function.