### PR TITLE
Log error message for unexpected server errors

### DIFF
--- a/services/server/src/common/errors/GenericErrorHandler.ts
+++ b/services/server/src/common/errors/GenericErrorHandler.ts
@@ -14,7 +14,7 @@ export default function genericErrorHandler(
     const errorCode =
       +err.statusCode || err.status || StatusCodes.INTERNAL_SERVER_ERROR;
     if (errorCode === StatusCodes.INTERNAL_SERVER_ERROR) {
-      logger.error("Unexpected server error", { error: err });
+      logger.error(`Unexpected server error: ${err.message}`, { error: err });
     }
 
     if (err.payload) {


### PR DESCRIPTION
This addresses the problem that, in GCP, the error message is hidden in the payload properties