### PR TITLE
Fix coloring in CI logs

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -280,10 +280,10 @@ jobs:
           command: npx lerna run build
       - run:
           name: lint
-          command: npm run lerna-lint
+          command: npx lerna run lerna-lint
       - run:
           name: test
-          command: npm run lerna-test
+          command: npx lerna run lerna-test
           environment:
             DOCKER_HOST_POSTGRES_TEST_PORT: 5432
             SOURCIFY_POSTGRES_HOST: "localhost"

--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -41,10 +41,10 @@ jobs:
           command: npx lerna run build
       - run:
           name: lint
-          command: npm run lerna-lint
+          command: npx lerna run lerna-lint
       - run:
           name: test
-          command: npm run lerna-test
+          command: npx lerna run lerna-test
           environment:
             DOCKER_HOST_POSTGRES_TEST_PORT: 5432
             SOURCIFY_POSTGRES_HOST: "localhost"


### PR DESCRIPTION
9db1250d2b1126a4f6b645b9681cb54b1c68bdc9 removed the coloring of the package in the CI logs. It seems like we need to call `npx lerna` directly to have the output colored.
