### PR TITLE
Update OpenAPI paths to use 'matchType' instead of 'full_match | partial_match' for repository contracts

### DIFF
--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -40,8 +40,8 @@ paths:
     $ref: "server/apiv1/verification/etherscan/stateless/etherscan.stateless.paths.yaml#/paths/~1verify~1etherscan"
   /verify/solc-json:
     $ref: "server/apiv1/verification/solc-json/stateless/solc-json.stateless.paths.yaml#/paths/~1verify~1solc-json"
-  /repository/contracts/{full_match | partial_match}/{chain}/{address}/{filePath}:
-    $ref: "server/apiv1/repository/get-file-static.stateless.paths.yaml#/paths/~1repository~1contracts~1{full_match | partial_match}~1{chain}~1{address}~1{filePath}"
+  /repository/contracts/{matchType}/{chain}/{address}/{filePath}:
+    $ref: "server/apiv1/repository/get-file-static.stateless.paths.yaml#/paths/~1repository~1contracts~1{matchType}~1{chain}~1{address}~1{filePath}"
   /check-all-by-addresses:
     $ref: "server/apiv1/repository/check-all-by-addresses.stateless.paths.yaml#/paths/~1check-all-by-addresses"
   /check-by-addresses:

--- a/services/server/src/server/apiv1/repository/get-file-static.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/get-file-static.stateless.paths.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 paths:
-  /repository/contracts/{full_match | partial_match}/{chain}/{address}/{filePath}:
+  /repository/contracts/{matchType}/{chain}/{address}/{filePath}:
     get:
       deprecated: true
       summary: Get a specific file from the repository with the file path (static serving)
@@ -9,12 +9,13 @@ paths:
       tags:
         - (Deprecated) Repository
       parameters:
-        - name: Match type `full_match` or `partial_match`
+        - name: matchType
           in: path
           required: true
           schema:
             type: string
             format: match-type
+          description: Either `full_match` or `partial_match`
         - name: chain
           in: path
           required: true


### PR DESCRIPTION
Fixes #2093 