### PR TITLE
Remove environment variables  from lib-sourcify

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -20,6 +20,18 @@ interface JsonRpcProviderWithUrl extends JsonRpcProvider {
   url?: string;
 }
 
+export function createFetchRequest(rpc: FetchRequestRPC): FetchRequest {
+  const ethersFetchReq = new FetchRequest(rpc.url);
+  ethersFetchReq.setHeader('Content-Type', 'application/json');
+  const headers = rpc.headers;
+  if (headers) {
+    headers.forEach(({ headerName, headerValue }) => {
+      ethersFetchReq.setHeader(headerName, headerValue);
+    });
+  }
+  return ethersFetchReq;
+}
+
 export class SourcifyChain {
   name: string;
   readonly title?: string | undefined;
@@ -91,7 +103,7 @@ export class SourcifyChain {
       } else {
         // else: rpc is of type FetchRequestRPC
         // Build ethers.js FetchRequest object for custom rpcs with auth headers
-        const ethersFetchReq = this.createFetchRequest(rpc);
+        const ethersFetchReq = createFetchRequest(rpc);
         provider = new JsonRpcProvider(ethersFetchReq, ethersNetwork, {
           staticNetwork: ethersNetwork,
         });
@@ -116,18 +128,6 @@ export class SourcifyChain {
       traceSupportedRPCs: this.traceSupportedRPCs,
     };
   };
-
-  createFetchRequest(rpc: FetchRequestRPC): FetchRequest {
-    const ethersFetchReq = new FetchRequest(rpc.url);
-    ethersFetchReq.setHeader('Content-Type', 'application/json');
-    const headers = rpc.headers;
-    if (headers) {
-      headers.forEach(({ headerName, headerValue }) => {
-        ethersFetchReq.setHeader(headerName, headerValue);
-      });
-    }
-    return ethersFetchReq;
-  }
 
   rejectInMs = (host?: string) =>
     new Promise<never>((_resolve, reject) => {

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -61,6 +61,10 @@ export class SourcifyChain {
     SourcifyChain.rpcTimeout = timeoutMs;
   }
 
+  public static getGlobalRpcTimeout(): number {
+    return SourcifyChain.rpcTimeout;
+  }
+
   constructor(sourcifyChainObj: SourcifyChainInstance) {
     this.name = sourcifyChainObj.name;
     this.title = sourcifyChainObj.title;

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
@@ -17,6 +17,7 @@ export type SourcifyChainExtension = {
   };
   fetchContractCreationTxUsing?: FetchContractCreationTxMethods;
   rpc?: Array<string | BaseRPC | APIKeyRPC | FetchRequestRPC>;
+  rpcHeadersValues?: { [key: string]: string };
 };
 
 // Need to define the rpc property explicitly as when a sourcifyChain is created with {...chain, sourcifyChainExtension}, Typescript throws with "Type '(string | FetchRequest)[]' is not assignable to type 'string[]'." For some reason the Chain.rpc is not getting overwritten by SourcifyChainExtension.rpc
@@ -52,7 +53,7 @@ export type FetchRequestRPC = Omit<BaseRPC, 'type'> & {
   type: 'FetchRequest';
   headers?: Array<{
     headerName: string;
-    headerEnvName: string;
+    headerValue: string;
   }>;
 };
 

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
@@ -17,7 +17,6 @@ export type SourcifyChainExtension = {
   };
   fetchContractCreationTxUsing?: FetchContractCreationTxMethods;
   rpc?: Array<string | BaseRPC | APIKeyRPC | FetchRequestRPC>;
-  rpcHeadersValues?: { [key: string]: string };
 };
 
 // Need to define the rpc property explicitly as when a sourcifyChain is created with {...chain, sourcifyChainExtension}, Typescript throws with "Type '(string | FetchRequest)[]' is not assignable to type 'string[]'." For some reason the Chain.rpc is not getting overwritten by SourcifyChainExtension.rpc

--- a/packages/lib-sourcify/src/Validation/fetchUtils.ts
+++ b/packages/lib-sourcify/src/Validation/fetchUtils.ts
@@ -1,6 +1,5 @@
 import { logError, logInfo, logDebug } from '../logger';
 import { id as keccak256str } from 'ethers';
-import { IpfsGateway } from './ValidationTypes';
 
 export async function performFetch(
   url: string,
@@ -105,32 +104,4 @@ export async function fetchWithBackoff(
     }
   }
   throw new Error(`Failed fetching ${resource}`);
-}
-
-/**
- * Because the gateway might change across tests, don't set it to a variable but look for env variable.
- * Otherwise fall back to the default ipfs.io.
- *
- * This will likely moved to server or somewhere else. But keep it here for now.
- */
-export function getIpfsGateway(): IpfsGateway {
-  let ipfsGatewaysHeaders;
-  if (process.env.IPFS_GATEWAY_HEADERS) {
-    try {
-      ipfsGatewaysHeaders = JSON.parse(process.env.IPFS_GATEWAY_HEADERS);
-    } catch (error) {
-      logError('Error while parsing IPFS_GATEWAY_HEADERS option', { error });
-      throw new Error('Error while parsing IPFS_GATEWAY_HEADERS option');
-    }
-  }
-
-  const ipfsGatewayUrl = process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
-  const urlWithTrailingSlash = ipfsGatewayUrl.endsWith('/')
-    ? ipfsGatewayUrl
-    : `${ipfsGatewayUrl}/`;
-
-  return {
-    url: urlWithTrailingSlash,
-    headers: ipfsGatewaysHeaders,
-  };
 }

--- a/packages/lib-sourcify/src/index.ts
+++ b/packages/lib-sourcify/src/index.ts
@@ -1,7 +1,8 @@
 // Logger exports
-import { setLogger, setLevel, ILogger } from './logger';
+import { setLogger, setLevel, ILogger, getLevel } from './logger';
 export const setLibSourcifyLogger = setLogger;
 export const setLibSourcifyLoggerLevel = setLevel;
+export const getLibSourcifyLoggerLevel = getLevel;
 export type ILibSourcifyLogger = ILogger;
 
 // Compilation exports

--- a/packages/lib-sourcify/src/logger.ts
+++ b/packages/lib-sourcify/src/logger.ts
@@ -6,7 +6,7 @@ export interface ILogger {
 
 // Default logger behavior
 export const DefaultLogger: ILogger = {
-  logLevel: process.env.NODE_ENV === 'production' ? 2 : 4,
+  logLevel: 2,
   setLevel(level: number) {
     this.logLevel = level;
   },

--- a/packages/lib-sourcify/src/logger.ts
+++ b/packages/lib-sourcify/src/logger.ts
@@ -60,6 +60,10 @@ export function setLogger(logger: ILogger) {
   AppLogger = logger;
 }
 
+export function getLevel(): number {
+  return AppLogger.logLevel;
+}
+
 export function setLevel(level: number) {
   AppLogger.setLevel(level);
 }

--- a/packages/lib-sourcify/test/Validation/fetchUtils.spec.ts
+++ b/packages/lib-sourcify/test/Validation/fetchUtils.spec.ts
@@ -3,7 +3,6 @@ import { describe, it, beforeEach, afterEach } from 'mocha';
 import {
   performFetch,
   fetchWithBackoff,
-  getIpfsGateway,
 } from '../../src/Validation/fetchUtils';
 import { id as keccak256str } from 'ethers';
 
@@ -87,40 +86,6 @@ describe('fetchUtils', () => {
       } catch (error: any) {
         expect(error.message).to.include('Failed fetching');
       }
-    });
-  });
-
-  describe('getIpfsGateway', () => {
-    it('should return default gateway when no env variables set', () => {
-      delete process.env.IPFS_GATEWAY;
-      delete process.env.IPFS_GATEWAY_HEADERS;
-
-      const gateway = getIpfsGateway();
-      expect(gateway.url).to.equal('https://ipfs.io/ipfs/');
-      expect(gateway.headers).to.be.undefined;
-    });
-
-    it('should use custom gateway from env', () => {
-      process.env.IPFS_GATEWAY = 'https://custom.gateway/ipfs';
-
-      const gateway = getIpfsGateway();
-      expect(gateway.url).to.equal('https://custom.gateway/ipfs/');
-    });
-
-    it('should parse headers from env', () => {
-      const headers = { Authorization: 'Bearer token' };
-      process.env.IPFS_GATEWAY_HEADERS = JSON.stringify(headers);
-
-      const gateway = getIpfsGateway();
-      expect(gateway.headers).to.deep.equal(headers);
-    });
-
-    it('should throw on invalid headers JSON', () => {
-      process.env.IPFS_GATEWAY_HEADERS = 'invalid json';
-
-      expect(() => getIpfsGateway()).to.throw(
-        'Error while parsing IPFS_GATEWAY_HEADERS option',
-      );
     });
   });
 });

