### PR TITLE
fix: update happy testnet (new url)

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -268,7 +268,7 @@
     "supported": true,
     "fetchContractCreationTxUsing": {
       "blockscoutApi": {
-        "url": "https://https://happy-testnet-sepolia.explorer.caldera.xyz"
+        "url": "https://explorer.testnet.happy.tech"
       }
     }
   },

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -259,11 +259,10 @@ describe("Test Supported Chains", function () {
   );
 
   verifyContract(
-    "0x0912105a5383b63DF25BBe39Bedc3De407c6c64B",
+    "0x54Add02fC1664435c38BA49e5553F5952F777bD9",
     "216",
     "Happychain Testnet",
     "shared/",
-    "partial",
   );
 
   verifyContract(


### PR DESCRIPTION
Updates deprecated explorer URL for Happychain Testnet and updates test

Please check the following items before submitting your pull request for a speedy review.

## Checklist

- [ ] The branch is named as `add-chain-<chainId>`.
- [x] I haven't modified the `chains.json` file directly.
- [x] In `sourcify-chains.json` file
  - [x] I've set `supported: true`.
  - [x] I haven't added an `rpc` field but the one in [chains.json](../../src/chains.json) is used (if not, please explain why).
- [x] I've added a test in [chain-tests.js](../../test/chains/chains-test.js) file.
- [x] `test-new-chain` test in Circle CI is passing.
