### PR TITLE
Added chain 50: XDC Network Mainnet

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -151,12 +151,21 @@
     "sourcifyName": "Ethereum Rinkeby Testnet",
     "supported": false
   },
-  "51": {
-    "sourcifyName": "Apothem",
+  "50": {
+    "sourcifyName": "XDC Network",
     "supported": true,
     "fetchContractCreationTxUsing": {
       "blocksScanApi": {
-        "url": "https://apothem.blocksscan.io/"
+        "url": "https://xdcscan.io/"
+      }
+    }
+  },
+  "51": {
+    "sourcifyName": "XDC Apothem Testnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blocksScanApi": {
+        "url": "https://apothem.xdcscan.io/"
       }
     }
   },

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -167,11 +167,17 @@ describe("Test Supported Chains", function () {
   //   "shared/"
   //
   // );
+  verifyContract(
+    "0xA0E83aE5dCe0B9203d805D9c2Df3B8dB8687714C",
+    "50",
+    "XDC Network",
+    "shared/",
+  );
 
   verifyContract(
-    "0x8C3FA94eb5b07c9AF7dBFcC53ea3D2BF7FdF3617",
+    "0x705DAB99067D67aec81dd410e8E697106900A045",
     "51",
-    "XinFin Apothem Testnet",
+    "XDC Apothem Testnet",
     "shared/",
   );
 

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -168,14 +168,14 @@ describe("Test Supported Chains", function () {
   //
   // );
   verifyContract(
-    "0xe71b27a3cf12c450fcb8f6d6f42863f4f2f7bf0c",
+    "0xbe4e03bebf828c8b7104841096a2ef19e587ae1d",
     "50",
     "XDC Network",
     "shared/",
   );
 
   verifyContract(
-    "0x705DAB99067D67aec81dd410e8E697106900A045",
+    "0x1eb067d61e9cf30ede5190ddde2f4096c6417ec1",
     "51",
     "XDC Apothem Testnet",
     "shared/",

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -168,7 +168,7 @@ describe("Test Supported Chains", function () {
   //
   // );
   verifyContract(
-    "0xA0E83aE5dCe0B9203d805D9c2Df3B8dB8687714C",
+    "0xe71b27a3cf12c450fcb8f6d6f42863f4f2f7bf0c",
     "50",
     "XDC Network",
     "shared/",


### PR DESCRIPTION
This pull request includes updates to the `services/server` to support the XDC Network and update the XDC Apothem Testnet. The changes primarily involve adding support for the XDC Network and updating the testnet configuration and tests.

Support for XDC Network:

* [`services/server/src/sourcify-chains-default.json`](diffhunk://#diff-ca61b58909fd176243490a3dd9ed979b5b47ae6631fbebba3307f1678d1e131dR154-R168): Added support for the XDC Network with the chain ID `50`, including the `blocksScanApi` URL for contract creation transaction fetching.

Updates to XDC Apothem Testnet:

* [`services/server/src/sourcify-chains-default.json`](diffhunk://#diff-ca61b58909fd176243490a3dd9ed979b5b47ae6631fbebba3307f1678d1e131dR154-R168): Updated the `sourcifyName` and `blocksScanApi` URL for the XDC Apothem Testnet (chain ID `51`).
* [`services/server/test/chains/chain-tests.spec.ts`](diffhunk://#diff-2424fb54671bde4db8df00dda71c574be52c3358a9c9847e1aae154a3c92eb8bR170-R180): Modified the test cases to reflect the new contract addresses and updated names for the XDC Network and XDC Apothem Testnet.<!-- If you are opening a chain support request PR please follow the template below. Otherwise you can write your own PR description -->

# Add New Chain <chainId>

Thanks for your pull request to add a new support in Sourcify.

If you haven't done so, please follow the instructions on [how to request chain support](https://docs.sourcify.dev/docs/chain-support/) in docs.

Please check the following items before submitting your pull request for a speedy review.

## Checklist

- [X] The branch is named as `add-chain-<chainId>`.
- [X] I haven't modified the `chains.json` file directly.
- [X] In `sourcify-chains.json` file
  - [X] I've set `supported: true`.
  - [X] I haven't added an `rpc` field but the one in [chains.json](../../src/chains.json) is used (if not, please explain why).
- [X] I've added a test in [chain-tests.js](../../test/chains/chains-test.js) file.
- [X] `test-new-chain` test in Circle CI is passing.
