### PR TITLE
Fix SIGTERM handling of server containers

### DIFF
--- a/services/database/database.json
+++ b/services/database/database.json
@@ -15,6 +15,14 @@
     "database": "sourcify",
     "port": { "ENV": "DOCKER_HOST_POSTGRES_TEST_PORT" }
   },
+  "local-docker": {
+    "driver": "pg",
+    "host": "db",
+    "user": "sourcify",
+    "password": "sourcify",
+    "database": "sourcify",
+    "port": 5432
+  },
   "production": {
     "driver": "pg",
     "host": { "ENV": "POSTGRES_HOST" },

--- a/services/server/Dockerfile
+++ b/services/server/Dockerfile
@@ -40,4 +40,5 @@ ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 
 WORKDIR /home/app/services/server
-CMD ["npm", "start"]
+# node command has to be used directly for SIGTERM handling (NOT npm start)
+CMD ["node", "dist/server/cli.js"]

--- a/services/server/README.md
+++ b/services/server/README.md
@@ -225,13 +225,30 @@ Sourcify's database schema is defined in the [services/database](../database/) a
 
 ## Docker
 
-If you want to build yourself, the builds need to be run from the project root context, e.g.:
+The images are published in the [Github Container Registry](https://github.com/ethereum/sourcify/pkgs/container/sourcify%2Fserver)
+
+### Running the server with docker compose
+
+There is a docker compose file which makes running the server locally easy:
+
+```bash
+cd ../..
+docker compose -f ./services/server/docker-compose.local.yml up
+```
+
+The setup starts a postgres database, runs the needed database migrations, and starts the Sourcify server with port 5555 exposed to your local machine.
+
+The server will use your local config (`./src/config/local.js`) and env file (`.env`). You can modify the docker compose file to also add a custom `sourcify-chains.json` for example.
+
+### Building the image
+
+If you want to build the image yourself, the builds need to be run from the project root context, e.g.:
 
 ```bash
 cd sourcify/ && docker build -f services/server/Dockerfile .
 ```
 
-The containers are published in the [Github Container Registry](https://github.com/ethereum/sourcify/pkgs/container/sourcify%2Fserver)
+### Running the image directly
 
 You can run the server using Docker and pass in a custom `sourcify-chains.json` (see above [Chains Config](#chains-config)) and `local.js` (see above [Server Config](#server-config)) config file.
 
@@ -248,7 +265,8 @@ $ docker run \
 ```
 
 ### Connecting to a node on the host
-If you are running an RPC server for a chain on the Docker host, you can have your Sourcify container connect to it by using `host.docker.internal` as the hostname (or `host.containers.internal` if using Podman instead of Docker). For example, if the RPC server is accessible on the host at `http://localhost:8545`, configure the RPC's URL in `sourcify-chains.json` as `http://host.docker.internal:8545`.
+
+The following feature is only supported on Docker Desktop for Mac and Windows: If you are running an RPC server for a chain on the Docker host, you can have your Sourcify container connect to it by using `host.docker.internal` as the hostname (or `host.containers.internal` if using Podman instead of Docker). For example, if the RPC server is accessible on the host at `http://localhost:8545`, configure the RPC's URL in `sourcify-chains.json` as `http://host.docker.internal:8545`.
 
 ## Logging
 

--- a/services/server/docker-compose.local.yml
+++ b/services/server/docker-compose.local.yml
@@ -1,0 +1,46 @@
+version: "3.8"
+
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: "sourcify"
+      POSTGRES_USER: "sourcify"
+      POSTGRES_PASSWORD: "sourcify"
+    ports:
+      - 5431:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Needed to separate the migration because node must have PID 1 in service server
+  run-migrations:
+    image: node:22.5.1-bullseye-slim
+    volumes:
+      - ../database:/home/app/services/database
+    command: /bin/bash -c "cd /home/app/services/database && npm run migrate:up -- --env local-docker"
+    restart: "no"
+    deploy:
+      restart_policy:
+        condition: none
+    depends_on:
+      db:
+        condition: service_healthy
+
+  server:
+    build:
+      context: ../..
+      dockerfile: services/server/Dockerfile
+    ports:
+      - "5555:5555"
+    env_file:
+      - .env
+    volumes:
+      - ./src/config/local.js:/home/app/services/server/dist/config/local.js
+    depends_on:
+      db:
+        condition: service_started
+      run-migrations:
+        condition: service_completed_successfully


### PR DESCRIPTION
I found why our server does not handle SIGTERM signals in GCP (#1877). The issue is our Dockerfile which used `npm start` to run the server. Due to this, `node` does not have PID 1 which is needed to properly handle signals from the outside in the container (see https://www.docker.com/blog/docker-best-practices-choosing-between-run-cmd-and-entrypoint/).

I created a docker compose file for locally testing if the SIGTERM is handled. The compose file makes it much easier to run the server with the db through Docker locally. I thought it would be good to also add it to the repo.