### PR TITLE
Add tests for SolidityMetadataContract

### DIFF
--- a/packages/lib-sourcify/test/Validation-draft/SolidityMetadataContract.spec.ts
+++ b/packages/lib-sourcify/test/Validation-draft/SolidityMetadataContract.spec.ts
@@ -1,0 +1,463 @@
+import { expect } from 'chai';
+import { SolidityMetadataContract } from '../../src/Validation/SolidityMetadataContract';
+import { PathContent, Metadata, ISolidityCompiler } from '../../src';
+import { id as keccak256str } from 'ethers';
+import nock from 'nock';
+
+describe('SolidityMetadataContract', () => {
+  let validMetadata: Metadata;
+  let validSourceContent: string;
+  let validSourcePath: string;
+  let validSources: PathContent[];
+
+  beforeEach(() => {
+    // Setup sample source content and calculate its hash
+    validSourcePath = 'contracts/Storage.sol';
+    validSourceContent = `
+      // SPDX-License-Identifier: MIT
+      pragma solidity ^0.8.0;
+
+      contract Storage {
+          uint256 number;
+
+          function store(uint256 num) public {
+              number = num;
+          }
+
+          function retrieve() public view returns (uint256){
+              return number;
+          }
+      }`;
+    const sourceHash = keccak256str(validSourceContent);
+
+    // Create sample metadata
+    validMetadata = {
+      compiler: {
+        version: '0.8.0',
+      },
+      language: 'Solidity',
+      output: {
+        abi: [],
+        devdoc: {
+          kind: 'dev',
+          methods: {},
+          version: 1,
+        },
+        userdoc: {
+          kind: 'user',
+          methods: {},
+          version: 1,
+        },
+      },
+      settings: {
+        compilationTarget: {
+          [validSourcePath]: 'Storage',
+        },
+        evmVersion: 'london',
+        libraries: {},
+        metadata: {
+          bytecodeHash: 'ipfs',
+        },
+        optimizer: {
+          enabled: false,
+          runs: 200,
+        },
+      },
+      sources: {
+        [validSourcePath]: {
+          keccak256: sourceHash,
+          urls: [],
+        },
+      },
+      version: 1,
+    };
+
+    validSources = [
+      {
+        path: validSourcePath,
+        content: validSourceContent,
+      },
+    ];
+  });
+
+  describe('constructor', () => {
+    it('should correctly initialize with valid metadata and sources', () => {
+      const contract = new SolidityMetadataContract(
+        validMetadata,
+        validSources,
+      );
+      expect(contract.name).to.equal('Storage');
+      expect(contract.path).to.equal(validSourcePath);
+      expect(contract.foundSources[validSourcePath]).to.equal(
+        validSourceContent,
+      );
+      expect(Object.keys(contract.missingSources)).to.be.empty;
+      expect(Object.keys(contract.invalidSources)).to.be.empty;
+    });
+
+    it('should handle missing sources', () => {
+      const contract = new SolidityMetadataContract(validMetadata, []);
+      expect(Object.keys(contract.missingSources)).to.have.lengthOf(1);
+      expect(contract.missingSources[validSourcePath]).to.exist;
+    });
+
+    it('should handle invalid sources', () => {
+      const invalidContent = 'invalid content';
+      const invalidSources = [
+        {
+          path: validSourcePath,
+          content: invalidContent,
+        },
+      ];
+      const contract = new SolidityMetadataContract(
+        validMetadata,
+        invalidSources,
+      );
+      expect(Object.keys(contract.missingSources)).to.have.lengthOf(1);
+      expect(contract.missingSources[validSourcePath]).to.exist;
+      expect(Object.keys(contract.invalidSources)).to.be.empty;
+    });
+
+    it('should handle invalid source content in metadata', () => {
+      const invalidMetadata = { ...validMetadata };
+      invalidMetadata.sources[validSourcePath].content = 'invalid content';
+      const contract = new SolidityMetadataContract(invalidMetadata, []);
+      expect(Object.keys(contract.invalidSources)).to.have.lengthOf(1);
+      expect(contract.invalidSources[validSourcePath]).to.exist;
+      expect(contract.invalidSources[validSourcePath].msg).to.include(
+        "don't match",
+      );
+    });
+  });
+
+  describe('handleInlinerBug', () => {
+    it('should remove inliner setting for affected versions', () => {
+      const affectedVersions = ['0.8.2', '0.8.3', '0.8.4'];
+
+      for (const version of affectedVersions) {
+        const metadataWithAffectedVersion = { ...validMetadata };
+        metadataWithAffectedVersion.compiler.version = version;
+        metadataWithAffectedVersion.settings.optimizer = {
+          enabled: true,
+          runs: 200,
+          details: {
+            inliner: true,
+          },
+        };
+
+        const contract = new SolidityMetadataContract(
+          metadataWithAffectedVersion,
+          validSources,
+        );
+        contract.createJsonInputFromMetadata();
+        expect(contract.solcJsonInput?.settings?.optimizer?.details?.inliner).to
+          .be.undefined;
+      }
+    });
+
+    it('should keep inliner setting for unaffected versions', () => {
+      const unaffectedVersions = ['0.8.1', '0.8.5', '0.8.0'];
+
+      for (const version of unaffectedVersions) {
+        const metadataWithUnaffectedVersion = { ...validMetadata };
+        metadataWithUnaffectedVersion.compiler.version = version;
+        metadataWithUnaffectedVersion.settings.optimizer = {
+          enabled: true,
+          runs: 200,
+          details: {
+            inliner: true,
+          },
+        };
+
+        const contract = new SolidityMetadataContract(
+          metadataWithUnaffectedVersion,
+          validSources,
+        );
+        contract.createJsonInputFromMetadata();
+        expect(contract.solcJsonInput?.settings?.optimizer?.details?.inliner).to
+          .be.true;
+      }
+    });
+  });
+
+  describe('compilationTarget', () => {
+    it('should handle invalid compilation target', () => {
+      const metadata = {
+        ...validMetadata,
+        settings: {
+          ...validMetadata.settings,
+          compilationTarget: {
+            'contract1.sol': 'Contract1',
+            'contract2.sol': 'Contract2',
+          },
+        },
+      };
+      expect(
+        () => new SolidityMetadataContract(metadata, validSources),
+      ).to.throw(
+        "Can't create JsonInput from metadata: Invalid compilationTarget in metadata: contract1.sol,contract2.sol",
+      );
+    });
+  });
+
+  describe('generateSourceVariations', () => {
+    it('should generate variations with different line endings', () => {
+      const content = 'line1\nline2\r\nline3\rline4';
+      const sources = [
+        {
+          path: validSourcePath,
+          content,
+        },
+      ];
+
+      const contract = new SolidityMetadataContract(validMetadata, sources);
+      contract.generateSourceVariations();
+
+      const variations = Array.from(contract.providedSourcesByHash.values());
+      expect(variations.length).to.be.greaterThan(1);
+    });
+  });
+
+  describe('handleLibraries', () => {
+    it('should handle pre-0.7.5 library format', () => {
+      const metadata = {
+        ...validMetadata,
+        settings: {
+          ...validMetadata.settings,
+          libraries: {
+            ERC20: '0x1234567890123456789012345678901234567890',
+          },
+        },
+      };
+      const contract = new SolidityMetadataContract(metadata, validSources);
+      contract.createJsonInputFromMetadata();
+      expect(
+        contract.solcJsonInput?.settings?.libraries?.[''] as any,
+      ).to.deep.equal({
+        ERC20: '0x1234567890123456789012345678901234567890',
+      });
+    });
+
+    it('should handle post-0.7.5 library format', () => {
+      const metadata = {
+        ...validMetadata,
+        settings: {
+          ...validMetadata.settings,
+          libraries: {
+            'contracts/Library.sol:ERC20':
+              '0x1234567890123456789012345678901234567890',
+          },
+        },
+      };
+      const contract = new SolidityMetadataContract(metadata, validSources);
+      contract.createJsonInputFromMetadata();
+      expect(
+        contract.solcJsonInput?.settings?.libraries?.[
+          'contracts/Library.sol'
+        ] as any,
+      ).to.deep.equal({
+        ERC20: '0x1234567890123456789012345678901234567890',
+      });
+    });
+  });
+
+  describe('createJsonInputFromMetadata', () => {
+    it('should throw error when there are missing sources', () => {
+      const contract = new SolidityMetadataContract(validMetadata, []);
+      expect(() => contract.createJsonInputFromMetadata()).to.throw(
+        /Can't create JsonInput from metadata: Missing or invalid sources in metadata/,
+      );
+    });
+
+    it('should throw error when there are invalid sources', () => {
+      const invalidSources = [
+        {
+          path: validSourcePath,
+          content: 'invalid content',
+        },
+      ];
+      const contract = new SolidityMetadataContract(
+        validMetadata,
+        invalidSources,
+      );
+      expect(() => contract.createJsonInputFromMetadata()).to.throw(
+        /Can't create JsonInput from metadata: Missing or invalid sources in metadata/,
+      );
+    });
+  });
+
+  describe('createCompilation', () => {
+    it('should create compilation when sources are available', async () => {
+      const contract = new SolidityMetadataContract(
+        validMetadata,
+        validSources,
+      );
+      const mockCompiler: ISolidityCompiler = {
+        compile: async () => ({
+          contracts: {},
+          sources: {},
+          errors: [],
+        }),
+      };
+      const compilation = await contract.createCompilation(mockCompiler);
+      expect(compilation).to.exist;
+      expect(compilation.compiler).to.equal(mockCompiler);
+      expect(compilation.compilerVersion).to.equal(
+        validMetadata.compiler.version,
+      );
+      expect(compilation.compilationTarget).to.equal(
+        `${validSourcePath}:Storage`,
+      );
+    });
+
+    it('should fetch missing sources before creating compilation', async () => {
+      // Create metadata with IPFS source URL
+      const ipfsMetadata = { ...validMetadata };
+      const ipfsHash = 'QmTest';
+      ipfsMetadata.sources[validSourcePath].urls = [`dweb:/ipfs/${ipfsHash}`];
+
+      // Setup mock IPFS response
+      nock('https://ipfs.io')
+        .get(`/ipfs/${ipfsHash}`)
+        .reply(200, validSourceContent);
+
+      const contract = new SolidityMetadataContract(ipfsMetadata, []);
+      expect(Object.keys(contract.missingSources)).to.have.lengthOf(1);
+
+      const mockCompiler: ISolidityCompiler = {
+        compile: async () => ({
+          contracts: {},
+          sources: {},
+          errors: [],
+        }),
+      };
+
+      const compilation = await contract.createCompilation(mockCompiler);
+
+      // Verify missing sources were fetched
+      expect(Object.keys(contract.missingSources)).to.be.empty;
+      expect(contract.foundSources[validSourcePath]).to.equal(
+        validSourceContent,
+      );
+
+      // Verify compilation was created successfully
+      expect(compilation).to.exist;
+      expect(compilation.compiler).to.equal(mockCompiler);
+      expect(compilation.compilerVersion).to.equal(
+        ipfsMetadata.compiler.version,
+      );
+    });
+  });
+
+  describe('fetchMissing', () => {
+    beforeEach(() => {
+      nock.cleanAll();
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should fetch missing sources from GitHub', async () => {
+      const githubMetadata = { ...validMetadata };
+      const githubPath =
+        'https://github.com/test/repo/blob/main/contracts/Storage.sol';
+
+      // Use the GitHub URL as the source path in metadata
+      githubMetadata.sources = {
+        [githubPath]: {
+          keccak256: keccak256str(validSourceContent),
+          urls: [], // URLs array can be empty since the GitHub path is in the filename
+        },
+      };
+
+      nock('https://raw.githubusercontent.com')
+        .get('/test/repo/main/contracts/Storage.sol')
+        .reply(200, validSourceContent);
+
+      const contract = new SolidityMetadataContract(githubMetadata, []);
+      expect(Object.keys(contract.missingSources)).to.have.lengthOf(1);
+
+      await contract.fetchMissing();
+      expect(Object.keys(contract.missingSources)).to.be.empty;
+      expect(contract.foundSources[githubPath]).to.equal(validSourceContent);
+    });
+
+    it('should fetch missing sources from IPFS', async () => {
+      const ipfsMetadata = { ...validMetadata };
+      const ipfsHash = 'QmTest';
+      ipfsMetadata.sources[validSourcePath].urls = [`dweb:/ipfs/${ipfsHash}`];
+
+      nock('https://ipfs.io')
+        .get(`/ipfs/${ipfsHash}`)
+        .reply(200, validSourceContent);
+
+      const contract = new SolidityMetadataContract(ipfsMetadata, []);
+      expect(Object.keys(contract.missingSources)).to.have.lengthOf(1);
+
+      await contract.fetchMissing();
+      expect(Object.keys(contract.missingSources)).to.be.empty;
+      expect(contract.foundSources[validSourcePath]).to.equal(
+        validSourceContent,
+      );
+    });
+
+    it('should throw error when sources cannot be fetched', async () => {
+      const contract = new SolidityMetadataContract(validMetadata, []);
+      expect(Object.keys(contract.missingSources)).to.have.lengthOf(1);
+
+      nock('https://ipfs.io').get(/.*/).reply(404);
+
+      try {
+        await contract.fetchMissing();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.an('Error');
+        expect((error as Error).message).to.include('Resource missing');
+      }
+    });
+  });
+
+  describe('assembleContract', () => {
+    it('should find sources after generating variations', () => {
+      // Create source with different line endings than expected
+      const contentWithDifferentEnding = validSourceContent.replace(
+        /\n/g,
+        '\r\n',
+      );
+      const sourceHash = keccak256str(validSourceContent); // Hash of the expected content
+
+      // Create metadata that expects the original content hash
+      const metadataWithHash = {
+        ...validMetadata,
+        sources: {
+          [validSourcePath]: {
+            keccak256: sourceHash,
+            urls: [],
+          },
+        },
+      };
+
+      // Provide source with different line endings
+      const sourcesWithDifferentEnding = [
+        {
+          path: validSourcePath,
+          content: contentWithDifferentEnding,
+        },
+      ];
+
+      const contract = new SolidityMetadataContract(
+        metadataWithHash,
+        sourcesWithDifferentEnding,
+      );
+
+      // Initially the source should be missing because the hash doesn't match
+      expect(Object.keys(contract.missingSources)).to.be.empty;
+      // But after variations are generated, it should be found
+      expect(contract.foundSources[validSourcePath]).to.exist;
+      expect(contract.metadataPathToProvidedFilePath[validSourcePath]).to.equal(
+        validSourcePath,
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the tests for `SolidityMetadataContract`.

**Coverage summary**

File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |    88.33 |     100 |     100 |                   
 SolidityMetadataContract.ts |     100 |    88.33 |     100 |     100 | 331,361,364,367   


Statements   : 100% ( 379/379 )
Branches     : 88.33% ( 53/60 )
Functions    : 100% ( 15/15 )
Lines        : 100% ( 379/379 )