### PR TITLE
Add `/v2/contract/{chainId}/{address}?fields=*` option

### DIFF
--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -138,6 +138,7 @@ paths:
         - name: fields
           in: query
           description: Comma seperated fields to include in the response. Can also take `*`
+          allowReserved: true
           schema:
             type: string
             examples:
@@ -145,6 +146,7 @@ paths:
         - name: omit
           in: query
           description: Comma seperated fields to NOT include in the response. All fields except matching ones will be returned. Can't be used simultanously with `fields`.
+          allowReserved: true
           schema:
             type: string
             examples:
@@ -408,6 +410,8 @@ components:
               value:
                 isJobCompleted: true
                 verificationId: 72d12273-0723-448e-a9f6-f7957128efa5
+                jobStartTime: '2024-07-24T11:00:00Z'
+                jobFinishTime: '2024-07-24T12:00:00Z'
                 error:
                   custom_code: non_existing_contract
                   message: Contract 0x2738d13E81e30bC615766A0410e7cF199FD59A83 does not exist on chain 11155111

--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -84,7 +84,15 @@ export function validateFieldsAndOmit(
     }
   };
 
-  fields?.forEach(validateField);
+  if (fields?.includes("*")) {
+    if (fields.length > 1) {
+      throw new InvalidParametersError("Cannot specify '*' with other fields");
+    }
+    // If * is requested, overwrite the requested fields with all existing ones
+    req.query.fields = Object.keys(FIELDS_TO_STORED_PROPERTIES).join(",");
+  } else {
+    fields?.forEach(validateField);
+  }
 
   omits?.forEach(validateField);
 

--- a/services/server/test/integration/apiv2/lookup.spec.ts
+++ b/services/server/test/integration/apiv2/lookup.spec.ts
@@ -749,7 +749,7 @@ describe("GET /v2/contract/:chainId/:address", function () {
     const res = await chai
       .request(serverFixture.server.app)
       .get(
-        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=${encodeURIComponent(optionalFields.join(","))}`,
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=${optionalFields.join(",")}`,
       );
 
     assertGetContractResponse(
@@ -783,7 +783,7 @@ describe("GET /v2/contract/:chainId/:address", function () {
     const res = await chai
       .request(serverFixture.server.app)
       .get(
-        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?omit=${encodeURIComponent(omittedFields.join(","))}`,
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?omit=${omittedFields.join(",")}`,
       );
 
     assertGetContractResponse(
@@ -799,7 +799,7 @@ describe("GET /v2/contract/:chainId/:address", function () {
     const res = await chai
       .request(serverFixture.server.app)
       .get(
-        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=${encodeURIComponent("creationBytecode.sourceMap,creationBytecode.onchainBytecode")}`,
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=creationBytecode.sourceMap,creationBytecode.onchainBytecode`,
       );
 
     assertGetContractResponse(res, chainFixture.defaultContractDeploymentInfo, [
@@ -814,7 +814,7 @@ describe("GET /v2/contract/:chainId/:address", function () {
     const res = await chai
       .request(serverFixture.server.app)
       .get(
-        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?omit=${encodeURIComponent("deployment.transactionHash,deployment.blockNumber")}`,
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?omit=deployment.transactionHash,deployment.blockNumber`,
       );
 
     assertGetContractResponse(

--- a/services/server/test/integration/apiv2/lookup.spec.ts
+++ b/services/server/test/integration/apiv2/lookup.spec.ts
@@ -759,6 +759,22 @@ describe("GET /v2/contract/:chainId/:address", function () {
     );
   });
 
+  it("should support a special field '*' for returning all fields", async function () {
+    await verifyContract(serverFixture, chainFixture);
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=*`,
+      );
+
+    assertGetContractResponse(
+      res,
+      chainFixture.defaultContractDeploymentInfo,
+      optionalFields,
+    );
+  });
+
   it("should return all fields but the omitted ones when requested", async function () {
     const omittedFields = ["proxyResolution", "deployment"];
 
@@ -847,6 +863,21 @@ describe("GET /v2/contract/:chainId/:address", function () {
       .request(serverFixture.server.app)
       .get(
         `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?omit=userdoc&fields=creationBytecode`,
+      );
+
+    chai.expect(res.status).to.equal(400);
+    chai.expect(res.body.customCode).to.equal("invalid_parameter");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
+
+  it("should return a 400 when '*' is used with another field", async function () {
+    await verifyContract(serverFixture, chainFixture);
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=*,creationBytecode`,
       );
 
     chai.expect(res.status).to.equal(400);


### PR DESCRIPTION
Closes #1887 

I added `allowReserved` to fields and omit parameters in Stoplight to prevent users from having to encode the `,` and `*` characters.