### PR TITLE
Add migrations for `verification_jobs` and `verification_jobs_ephemeral` tables

### DIFF
--- a/services/database/migrations/20231109160023-sourcify.js
+++ b/services/database/migrations/20231109160023-sourcify.js
@@ -75,6 +75,38 @@ exports.up = function (db, callback) {
         ALTER TABLE "session" ADD CONSTRAINT "session_pkey" PRIMARY KEY ("sid") NOT DEFERRABLE INITIALLY IMMEDIATE;
         CREATE INDEX "IDX_session_expire" ON "session" ("expire");`,
       ),
+      // Add verification job tables
+      db.runSql.bind(
+        db,
+        `CREATE TABLE verification_jobs (
+            id BIGSERIAL NOT NULL,
+            status varchar NOT NULL,
+            started_at timestamptz NOT NULL DEFAULT NOW(),
+            completed_at timestamptz,
+            chain_id bigint NOT NULL,
+            contract_address bytea NOT NULL,
+            verified_contract_id BIGSERIAL,
+            error_code varchar,
+            error_id uuid,
+            verification_endpoint varchar NOT NULL,
+            hardware varchar,
+            compilation_time interval,
+            CONSTRAINT verification_jobs_pkey PRIMARY KEY (id),
+            CONSTRAINT verification_jobs_verified_contract_id_fk FOREIGN KEY (verified_contract_id) REFERENCES verified_contracts(id) ON DELETE RESTRICT ON UPDATE RESTRICT
+        );`,
+      ),
+      db.runSql.bind(
+        db,
+        `CREATE TABLE verification_jobs_ephemeral (
+            id BIGSERIAL NOT NULL,
+            onchain_creation_code bytea,
+            onchain_runtime_code bytea,
+            recompiled_creation_code bytea,
+            recompiled_runtime_code bytea,
+            CONSTRAINT verification_jobs_ephemeral_pkey PRIMARY KEY (id),
+            CONSTRAINT verification_jobs_ephemeral_id_fk FOREIGN KEY (id) REFERENCES verification_jobs(id) ON DELETE CASCADE ON UPDATE CASCADE
+        );`,
+      ),
     ],
     callback,
   );
@@ -83,6 +115,8 @@ exports.up = function (db, callback) {
 exports.down = function (db, callback) {
   async.series(
     [
+      db.dropTable.bind(db, "verification_jobs_ephemeral"),
+      db.dropTable.bind(db, "verification_jobs"),
       db.dropTable.bind(db, "session"),
       db.dropTable.bind(db, "sourcify_sync"),
       db.dropTable.bind(db, "sourcify_matches"),


### PR DESCRIPTION
Closes #1884

I created the migrations for the `verification_jobs` table as in my last proposal in #1826 , not including the specific server hardware, because its use case is not entirely clear to me. The `hardware` column should be `"cloud_run:${process.env.K_REVISION}"` as Marco proposed.