### PR TITLE
Remove support for chains

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -131,12 +131,7 @@
   },
   "7078815900": {
     "sourcifyName": "Ethereum Mekong Testnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutApi": {
-        "url": "https://explorer.mekong.ethpandaops.io/"
-      }
-    }
+    "supported": false
   },
   "369": {
     "sourcifyName": "PulseChain Mainnet",
@@ -834,10 +829,7 @@
   },
   "11111": {
     "sourcifyName": "WAGMI Testnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "avalancheApi": true
-    }
+    "supported": false
   },
   "192837465": {
     "sourcifyName": "Gather Mainnet",
@@ -1360,20 +1352,11 @@
   },
   "222000222": {
     "sourcifyName": "Kanazawa Testnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "avalancheApi": true
-    }
+    "supported": false
   },
   "333000333": {
     "sourcifyName": "MELD",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "avalancheApi": true,
-      "routescanApi": {
-        "type": "mainnet"
-      }
-    }
+    "supported": false
   },
   "2222": {
     "sourcifyName": "Kava EVM",
@@ -1742,10 +1725,7 @@
   },
   "1127469": {
     "sourcifyName": "Tiltyard Subnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "avalancheApi": true
-    }
+    "supported": false
   },
   "1101": {
     "sourcifyName": "Polygon zkEVM",
@@ -2039,19 +2019,11 @@
   },
   "17069": {
     "sourcifyName": "Garnet Holesky",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutApi": {
-        "url": "https://explorer.garnetchain.com/api"
-      }
-    }
+    "supported": false
   },
   "12898": {
     "sourcifyName": "PlayFair Testnet Subnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "avalancheApi": true
-    }
+    "supported": false
   },
   "19011": {
     "sourcifyName": "HOME Verse Mainnet",

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -124,13 +124,13 @@ describe("Test Supported Chains", function () {
   //   "shared/"
   // );
 
-  // Ethereum Mekong Testnet
-  verifyContract(
-    "0x247a8A599c99336dF37af1975661b32f7A26a88E",
-    "7078815900",
-    "Ethereum Mekong Testnet",
-    "shared/",
-  );
+  // // Ethereum Mekong Testnet
+  // verifyContract(
+  //   "0x247a8A599c99336dF37af1975661b32f7A26a88E",
+  //   "7078815900",
+  //   "Ethereum Mekong Testnet",
+  //   "shared/",
+  // );
 
   verifyContract(
     "0x7ecedB5ca848e695ee8aB33cce9Ad1E1fe7865F8",
@@ -559,12 +559,12 @@ describe("Test Supported Chains", function () {
   );
 
   // WAGMI Testnet
-  verifyContract(
-    "0x5974BF3196fc03A20cEB196270307707e0158BbD",
-    "11111",
-    "WAGMI",
-    "shared/",
-  );
+  // verifyContract(
+  //   "0x5974BF3196fc03A20cEB196270307707e0158BbD",
+  //   "11111",
+  //   "WAGMI",
+  //   "shared/",
+  // );
 
   // // Gather Mainnet
   // verifyContract(
@@ -1035,20 +1035,20 @@ describe("Test Supported Chains", function () {
   );
 
   // Kanazawa Chain Testnet
-  verifyContract(
-    "0x24c456Fb4c450208366B1f8322c3241aA013758e",
-    "222000222",
-    "Kanazawa Chain",
-    "multicall-literal-contents/",
-  );
+  // verifyContract(
+  //   "0x24c456Fb4c450208366B1f8322c3241aA013758e",
+  //   "222000222",
+  //   "Kanazawa Chain",
+  //   "multicall-literal-contents/",
+  // );
 
-  // MELD Chain Testnet
-  verifyContract(
-    "0x769eE5A8e82C15C1b6E358f62aC8eb6E3AbE8dC5",
-    "333000333",
-    "MELD Chain",
-    "multicall-literal-contents/",
-  );
+  // // MELD Chain Testnet
+  // verifyContract(
+  //   "0x769eE5A8e82C15C1b6E358f62aC8eb6E3AbE8dC5",
+  //   "333000333",
+  //   "MELD Chain",
+  //   "multicall-literal-contents/",
+  // );
 
   // Kiwi Subnet
   verifyContract(
@@ -1342,13 +1342,13 @@ describe("Test Supported Chains", function () {
     "shared/",
   );
 
-  // Tiltyard Subnet
-  verifyContract(
-    "0xfd52e1A54442aC8d6a7C54713f99D0dc113df220",
-    "1127469",
-    "Tiltyard Subnet",
-    "multicall-src/",
-  );
+  // // Tiltyard Subnet
+  // verifyContract(
+  //   "0xfd52e1A54442aC8d6a7C54713f99D0dc113df220",
+  //   "1127469",
+  //   "Tiltyard Subnet",
+  //   "multicall-src/",
+  // );
 
   // Polygon zkEVM Mainnet
   verifyContract(
@@ -1574,21 +1574,21 @@ describe("Test Supported Chains", function () {
     "shared/",
   );
 
-  // Garnet Holesky
-  verifyContract(
-    "0x81EbbEDEd806Dbaa6ccD5a9D6D88D0d90B70dfc9",
-    "17069",
-    "Garnet Holesky",
-    "shared/",
-  );
+  // // Garnet Holesky
+  // verifyContract(
+  //   "0x81EbbEDEd806Dbaa6ccD5a9D6D88D0d90B70dfc9",
+  //   "17069",
+  //   "Garnet Holesky",
+  //   "shared/",
+  // );
 
-  // PlayFair Testnet Subnet
-  verifyContract(
-    "0x9be71dB4693657625F92359d046c513Bb35F96db",
-    "12898",
-    "PlayFair Testnet Subnet",
-    "shared/",
-  );
+  // // PlayFair Testnet Subnet
+  // verifyContract(
+  //   "0x9be71dB4693657625F92359d046c513Bb35F96db",
+  //   "12898",
+  //   "PlayFair Testnet Subnet",
+  //   "shared/",
+  // );
 
   // HOME Verse Mainnet
   verifyContract(


### PR DESCRIPTION
…rted

* Mark Ethereum Mekong Testnet, WAGMI Testnet, Kanazawa Testnet, MELD, Tiltyard Subnet, Garnet Holesky, and PlayFair Testnet Subnet as unsupported.
* Remove associated fetchContractCreationTxUsing configurations for these chains.
* Update chain-tests.spec.ts to comment out tests for the unsupported chains.