--- a/services/monitor/src/Monitor.ts
+++ b/services/monitor/src/Monitor.ts
@@ -141,11 +141,11 @@ export function authenticateRpcs(
           headers: [
             {
               headerName: "CF-Access-Client-Id",
-              headerEnvName: "CF_ACCESS_CLIENT_ID",
+              headerValue: process.env["CF_ACCESS_CLIENT_ID"] || "",
             },
             {
               headerName: "CF-Access-Client-Secret",
-              headerEnvName: "CF_ACCESS_CLIENT_SECRET",
+              headerValue: process.env["CF_ACCESS_CLIENT_SECRET"] || "",
             },
           ],
         };

--- a/services/monitor/test/Monitor.spec.ts
+++ b/services/monitor/test/Monitor.spec.ts
@@ -105,8 +105,10 @@ describe("Monitor", function () {
     });
 
     it("should create FetchRequest for ethpandaops.io URLs", () => {
-      process.env.CF_ACCESS_CLIENT_ID = "client123";
-      process.env.CF_ACCESS_CLIENT_SECRET = "secret456";
+      const clientId = "client123";
+      const clientSecret = "secret456";
+      process.env.CF_ACCESS_CLIENT_ID = clientId;
+      process.env.CF_ACCESS_CLIENT_SECRET = clientSecret;
       const rpc = ["https://rpc.ethpandaops.io/test"];
       const result = authenticateRpcs({ chainId: 1, rpc: rpc, name: "Test" });
 
@@ -116,11 +118,11 @@ describe("Monitor", function () {
       expect(fetchRequest.headers).to.have.lengthOf(2);
       expect(fetchRequest.headers).to.deep.include({
         headerName: "CF-Access-Client-Id",
-        headerEnvName: "CF_ACCESS_CLIENT_ID",
+        headerValue: clientId,
       });
       expect(fetchRequest.headers).to.deep.include({
         headerName: "CF-Access-Client-Secret",
-        headerEnvName: "CF_ACCESS_CLIENT_SECRET",
+        headerValue: clientSecret,
       });
     });
 

--- a/services/server/src/common/logger.ts
+++ b/services/server/src/common/logger.ts
@@ -15,19 +15,7 @@ export enum LogLevels {
 }
 
 export const validLogLevels = Object.values(LogLevels);
-
-if (
-  process.env.NODE_LOG_LEVEL &&
-  !validLogLevels.includes(process.env.NODE_LOG_LEVEL)
-) {
-  throw new Error(`Invalid log level: ${process.env.NODE_LOG_LEVEL}`);
-}
-
-const loggerInstance: Logger = createLogger({
-  level:
-    process.env.NODE_LOG_LEVEL ||
-    (process.env.NODE_ENV === "production" ? "info" : "debug"),
-});
+const loggerInstance: Logger = createLogger();
 
 // 2024-03-06T17:04:16.375Z [warn]: [RepositoryV2Service] Storing contract address=0x5FbDB2315678afecb367f032d93F642f64180aa3, chainId=1337, matchQuality=0.5
 const rawlineFormat = format.printf(

--- a/services/server/src/server/apiv1/verification/session-state/session-state.handlers.ts
+++ b/services/server/src/server/apiv1/verification/session-state/session-state.handlers.ts
@@ -13,8 +13,8 @@ import {
   IVyperCompiler,
   PathBuffer,
   PathContent,
-  getIpfsGateway,
   performFetch,
+  SolidityMetadataContract,
 } from "@ethereum-sourcify/lib-sourcify";
 import { BadRequestError } from "../../../../common/errors";
 
@@ -113,7 +113,7 @@ export async function addInputContractEndpoint(req: Request, res: Response) {
     throw new BadRequestError("The contract doesn't have a metadata IPFS CID");
   }
 
-  const ipfsGateway = getIpfsGateway();
+  const ipfsGateway = SolidityMetadataContract.getGlobalIpfsGateway();
   const ipfsUrl = `${ipfsGateway.url}${metadataIpfsCid}`;
   const metadataFileName = "metadata.json";
   const retrievedMetadataText = await performFetch(

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -40,20 +40,17 @@ if (process.env.IPFS_GATEWAY || process.env.IPFS_GATEWAY_HEADERS) {
 if (process.env.RPC_TIMEOUT) {
   try {
     libSourcifyConfig.rpcTimeout = parseInt(process.env.RPC_TIMEOUT);
-    logger.info("lib-sourcify RPC timeout set", {
-      rpcTimeout: process.env.RPC_TIMEOUT,
-    });
   } catch (error) {
     logger.error("Error setting lib-sourcify RPC timeout", { error });
     throw new Error("Error setting lib-sourcify RPC timeout");
   }
 }
 
-if (process.env.NODE_ENV !== "production") {
-  // Set the log level to 4 (debug) in non-production environments
-  libSourcifyConfig.logLevel = 4;
-  logger.info("lib-sourcify log level set to debug");
-}
+// This variable is used to set the log level for the server and lib-sourcify
+const logLevel = parseInt(
+  process.env.NODE_LOG_LEVEL ||
+    (process.env.NODE_ENV === "production" ? "1" : "5"),
+);
 
 // Solidity Compiler
 
@@ -92,6 +89,7 @@ const server = new Server(
     upgradeContract: config.get("upgradeContract"),
     sessionOptions: getSessionOptions(),
     sourcifyPrivateToken: process.env.SOURCIFY_PRIVATE_TOKEN,
+    logLevel,
     libSourcifyConfig,
   },
   {

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -23,6 +23,46 @@ import { SolcLocal } from "./services/compiler/local/SolcLocal";
 
 import session from "express-session";
 import { VyperLocal } from "./services/compiler/local/VyperLocal";
+import {
+  setLibSourcifyLoggerLevel,
+  SolidityMetadataContract,
+  SourcifyChain,
+} from "@ethereum-sourcify/lib-sourcify";
+
+// lib-sourcify configuration
+if (process.env.IPFS_GATEWAY || process.env.IPFS_GATEWAY_HEADERS) {
+  try {
+    SolidityMetadataContract.setGlobalIpfsGateway({
+      url: process.env.IPFS_GATEWAY || "https://ipfs.io/ipfs/",
+      headers: JSON.parse(process.env.IPFS_GATEWAY_HEADERS || "{}"),
+    });
+    logger.info("lib-sourcifs IPFS gateway set", {
+      ipfsGateway: process.env.IPFS_GATEWAY,
+      ipfsGatewayHeaders: process.env.IPFS_GATEWAY_HEADERS,
+    });
+  } catch (error) {
+    logger.error("Error setting lib-sourcify IPFS gateway", { error });
+    throw new Error("Error setting lib-sourcify IPFS gateway");
+  }
+}
+
+if (process.env.RPC_TIMEOUT) {
+  try {
+    SourcifyChain.setGlobalRpcTimeout(parseInt(process.env.RPC_TIMEOUT));
+    logger.info("lib-sourcify RPC timeout set", {
+      rpcTimeout: process.env.RPC_TIMEOUT,
+    });
+  } catch (error) {
+    logger.error("Error setting lib-sourcify RPC timeout", { error });
+    throw new Error("Error setting lib-sourcify RPC timeout");
+  }
+}
+
+if (process.env.NODE_ENV !== "production") {
+  // Set the log level to 4 (debug) in non-production environments
+  setLibSourcifyLoggerLevel(4);
+  logger.info("lib-sourcify log level set to debug");
+}
 
 // Solidity Compiler
 

--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -80,8 +80,8 @@ export class Server {
     verificationServiceOptions: VerificationServiceOptions,
     storageServiceOptions: StorageServiceOptions,
   ) {
-    if (options.logLevel) {
-      if (options.logLevel && !validLogLevels.includes(options.logLevel)) {
+    if (options.logLevel !== undefined) {
+      if (!validLogLevels.includes(options.logLevel)) {
         throw new Error(`Invalid log level: ${options.logLevel}`);
       }
       setLogLevel(LogLevels[options.logLevel]);

--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -38,6 +38,7 @@ import { SessionOptions } from "express-session";
 import { makeV1ValidatorFormats } from "./apiv1/validation";
 import { errorHandler as v2ErrorHandler } from "./apiv2/errors";
 import http from "http";
+import { setCompilersLoggerLevel } from "@ethereum-sourcify/compilers";
 
 declare module "express-serve-static-core" {
   interface Request {
@@ -86,6 +87,7 @@ export class Server {
       }
       setLogLevel(LogLevels[options.logLevel]);
       setLibSourcifyLoggerLevel(options.logLevel);
+      setCompilersLoggerLevel(options.logLevel);
     }
 
     this.port = options.port;

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -38,7 +38,6 @@ export interface ExtendedSourcifyChainsExtensionsObject {
     };
     fetchContractCreationTxUsing?: any; // Using any to avoid importing the full type
     rpc?: Array<string | BaseRPC | APIKeyRPC | ExtendedFetchRequestRPC>;
-    rpcHeadersValues?: { [key: string]: string };
   };
 }
 

--- a/services/server/test/helpers/LocalChainFixture.ts
+++ b/services/server/test/helpers/LocalChainFixture.ts
@@ -14,6 +14,7 @@ import storageContractMetadataModified from "../testcontracts/Storage/metadataMo
 import storageJsonInput from "../testcontracts/Storage/StorageJsonInput.json";
 import { ChildProcess, spawn } from "child_process";
 import treeKill from "tree-kill";
+import { SolidityMetadataContract } from "@ethereum-sourcify/lib-sourcify";
 
 const storageContractSourcePath = path.join(
   __dirname,
@@ -118,7 +119,7 @@ export class LocalChainFixture {
         path.join(__dirname, "..", "mocks", "ipfs"),
       );
       for (const ipfsKey of Object.keys(mockContent)) {
-        nock(process.env.IPFS_GATEWAY || "")
+        nock(SolidityMetadataContract.getGlobalIpfsGateway().url || "")
           .persist()
           .get("/" + ipfsKey)
           .reply(function () {


### PR DESCRIPTION
In this PR I'm removing environment variables from `lib-sourcify`. 
- We already have `setLibSourcifyLoggerLevel` to change the log level of lib-sourcify
- I added `SourcifyChain.setGlobalRpcTimeout` to change the rpc timeout in `SourcifyChain`
- I added `SolidityMetadataContract.setGlobalIpfsGateway` to change the `IpfsGateway`. I decided to not create a custom function outside of `SolidityMetadataContract` because that's the only place in which we use the `IpfsGateway`
- The `LibSourcify.SourcifyChainsExtensionsObject` doesn't have anymore a `headerEnvName` parameter. Now it has only a `headerValue` parameters. Consequently I had to create a custom `SourcifyServer.SourcifyChainsExtensionsObjectWithHeaderEnvName`, that includes `headerEnvName`, and at server's boot it loads the environment variables values inside `headerValue`

**TODO**
- [x] Tests passing
- [x] Update docs
