### PR TITLE
Update URL of Syscoin Testnet Tanenbaum explorer (chain 5700).

### DIFF
--- a/services/server/src/chains.json
+++ b/services/server/src/chains.json
@@ -21720,7 +21720,7 @@
     "explorers": [
       {
         "name": "Syscoin Testnet Block Explorer",
-        "url": "https://explorer.tanenbaum.io",
+        "url": "https://tanenbaum.io",
         "standard": "EIP3091"
       }
     ]

--- a/services/server/src/chains.json
+++ b/services/server/src/chains.json
@@ -21720,7 +21720,7 @@
     "explorers": [
       {
         "name": "Syscoin Testnet Block Explorer",
-        "url": "https://tanenbaum.io",
+        "url": "https://explorer.tanenbaum.io",
         "standard": "EIP3091"
       }
     ]

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -532,7 +532,7 @@
     "supported": true,
     "fetchContractCreationTxUsing": {
       "blockscoutScrape": {
-        "url": "https://tanenbaum.io/"
+        "url": "https://explorer.tanenbaum.io/"
       }
     }
   },


### PR DESCRIPTION
# Update Chain 5700

This is only a URL update but seems related to contract verification issue (probably your backend is trying to reach the old explorer URL).

Thanks in advance for your kind help.
