### PR TITLE
Do not throw when chain API keys missing on production

### DIFF
--- a/packages/lib-sourcify/src/lib/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/lib/SourcifyChain.ts
@@ -90,8 +90,6 @@ export default class SourcifyChain {
           provider.url = rpc;
         } else {
           // Do not use WebSockets because of not being able to catch errors on websocket initialization. Most networks don't support WebSockets anyway. See https://github.com/ethers-io/ethers.js/discussions/2896
-          // provider = new WebSocketProvider(rpc);
-          logDebug("Won't create a WebSocketProvider", { rpc });
         }
       } else {
         provider = new JsonRpcProvider(rpc, ethersNetwork, {

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -105,10 +105,13 @@ function buildCustomRpcs(
       const apiKey =
         process.env[sourcifyRpc.apiKeyEnvName] || process.env["API_KEY"] || "";
       if (!apiKey) {
-        // API key is required for all APIKeyRPCs
-        if (process.env.CI === "true") {
+        // Just warn on CI or development
+        if (
+          process.env.CI === "true" ||
+          process.env.NODE_ENV !== "production"
+        ) {
           logger.warn(
-            `API key not found for ${sourcifyRpc.apiKeyEnvName}, skipping on CI`,
+            `API key not found for ${sourcifyRpc.apiKeyEnvName} on ${sourcifyRpc.url}, skipping on CI or development`,
           );
           return;
         } else {


### PR DESCRIPTION
Fixes #1891 

Also removes the useless warning message about Websockets.
