### PR TITLE
Use GenericErrorResponse for all errors returned from /v2

### DIFF
--- a/services/server/src/server/apiv1/controllers.common.ts
+++ b/services/server/src/server/apiv1/controllers.common.ts
@@ -6,6 +6,30 @@ import { isContractAlreadyPerfect } from "./verification/verification.common";
 import { getResponseMatchFromMatch } from "../common";
 import { Services } from "../services/services";
 
+export function checksumAddresses(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  // stateless
+  if (req.body.address) {
+    req.body.address = getAddress(req.body.address);
+  }
+  // session
+  if (req.body.contracts) {
+    req.body.contracts.forEach((contract: any) => {
+      contract.address = getAddress(contract.address);
+    });
+  }
+  if (req.query.addresses) {
+    req.query.addresses = (req.query.addresses as string)
+      .split(",")
+      .map((address: string) => getAddress(address))
+      .join(",");
+  }
+  next();
+}
+
 export function validateAddress(
   req: Request,
   res: Response,

--- a/services/server/src/server/apiv1/routes.ts
+++ b/services/server/src/server/apiv1/routes.ts
@@ -6,8 +6,12 @@ import verifyRoutes from "./verification/verify/verify.routes";
 import solcJsonRoutes from "./verification/solc-json/solc-json.routes";
 import etherscanRoutes from "./verification/etherscan/etherscan.routes";
 import vyperRoutes from "./verification/vyper/vyper.routes";
+import { checksumAddresses } from "./controllers.common";
 
 const router: Router = Router();
+
+// checksum addresses in every request
+router.use(checksumAddresses);
 
 router.use("/chain-tests", testArtifactsRoutes);
 

--- a/services/server/src/server/apiv1/validation.ts
+++ b/services/server/src/server/apiv1/validation.ts
@@ -1,0 +1,67 @@
+import { getAddress, isAddress } from "ethers";
+import { BadRequestError } from "../../common/errors";
+import { ChainRepository } from "../../sourcify-chain-repository";
+import type { OpenApiValidatorOpts } from "express-openapi-validator/dist/framework/types";
+
+export function makeV1ValidatorFormats(
+  chainRepository: ChainRepository,
+): OpenApiValidatorOpts["formats"] {
+  return {
+    "comma-separated-addresses": {
+      type: "string",
+      validate: (addresses: string) => validateAddresses(addresses),
+    },
+    address: {
+      type: "string",
+      validate: (address: string) => validateSingleAddress(address),
+    },
+    "comma-separated-sourcify-chainIds": {
+      type: "string",
+      validate: (chainIds: string) =>
+        chainRepository.validateSourcifyChainIds(chainIds),
+    },
+    "supported-chainId": {
+      type: "string",
+      validate: (chainId: string) =>
+        chainRepository.checkSupportedChainId(chainId),
+    },
+    // "Sourcify chainIds" include the chains that are revoked verification support, but can have contracts in the repo.
+    "sourcify-chainId": {
+      type: "string",
+      validate: (chainId: string) =>
+        chainRepository.checkSourcifyChainId(chainId),
+    },
+    "match-type": {
+      type: "string",
+      validate: (matchType: string) =>
+        matchType === "full_match" || matchType === "partial_match",
+    },
+  };
+}
+
+const validateSingleAddress = (address: string): boolean => {
+  if (!isAddress(address)) {
+    throw new BadRequestError(`Invalid address: ${address}`);
+  }
+  return true; // if it doesn't throw
+};
+
+const validateAddresses = (addresses: string): boolean => {
+  const addressesArray = addresses.split(",");
+  const invalidAddresses: string[] = [];
+  for (const i in addressesArray) {
+    const address = addressesArray[i];
+    if (!isAddress(address)) {
+      invalidAddresses.push(address);
+    } else {
+      addressesArray[i] = getAddress(address);
+    }
+  }
+
+  if (invalidAddresses.length) {
+    throw new BadRequestError(
+      `Invalid addresses: ${invalidAddresses.join(", ")}`,
+    );
+  }
+  return true; // if it doesn't throw
+};

--- a/services/server/src/server/common.ts
+++ b/services/server/src/server/common.ts
@@ -1,4 +1,3 @@
-import { BadRequestError } from "../common/errors";
 import {
   InvalidSources,
   Language,
@@ -9,7 +8,6 @@ import {
   Status,
   StringMap,
 } from "@ethereum-sourcify/lib-sourcify";
-import { getAddress, isAddress } from "ethers";
 import logger from "../common/logger";
 import { InternalServerError } from "express-openapi-validator/dist/openapi.validator";
 import { Request, Response, NextFunction } from "express";
@@ -30,33 +28,6 @@ export const safeHandler = <T extends Request = Request>(
       );
     }
   };
