### PR TITLE
Add Zircuit Mainnet to monitored chains

### DIFF
--- a/services/monitor/monitorChains.json
+++ b/services/monitor/monitorChains.json
@@ -194,5 +194,16 @@
       "https://rpc.ankr.com/scroll_sepolia_testnet",
       "https://scroll-sepolia-rpc.publicnode.com"
     ]
+  },
+  {
+    "name": "Zircuit Mainnet",
+    "chainId": 48900,
+    "rpc": [
+      {
+        "type": "ApiKey",
+        "url": "https://lb.drpc.org/ogrpc?network=zircuit-mainnet&dkey={API_KEY}",
+        "apiKeyEnvName": "ZIRCUIT_API_KEY"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
I already added the secret in GCP for both production and staging monitor services.