### PR TITLE
Fixes to GET `/v2/contract/`

### DIFF
--- a/services/server/src/server/apiv2/lookup/lookup.handlers.ts
+++ b/services/server/src/server/apiv2/lookup/lookup.handlers.ts
@@ -91,6 +91,10 @@ export async function getContractEndpoint(
     [req.params.chainId, req.params.address, fields, omit],
   );
 
+  if (!contract.match) {
+    return res.status(StatusCodes.NOT_FOUND).json(contract);
+  }
+
   // TODO:
   // The proxy detection will be integrated into the verification process,
   // and the proxy detection result will be stored in the database.
@@ -154,7 +158,5 @@ export async function getContractEndpoint(
     contract.proxyResolution = proxyResolution;
   }
 
-  return res
-    .status(contract.match ? StatusCodes.OK : StatusCodes.NOT_FOUND)
-    .json(contract);
+  return res.status(StatusCodes.OK).json(contract);
 }

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -373,6 +373,10 @@ export class SourcifyDatabaseService
       );
 
     if (sourcifyMatchResult.rowCount === 0) {
+      logger.debug("No sourcify match found for contract", {
+        chainId,
+        address,
+      });
       return {
         match: null,
         creationMatch: null,

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -186,10 +186,10 @@ ${
           AND contract_deployments.chain_id = $1 
           AND contract_deployments.address = $2
         JOIN ${this.schema}.contracts ON contracts.id = contract_deployments.contract_id
-        JOIN ${this.schema}.code as onchain_runtime_code ON onchain_runtime_code.code_hash = contracts.runtime_code_hash
-        JOIN ${this.schema}.code as onchain_creation_code ON onchain_creation_code.code_hash = contracts.creation_code_hash
-        JOIN ${this.schema}.code as recompiled_runtime_code ON recompiled_runtime_code.code_hash = compiled_contracts.runtime_code_hash
-        JOIN ${this.schema}.code as recompiled_creation_code ON recompiled_creation_code.code_hash = compiled_contracts.creation_code_hash
+        LEFT JOIN ${this.schema}.code as onchain_runtime_code ON onchain_runtime_code.code_hash = contracts.runtime_code_hash
+        LEFT JOIN ${this.schema}.code as onchain_creation_code ON onchain_creation_code.code_hash = contracts.creation_code_hash
+        LEFT JOIN ${this.schema}.code as recompiled_runtime_code ON recompiled_runtime_code.code_hash = compiled_contracts.runtime_code_hash
+        LEFT JOIN ${this.schema}.code as recompiled_creation_code ON recompiled_creation_code.code_hash = compiled_contracts.creation_code_hash
 ${
   properties.includes("sources") || properties.includes("std_json_input")
     ? `JOIN ${this.schema}.compiled_contracts_sources ON compiled_contracts_sources.compilation_id = compiled_contracts.id

--- a/services/server/test/integration/apiv2/lookup.spec.ts
+++ b/services/server/test/integration/apiv2/lookup.spec.ts
@@ -992,4 +992,22 @@ describe("GET /v2/contract/:chainId/:address", function () {
       address: contractAddress,
     });
   });
+
+  it("should not return any additional information when the contract is not verified even though all fields are requested", async function () {
+    const contractAddress = "0x0000000000000000000000000000000000000000";
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(
+        `/v2/contract/${chainFixture.chainId}/${contractAddress}?fields=all`,
+      );
+
+    chai.expect(res.status).to.equal(404);
+    chai.expect(res.body).to.deep.equal({
+      match: null,
+      creationMatch: null,
+      runtimeMatch: null,
+      chainId: chainFixture.chainId,
+      address: contractAddress,
+    });
+  });
 });

--- a/services/server/test/integration/apiv2/lookup.spec.ts
+++ b/services/server/test/integration/apiv2/lookup.spec.ts
@@ -204,11 +204,12 @@ describe("GET /v2/contract/:chainId/:address", function () {
     res: Response,
     deploymentInfo: DeploymentInfo,
     requestedFields: string[] = [],
+    hasCreationMatch: boolean = true,
   ) => {
     chai.expect(res.status).to.equal(200);
     chai.expect(res.body).to.include({
       match: "exact_match",
-      creationMatch: "exact_match",
+      creationMatch: hasCreationMatch ? "exact_match" : null,
       runtimeMatch: "exact_match",
       chainId: chainFixture.chainId,
       address: deploymentInfo.contractAddress,
@@ -819,6 +820,29 @@ describe("GET /v2/contract/:chainId/:address", function () {
       optionalFields
         .filter((field) => field !== "deployment")
         .concat(["deployment.transactionIndex", "deployment.deployer"]),
+    );
+  });
+
+  it("should return minimal information for a contract for which no creation code is stored", async function () {
+    // Random tx hash to make sure creation code cannot be found
+    await verifyContract(
+      serverFixture,
+      chainFixture,
+      undefined,
+      "0x60b6dcfac48e31ebdba02f8b32759b66d2593ffa00b763761a22e25d55ace14e",
+    );
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}`,
+      );
+
+    assertGetContractResponse(
+      res,
+      chainFixture.defaultContractDeploymentInfo,
+      [],
+      false,
     );
   });
 


### PR DESCRIPTION
Fixes #1918 

The SQL query used a usual join on the creation bytecode which makes it not possible to retrieve a contract in case we didn't store the creation code.

The other issue was that the proxy resolution was run even though a contract is not veried.