### PR TITLE
Added new chains 42793 & 128123

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -2330,5 +2330,23 @@
         "url": "https://maizenet-explorer.usecorn.com"
       }
     }
+  },
+  "42793": {
+    "sourcifyName": "Etherlink",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://explorer.etherlink.com"
+      }
+    }
+  },
+  "128123": {
+    "sourcifyName": "Etherlink Testnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://testnet.explorer.etherlink.com"
+      }
+    }
   }
 }

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -1840,6 +1840,22 @@ describe("Test Supported Chains", function () {
     "shared/",
   );
 
+  // Etherlink
+  verifyContract(
+    "0xec5504BcE3BCE4F1c4088a6A150A4A8C840945a7",
+    "42793",
+    "Etherlink",
+    "shared/",
+  );
+
+  // Etherlink Testnet
+  verifyContract(
+    "0x5827317D75D53E7a7901657307209bC684B8EcDc",
+    "128123",
+    "Etherlink Testnet",
+    "shared/",
+  );
+
   it("should have included Etherscan contracts for all testedChains having etherscanAPI", function (done) {
     const missingEtherscanTests: ChainApiResponse[] = [];
     supportedChains


### PR DESCRIPTION
<!-- If you are opening a chain support request PR please follow the template below. Otherwise you can write your own PR description -->

# Add New Chain 42792-128123 Etherlink & Etherlink Testnet

Thanks for your pull request to add a new support in Sourcify.

If you haven't done so, please follow the instructions on [how to request chain support](https://docs.sourcify.dev/docs/chain-support/) in docs.

Please check the following items before submitting your pull request for a speedy review.

## Checklist

- [x] The branch is named as `add-chain-<chainId>`.
- [x] I haven't modified the `chains.json` file directly.
- [x] In `sourcify-chains.json` file
  - [x] I've set `supported: true`.
  - [x] I haven't added an `rpc` field but the one in [chains.json](../../src/chains.json) is used (if not, please explain why).
- [x] I've added a test in [chain-tests.js](../../test/chains/chains-test.js) file.
- [x] `test-new-chain` test in Circle CI is passing.
