### PR TITLE
Deprecate v1 repository endpoints in openapi spec

### DIFF
--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -13,8 +13,8 @@ tags:
     description: API v2 - Tools and endpoints for looking up contract information
   - name: Stateless Verification 
     description: API v1 - Main verification endpoints
-  - name: Repository
-    description: API v1 - Access to already verified contracts and files
+  - name: (Deprecated) Repository
+    description: API v1 - Access to already verified contracts and files. - Deprecated. Please use the API v2 Contract Lookup instead.
   - name: Session Verification
     description: API v1 - Used by the Sourcify UI to verify contracts. Not intended for external usage. Will require CORS.
 paths:

--- a/services/server/src/server/apiv1/repository/check-all-by-addresses.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/check-all-by-addresses.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /check-all-by-addresses:
     get:
-      deprecated: false
+      deprecated: true
       summary: Check if contracts are verified (full or partial match) by addresses and chain IDs
       description: Checks if contract with the desired chain and address is verified and in the repository. It will search for both perfect and partial matches.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: addresses
           in: query

--- a/services/server/src/server/apiv1/repository/check-by-addresses.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/check-by-addresses.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /check-by-addresses:
     get:
-      deprecated: false
+      deprecated: true
       summary: Check if contracts are verified (full match) by addresses and chain IDs
       description: Checks if contract with the desired chain and address is verified and in the repository. It will search only the perfect matches.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: addresses
           in: query

--- a/services/server/src/server/apiv1/repository/get-contract-addresses-all.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-contract-addresses-all.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/contracts/{chain}:
     get:
-      deprecated: false
+      deprecated: true
       summary: (Deprecated) Get the first 200 contract addresses verified on a chain (full or partial match)
       description: Returns the first 200 verified contracts from the repository for the desired chain. Searches for full and partial matches. This endpoint is deprecated and only retuns 200 addresses. Use `/files/contracts/any/` and `/files/contracts/full/` instead
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-contract-addresses-paginated-all.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-contract-addresses-paginated-all.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/contracts/any/{chain}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get the contract addresses verified on a chain (full or partial match)
       description: Returns the verified contracts from the repository for the desired chain. Searches for full and partial matches. API is paginated. Limit must be a number between 1 and 200.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-contract-addresses-paginated-full.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-contract-addresses-paginated-full.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/contracts/full/{chain}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get the contract addresses perfectly verified on a chain
       description: Returns the perfectly verified contracts from the repository for the desired chain. API is paginated. Limit must be a number between 1 and 200.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-contract-addresses-paginated-partial.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-contract-addresses-paginated-partial.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/contracts/partial/{chain}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get the contract addresses partially verified on a chain
       description: Returns the partially verified contracts from the repository for the desired chain. API is paginated. Limit must be a number between 1 and 200.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-file-static.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-file-static.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /repository/contracts/{full_match | partial_match}/{chain}/{address}/{filePath}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get a specific file from the repository with the file path (static serving)
       description: Retrieve statically served files over the server.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: Match type `full_match` or `partial_match`
           in: path

--- a/services/server/src/server/apiv1/repository/get-file-tree-all.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-file-tree-all.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/tree/any/{chain}/{address}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get file tree (full and partial match)
       description: Returns repository URLs for every file in the source tree for the desired chain and address. Searches for full and partial matches.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-file-tree-full.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-file-tree-full.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/tree/{chain}/{address}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get file tree (full match)
       description: Returns repository URLs for every file in the source tree for the desired chain and address. Searches only for full matches.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-source-files-all.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-source-files-all.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/any/{chain}/{address}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get all files of a contract (full and partial match)
       description: Returns all files for the desired contract with the address and chain. Searches both full and partial matches.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path

--- a/services/server/src/server/apiv1/repository/get-source-files-full.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-source-files-full.stateless.paths.yaml
@@ -3,11 +3,11 @@ openapi: "3.0.0"
 paths:
   /files/{chain}/{address}:
     get:
-      deprecated: false
+      deprecated: true
       summary: Get all files of a contract (full match)
       description: Returns all files for the desired contract with the address and chain. Searches only for full matches.
       tags:
-        - Repository
+        - (Deprecated) Repository
       parameters:
         - name: chain
           in: path


### PR DESCRIPTION
Updates the API docs in order to encourage users to use v2 lookup.