### PR TITLE
Fix creation tx fetching from blockscout after the API change

### DIFF
--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -91,7 +91,8 @@ function getBlockscoutApiContractCreatorFetcher(
 ): ContractCreationFetcher {
   return getApiContractCreationFetcher(
     apiURL + BLOCKSCOUT_API_SUFFIX,
-    (response: any) => response?.creation_tx_hash,
+    (response: any) =>
+      response?.creation_tx_hash || response?.creation_transaction_hash,
   );
 }
 

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -185,6 +185,10 @@ describe("contract creation util", function () {
           [testCase]: testChain.fetchContractCreationTxUsing[testCase],
         };
       }
+      // Block the getBlockNumber call to block the binary search
+      testChain.getBlockNumber = async () => {
+        throw new Error("Blocked getBlockNumber");
+      };
 
       const creatorTx = await getCreatorTx(
         testChain,


### PR DESCRIPTION
This fixes the creation tx hash fetching from the Blockscout API after the unexpected change of `creation_tx_hash` to `creation_transaction_hash`.

Also block binary search during the tests to correctly test the specific case