### PR TITLE
Add missing Etherscan api key env names

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -734,7 +734,8 @@
     "sourcifyName": "Moonbase",
     "supported": true,
     "etherscanApi": {
-      "apiURL": "https://api-moonbase.moonscan.io"
+      "apiURL": "https://api-moonbase.moonscan.io",
+      "apiKeyEnvName": "MOONSCAN_MOONBEAM_API_KEY"
     },
     "fetchContractCreationTxUsing": {
       "etherscanApi": true
@@ -2081,7 +2082,8 @@
       "etherscanApi": true
     },
     "etherscanApi": {
-      "apiURL": "https://api-sepolia.basescan.org/"
+      "apiURL": "https://api-sepolia.basescan.org/",
+      "apiKeyEnvName": "BASESCAN_API_KEY"
     },
     "rpc": [
       "https://sepolia.base.org",
@@ -2175,7 +2177,7 @@
     "supported": true,
     "etherscanApi": {
       "apiURL": "https://api-cardona-zkevm.polygonscan.com",
-      "apiKeyEnvName": "POLYGONSCAN_API_KEY"
+      "apiKeyEnvName": "ZKEVM_POLYGONSCAN_API_KEY"
     },
     "fetchContractCreationTxUsing": {
       "etherscanApi": true


### PR DESCRIPTION
See #1835 

Etherscan seems to have changed something about their instances. Some instances seem to not have required an API key, and for some of these we didn't set up a key in the CI or didn't configure them properly in the `sourcify-chains-default.json`.

This PR fixes the latter. I already added the missing env variables to the CI.