### PR TITLE
Fix server logging

### DIFF
--- a/services/server/src/common/logger.ts
+++ b/services/server/src/common/logger.ts
@@ -6,7 +6,10 @@ import {
   ILibSourcifyLogger,
 } from "@ethereum-sourcify/lib-sourcify";
 import { asyncLocalStorage } from "./async-context";
-import { setCompilersLogger } from "@ethereum-sourcify/compilers";
+import {
+  setCompilersLogger,
+  setCompilersLoggerLevel,
+} from "@ethereum-sourcify/compilers";
 
 export enum LogLevels {
   error = 0,
@@ -171,6 +174,7 @@ export function setLogLevel(level: string): void {
   process.env.NODE_LOG_LEVEL = level;
   // Also set lib-sourcify's logger level
   setLibSourcifyLoggerLevel(logLevelStringToNumber(level));
+  setCompilersLoggerLevel(logLevelStringToNumber(level));
 }
 
 const makePackageLogger = (packageName: string): ILibSourcifyLogger => {

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -49,7 +49,7 @@ if (process.env.RPC_TIMEOUT) {
 // This variable is used to set the log level for the server and lib-sourcify
 const logLevel = parseInt(
   process.env.NODE_LOG_LEVEL ||
-    (process.env.NODE_ENV === "production" ? "1" : "5"),
+    (process.env.NODE_ENV === "production" ? "2" : "5"),
 );
 
 // Solidity Compiler

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -47,10 +47,9 @@ if (process.env.RPC_TIMEOUT) {
 }
 
 // This variable is used to set the log level for the server and lib-sourcify
-const logLevel = parseInt(
+const logLevel =
   process.env.NODE_LOG_LEVEL ||
-    (process.env.NODE_ENV === "production" ? "2" : "5"),
-);
+  (process.env.NODE_ENV === "production" ? "info" : "debug");
 
 // Solidity Compiler
 

--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -79,9 +79,7 @@ export class Server {
     verificationServiceOptions: VerificationServiceOptions,
     storageServiceOptions: StorageServiceOptions,
   ) {
-    if (options.logLevel !== undefined) {
-      setLogLevel(options.logLevel);
-    }
+    setLogLevel(options.logLevel || "info");
 
     this.port = options.port;
     logger.info("Server port set", { port: this.port });

--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -28,7 +28,6 @@ import {
   getLibSourcifyLoggerLevel,
   ISolidityCompiler,
   IVyperCompiler,
-  setLibSourcifyLoggerLevel,
   SolidityMetadataContract,
   SourcifyChain,
   SourcifyChainMap,
@@ -38,7 +37,6 @@ import { SessionOptions } from "express-session";
 import { makeV1ValidatorFormats } from "./apiv1/validation";
 import { errorHandler as v2ErrorHandler } from "./apiv2/errors";
 import http from "http";
-import { setCompilersLoggerLevel } from "@ethereum-sourcify/compilers";
 
 declare module "express-serve-static-core" {
   interface Request {
@@ -66,7 +64,7 @@ export interface ServerOptions {
   sessionOptions: SessionOptions;
   sourcifyPrivateToken?: string;
   libSourcifyConfig?: LibSourcifyConfig;
-  logLevel?: number;
+  logLevel?: string;
 }
 
 export class Server {
@@ -82,12 +80,7 @@ export class Server {
     storageServiceOptions: StorageServiceOptions,
   ) {
     if (options.logLevel !== undefined) {
-      if (!validLogLevels.includes(options.logLevel)) {
-        throw new Error(`Invalid log level: ${options.logLevel}`);
-      }
-      setLogLevel(LogLevels[options.logLevel]);
-      setLibSourcifyLoggerLevel(options.logLevel);
-      setCompilersLoggerLevel(options.logLevel);
+      setLogLevel(options.logLevel);
     }
 
     this.port = options.port;

--- a/services/server/test/helpers/ServerFixture.ts
+++ b/services/server/test/helpers/ServerFixture.ts
@@ -108,7 +108,7 @@ export class ServerFixture {
           store: postgresSessionStore,
         },
         sourcifyPrivateToken: "sourcify-test-token",
-        logLevel: 5,
+        logLevel: "debug",
       };
 
       this._server = new Server(


### PR DESCRIPTION
#2058 introduced two issues:

- The log level was set to warning in production mode (before it was info)
- The type of the `NODE_LOG_LEVEL` environment variable changed from string to number. I think we don't need this breaking change and it led to the issue before.

This PR fixes these issues and makes general improvements to the logging.