### PR TITLE
Add configurable Dune namespace via environment variable

### DIFF
--- a/services/database/dune/DuneDataClient.ts
+++ b/services/database/dune/DuneDataClient.ts
@@ -102,7 +102,7 @@ export interface InsertData {
 export default class DuneClient {
   private readonly baseUrl = "https://api.dune.com/api/v1/table";
   private readonly headers: { [key: string]: string };
-  private readonly namespace = "sourcify_team";
+  private readonly namespace = process.env.DUNE_NAMESPACE || "sourcify";
 
   constructor(apiKey: string) {
     if (!apiKey) {

--- a/services/database/dune/DuneTableClient.ts
+++ b/services/database/dune/DuneTableClient.ts
@@ -12,7 +12,7 @@ interface CreateTableRequest {
 export default class DuneTableClient {
   private readonly baseUrl = "https://api.dune.com/api/v1/table";
   private readonly headers: Record<string, string>;
-  private readonly namespace: string;
+  private readonly namespace = process.env.DUNE_NAMESPACE || "sourcify";
 
   constructor(apiKey: string) {
     if (!apiKey) {
@@ -23,7 +23,6 @@ export default class DuneTableClient {
       "x-dune-api-key": apiKey,
       "Content-Type": "application/json",
     };
-    this.namespace = "sourcify_team";
   }
 
   private async createTable(request: CreateTableRequest): Promise<Response> {

--- a/services/database/dune/README.md
+++ b/services/database/dune/README.md
@@ -20,6 +20,7 @@ POSTGRES_PASSWORD=your_postgres_password
 
 # Dune API Configuration
 DUNE_API_KEY=your_dune_api_key
+DUNE_NAMESPACE=your_dune_namespace
 ```
 
 ### Installation


### PR DESCRIPTION
This PR implements a new environment variable to override the default Dune namespace (default: `sourcify`).