### PR TITLE
copy `fetchContractCreationTxUsing` for an unknown chain

### DIFF
--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -270,6 +270,7 @@ if (missingChains.length > 0) {
         chainId: parseInt(chainId),
         supported: chain.supported,
         rpc: rpc as FetchRequestRPC[],
+        fetchContractCreationTxUsing: chain.fetchContractCreationTxUsing,
         rpcWithoutApiKeys,
         traceSupportedRPCs,
       });


### PR DESCRIPTION
Currently, when you use custom `sourcify-chains.json` there is a problem for networks that are not present `chains.json`, it is then categorized as `unknownChain` and not all of the properties are being copied when populating `sourcifyChainsMap`.

I've added `fetchContractCreationTxUsing` to prevent contract creation transaction being fetched only through binary search wtih RPC.

