### PR TITLE
Don't store full source content in mocked Vyper metadata object

### DIFF
--- a/packages/lib-sourcify/src/lib/VyperCheckedContract.ts
+++ b/packages/lib-sourcify/src/lib/VyperCheckedContract.ts
@@ -58,7 +58,6 @@ export class VyperCheckedContract extends AbstractCheckedContract {
       (acc, [path, content]) => ({
         ...acc,
         [path]: {
-          content,
           keccak256: id(content),
         },
       }),

--- a/packages/lib-sourcify/test/functions.spec.ts
+++ b/packages/lib-sourcify/test/functions.spec.ts
@@ -304,7 +304,6 @@ describe('Checked contract', () => {
       },
       sources: {
         [contractFileName]: {
-          content: vyperContent.toString(),
           keccak256: id(vyperContent.toString()),
         },
       },


### PR DESCRIPTION
This would blow up the metadata.json for Vyper contracts significantly. The source should be accessed through the source file, not the metadata.