### PR TITLE
Activate S3Repository in production

### DIFF
--- a/services/server/src/config/master.js
+++ b/services/server/src/config/master.js
@@ -13,6 +13,7 @@ module.exports = {
     writeOrWarn: [
       // WStorageIdentifiers.AllianceDatabase,
       RWStorageIdentifiers.RepositoryV1,
+      WStorageIdentifiers.S3Repository,
     ],
     writeOrErr: [
       WStorageIdentifiers.RepositoryV2,


### PR DESCRIPTION
I already added the environment variables on GCP. The only thing left is to add `WStorageIdentifiers.S3Repository` in the production configurations.