### PR TITLE
Remove error that prevents finding creationAuxdata by recompilation

### DIFF
--- a/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
@@ -139,10 +139,6 @@ export class SolidityCompilation extends AbstractCompilation {
           this.auxdataStyle,
         );
 
-        if (!creationAuxdataCbor) {
-          throw new Error('creationAuxdataCbor is undefined');
-        }
-
         // If we can find the auxdata at the end of the bytecode return; otherwise continue with `generateEditedContract`
         if (creationAuxdataCbor) {
           const auxdataFromRawCreationBytecode = `${creationAuxdataCbor}${creationCborLengthHex}`;


### PR DESCRIPTION
This error should not be thrown, if creation auxdata generation fails at this point we will try to generate it later by re-compiling with slightly edited file