### PR TITLE
Simplify chain tests commands

### DIFF
--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -82,7 +82,7 @@ jobs:
             fi
       - run:
           name: install build and test
-          command: npm install && npx lerna run build --scope=sourcify-server && cd services/server && npm run postgres-test:migrate && npm run test:chains
+          command: npm install && npx lerna run build --scope=sourcify-server && cd services/server && npm run test:chains
           environment:
             DOCKER_HOST_POSTGRES_TEST_PORT: 5432
             SOURCIFY_POSTGRES_HOST: "localhost"

--- a/.circleci/test-chains-regularly.yml
+++ b/.circleci/test-chains-regularly.yml
@@ -21,7 +21,7 @@ jobs:
           command: npm install
       - run:
           name: build and test
-          command: npx lerna run build && npx lerna run test:chains          
+          command: npx lerna run build --scope=sourcify-server && cd services/server && npm run test:chains
           environment:
             DOCKER_HOST_POSTGRES_TEST_PORT: 5432
             SOURCIFY_POSTGRES_HOST: "localhost"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "server:start": "cd services/server && node ./dist/server/cli.js",
     "monitor:start": "node ./services/monitor/dist/index.js",
     "update-chains": "node --experimental-fetch scripts/updateChains.mjs && prettier --write services/server/src/chains.json",
-    "test:chains": "cd services/server && npm run test:chains",
     "lerna-test": "lerna run test --stream",
     "lerna-lint": "lerna run check",
     "lerna-fix": "lerna run fix",


### PR DESCRIPTION
the chain tests were run twice in the CI because we had an unnecessary command in the monorepo package.json. 

This should also fix the git submodule error we saw.