### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/services/server/CHANGELOG.md
+++ b/services/server/CHANGELOG.md
@@ -142,7 +142,7 @@ All notable changes to this project will be documented in this file.
 
 - Use Postgres session table for session instead of memory only
 - Add dry run parameter for the session verify endpoint
-- Increase lambda function max response size by swithching to streaming
+- Increase lambda function max response size by switching to streaming
 - Add fallback to the local compiler when the lambda response is too large
 - Don't store contract once again if it's already partial and the result is partial
 - New chains:


### PR DESCRIPTION
# Fix Typo in `CHANGELOG.md`

## Description
This pull request addresses a typo in the `services/server/CHANGELOG.md` file:
- **Line 142:** Corrected "swithching" to "switching" for better readability and accuracy.

## Change Details
- **File:** `services/server/CHANGELOG.md`
- **Changes:** 1 addition, 1 deletion.

## Context
The fix ensures proper spelling in the changelog, improving its clarity and professionalism.

Let me know if any additional details are needed!
