### PR TITLE
Fix check for running jobs

### DIFF
--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -192,7 +192,7 @@ export async function checkIfJobIsAlreadyRunning(
     [chainId, address],
   );
 
-  if (jobs.length > 0 && jobs.every((job) => !job.isJobCompleted)) {
+  if (jobs.length > 0 && jobs.some((job) => !job.isJobCompleted)) {
     logger.warn("Contract already being verified", { chainId, address });
     throw new DuplicateVerificationRequestError(
       `Contract ${address} on chain ${chainId} is already being verified`,


### PR DESCRIPTION
Came across this check which was simply wrong before.

It should not start a new verification if any of the jobs is not completed.

There is already a test for this check, not sure if it is worth to have another.