### PR TITLE
Improve express error handler

### DIFF
--- a/services/server/src/common/errors/BadGatewayError.ts
+++ b/services/server/src/common/errors/BadGatewayError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class BadGatewayError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.BAD_GATEWAY;
+    this.statusCode = StatusCodes.BAD_GATEWAY;
     this.message = message || "Bad gateway";
   }
 }

--- a/services/server/src/common/errors/BadRequestError.ts
+++ b/services/server/src/common/errors/BadRequestError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class BadRequestError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.BAD_REQUEST;
+    this.statusCode = StatusCodes.BAD_REQUEST;
     this.message = message || "Bad request";
   }
 }

--- a/services/server/src/common/errors/ConflictError.ts
+++ b/services/server/src/common/errors/ConflictError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class ConflictError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.CONFLICT;
+    this.statusCode = StatusCodes.CONFLICT;
     this.message =
       message || "Conflict between the request body vs. the server state";
   }

--- a/services/server/src/common/errors/ContractIsAlreadyBeingVerifiedError.ts
+++ b/services/server/src/common/errors/ContractIsAlreadyBeingVerifiedError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class ContractIsAlreadyBeingVerifiedError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(chainId: string, address: string) {
-    this.code = StatusCodes.TOO_MANY_REQUESTS;
+    this.statusCode = StatusCodes.TOO_MANY_REQUESTS;
     this.message = `The contract ${address} on chainId ${chainId} is already being verified, please wait`;
   }
 }

--- a/services/server/src/common/errors/GenericErrorHandler.ts
+++ b/services/server/src/common/errors/GenericErrorHandler.ts
@@ -1,5 +1,6 @@
 import * as HttpStatus from "http-status-codes";
 import { Request, Response } from "express";
+import logger from "../logger";
 
 export default function genericErrorHandler(
   err: any,
@@ -9,7 +10,10 @@ export default function genericErrorHandler(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _next: any,
 ): void {
-  const errorCode = +err.code || err.status || 500;
+  const errorCode = +err.statusCode || err.status || 500;
+  if (errorCode === 500) {
+    logger.error("Unexpected server error", { error: err });
+  }
 
   if (err.payload) {
     // APIv2 errors include the response payload
@@ -25,7 +29,7 @@ export default function genericErrorHandler(
     return;
   }
   res.status(errorCode).json({
-    error: err.message || HttpStatus.getStatusText(errorCode), // Need to keep this for backward compatibility, but ideally we should respond with `message` only
-    message: err.message || HttpStatus.getStatusText(errorCode),
+    error: err.message || HttpStatus.getReasonPhrase(errorCode), // Need to keep this for backward compatibility, but ideally we should respond with `message` only
+    message: err.message || HttpStatus.getReasonPhrase(errorCode),
   });
 }

--- a/services/server/src/common/errors/GenericErrorHandler.ts
+++ b/services/server/src/common/errors/GenericErrorHandler.ts
@@ -1,4 +1,4 @@
-import * as HttpStatus from "http-status-codes";
+import { getReasonPhrase, StatusCodes } from "http-status-codes";
 import { Request, Response } from "express";
 import logger from "../logger";
 
@@ -10,26 +10,36 @@ export default function genericErrorHandler(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _next: any,
 ): void {
-  const errorCode = +err.statusCode || err.status || 500;
-  if (errorCode === 500) {
-    logger.error("Unexpected server error", { error: err });
-  }
+  try {
+    const errorCode =
+      +err.statusCode || err.status || StatusCodes.INTERNAL_SERVER_ERROR;
+    if (errorCode === StatusCodes.INTERNAL_SERVER_ERROR) {
+      logger.error("Unexpected server error", { error: err });
+    }
 
-  if (err.payload) {
-    // APIv2 errors include the response payload
-    res.status(errorCode).json(err.payload);
-    return;
-  }
-  if (err.errors) {
-    // This is a validation error
+    if (err.payload) {
+      // APIv2 errors include the response payload
+      res.status(errorCode).json(err.payload);
+      return;
+    }
+    if (err.errors) {
+      // This is a validation error
+      res.status(errorCode).json({
+        message: err.message,
+        errors: err.errors,
+      });
+      return;
+    }
     res.status(errorCode).json({
-      message: err.message,
-      errors: err.errors,
+      error: err.message || getReasonPhrase(errorCode), // Need to keep this for backward compatibility, but ideally we should respond with `message` only
+      message: err.message || getReasonPhrase(errorCode),
     });
-    return;
+  } catch (error) {
+    logger.error("Error in genericErrorHandler", { error });
+    const errorCode = StatusCodes.INTERNAL_SERVER_ERROR;
+    res.status(errorCode).json({
+      error: err.message || getReasonPhrase(errorCode),
+      message: err.message || getReasonPhrase(errorCode),
+    });
   }
-  res.status(errorCode).json({
-    error: err.message || HttpStatus.getReasonPhrase(errorCode), // Need to keep this for backward compatibility, but ideally we should respond with `message` only
-    message: err.message || HttpStatus.getReasonPhrase(errorCode),
-  });
 }

--- a/services/server/src/common/errors/InternalServerError.ts
+++ b/services/server/src/common/errors/InternalServerError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class InternalServerError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.INTERNAL_SERVER_ERROR;
+    this.statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
     this.message = message || "Something went wrong";
   }
 }

--- a/services/server/src/common/errors/NotFoundError.ts
+++ b/services/server/src/common/errors/NotFoundError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class NotFoundError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.NOT_FOUND;
+    this.statusCode = StatusCodes.NOT_FOUND;
     this.message = message || "Resouce not found";
   }
 }

--- a/services/server/src/common/errors/PayloadTooLargeError.ts
+++ b/services/server/src/common/errors/PayloadTooLargeError.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class PayloadTooLargeError implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.REQUEST_TOO_LONG;
+    this.statusCode = StatusCodes.REQUEST_TOO_LONG;
     this.message = message || "Payload too large";
   }
 }

--- a/services/server/src/common/errors/TooManyRequests.ts
+++ b/services/server/src/common/errors/TooManyRequests.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 import { IResponseError } from "../interfaces";
 
 export class TooManyRequests implements IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
 
   constructor(message?: string) {
-    this.code = StatusCodes.TOO_MANY_REQUESTS;
+    this.statusCode = StatusCodes.TOO_MANY_REQUESTS;
     this.message = message || "Too Many Requests";
   }
 }

--- a/services/server/src/common/interfaces.ts
+++ b/services/server/src/common/interfaces.ts
@@ -4,7 +4,7 @@ export interface IController {
   registerRoutes(): Router;
 }
 export interface IResponseError {
-  code: number;
+  statusCode: number;
   message: string;
   errors?: any[];
   payload?: Record<string, any>;

--- a/services/server/src/server/apiv2/errors.ts
+++ b/services/server/src/server/apiv2/errors.ts
@@ -118,7 +118,6 @@ export function errorHandler(
     return;
   }
 
-  logger.error("Unknown server error: ", err);
   next(new UnknownError("The server encountered an unexpected error."));
 }
 


### PR DESCRIPTION
Rename `code` of `IResponseError` to `statusCode`
Needed to avoid interfering with postgres errors that also have a `code` property.

Adds logging for all unknown errors.

Also renames deprecated `getStatusText` method of HttpStatus to `getReasonPhrase`