### PR TITLE
Fix on conflict clause for insertContractDeployment

### DIFF
--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -484,7 +484,7 @@ ${
         block_number,
         transaction_index,
         deployer
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (chain_id, address, transaction_hash, contract_id) DO NOTHING RETURNING *`,
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT ON CONSTRAINT contract_deployments_pseudo_pkey DO NOTHING RETURNING *`,
       [
         chain_id,
         address,


### PR DESCRIPTION
The `ON CONFLICT (chain_id, address, transaction_hash, contract_id)` clause should always match the constraint stored in the database, I didn't know that you can actually use the different syntax `ON CONFLICT ON CONSTRAINT contract_deployments_pseudo_pkey` instead of listing the columns.