-};
-
-export const validateSingleAddress = (address: string): boolean => {
-  if (!isAddress(address)) {
-    throw new BadRequestError(`Invalid address: ${address}`);
-  }
-  return true; // if it doesn't throw
-};
-
-export const validateAddresses = (addresses: string): boolean => {
-  const addressesArray = addresses.split(",");
-  const invalidAddresses: string[] = [];
-  for (const i in addressesArray) {
-    const address = addressesArray[i];
-    if (!isAddress(address)) {
-      invalidAddresses.push(address);
-    } else {
-      addressesArray[i] = getAddress(address);
-    }
-  }
-
-  if (invalidAddresses.length) {
-    throw new BadRequestError(
-      `Invalid addresses: ${invalidAddresses.join(", ")}`,
-    );
-  }
-  return true; // if it doesn't throw
 };
 
 export interface PathContentMap {

--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -21,7 +21,6 @@ import { asyncLocalStorage } from "../common/async-context";
 import logger from "../common/logger";
 import routes from "./routes";
 import genericErrorHandler from "../common/errors/GenericErrorHandler";
-import { validateAddresses, validateSingleAddress } from "./common";
 import { initDeprecatedRoutes } from "./apiv1/deprecated.routes";
 import getSessionMiddleware from "./session";
 import { Services } from "./services/services";
@@ -34,6 +33,7 @@ import {
 } from "@ethereum-sourcify/lib-sourcify";
 import { ChainRepository } from "../sourcify-chain-repository";
 import { SessionOptions } from "express-session";
+import { makeV1ValidatorFormats } from "./apiv1/validation";
 
 declare module "express-serve-static-core" {
   interface Request {
@@ -174,61 +174,13 @@ export class Server {
           },
         },
         formats: {
-          "comma-separated-addresses": {
-            type: "string",
-            validate: (addresses: string) => validateAddresses(addresses),
-          },
-          address: {
-            type: "string",
-            validate: (address: string) => validateSingleAddress(address),
-          },
-          "comma-separated-sourcify-chainIds": {
-            type: "string",
-            validate: (chainIds: string) =>
-              this.chainRepository.validateSourcifyChainIds(chainIds),
-          },
-          "supported-chainId": {
-            type: "string",
-            validate: (chainId: string) =>
-              this.chainRepository.checkSupportedChainId(chainId),
-          },
-          // "Sourcify chainIds" include the chains that are revoked verification support, but can have contracts in the repo.
-          "sourcify-chainId": {
-            type: "string",
-            validate: (chainId: string) =>
-              this.chainRepository.checkSourcifyChainId(chainId),
-          },
-          "match-type": {
-            type: "string",
-            validate: (matchType: string) =>
-              matchType === "full_match" || matchType === "partial_match",
-          },
+          ...makeV1ValidatorFormats(this.chainRepository),
         },
         $refParser: {
           mode: "dereference",
         },
       }),
     );
-    // checksum addresses in every request
-    this.app.use((req: any, res: any, next: any) => {
-      // stateless
-      if (req.body.address) {
-        req.body.address = getAddress(req.body.address);
-      }
-      // session
-      if (req.body.contracts) {
-        req.body.contracts.forEach((contract: any) => {
-          contract.address = getAddress(contract.address);
-        });
-      }
-      if (req.query.addresses) {
-        req.query.addresses = req.query.addresses
-          .split(",")
-          .map((address: string) => getAddress(address))
-          .join(",");
-      }
-      next();
-    });
 
     if (options.rateLimit.enabled) {
       const hideIpInLogs = options.rateLimit.hideIpInLogs;

--- a/services/server/test/integration/apiv2/lookup.spec.ts
+++ b/services/server/test/integration/apiv2/lookup.spec.ts
@@ -996,13 +996,31 @@ describe("GET /v2/contract/:chainId/:address", function () {
     chainMap[unknownChainId] = chainToRestore;
   });
 
-  it("should return a 400 when the address is invalid", async function () {
+  it("should return a 400 when the address has the wrong length", async function () {
+    const wrongLengthAddress = "0xabc";
+
     const res = await chai
       .request(serverFixture.server.app)
-      .get(`/v2/contract/${chainFixture.chainId}/0xabc`);
+      .get(`/v2/contract/${chainFixture.chainId}/${wrongLengthAddress}`);
 
     chai.expect(res.status).to.equal(400);
-    // todo check error properties when #1855 is implemented
+    chai.expect(res.body.customCode).to.equal("invalid_parameter");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
+
+  it("should return a 400 when the address is invalid", async function () {
+    const invalidAddress =
+      chainFixture.defaultContractAddress.slice(0, 41) + "G";
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contract/${chainFixture.chainId}/${invalidAddress}`);
+
+    chai.expect(res.status).to.equal(400);
+    chai.expect(res.body.customCode).to.equal("invalid_parameter");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
   });
 
   it("should return a 404 when the contract is not verified", async function () {

--- a/services/server/test/integration/errors.spec.ts
+++ b/services/server/test/integration/errors.spec.ts
@@ -1,0 +1,27 @@
+import chai from "chai";
+import chaiHttp from "chai-http";
+import { ServerFixture } from "../helpers/ServerFixture";
+
+chai.use(chaiHttp);
+
+describe("Error handling", function () {
+  const serverFixture = new ServerFixture();
+
+  it("should return a 404 on unknown routes", async function () {
+    const res = await chai.request(serverFixture.server.app).get("/unknown");
+    chai.expect(res.status).equals(404);
+    chai.expect(res.body.customCode).to.equal("route_not_found");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
+
+  it("should return a 404 on unknown methods on known routes", async function () {
+    const res = await chai
+      .request(serverFixture.server.app)
+      .post("/v2/contracts/1");
+    chai.expect(res.status).equals(404);
+    chai.expect(res.body.customCode).to.equal("route_not_found");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
+});


### PR DESCRIPTION
Closes #1855 

This maps the following errors to the new format:
- openapi validator errors
- route not found errors
- unknown / uncaught errors

Also refactors some of the v1 code to the v1 folder in order to reduce the `server.ts` file.