### PR TITLE
Log the fetched bytecode length and first 32 bytes

### DIFF
--- a/packages/lib-sourcify/src/lib/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/lib/SourcifyChain.ts
@@ -434,6 +434,8 @@ export default class SourcifyChain {
         logInfo('Fetched bytecode', {
           address,
           blockNumber,
+          bytecodeLength: bytecode.length,
+          bytecodeStart: bytecode.slice(0, 32),
           providerUrl: provider.url,
           chainId: this.chainId,
         });


### PR DESCRIPTION
While debugging why holesky monitor for `0xC13971850152480FE12238676066A9a9D6d0296a` failed, I could see the bytecode was fetched but couldn't see if the RPC returned an empty or invalid response and there were no other informative logs. 

By logging the bytecode length and first bytes we can see what happened there. 

This should be reflected in #1879 @marcocastignoli 