### PR TITLE
Fix v2 Etherscan import and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5379,9 +5379,9 @@
       }
     },
     "node_modules/@solidity-parser/parser": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.20.0.tgz",
-      "integrity": "sha512-eYOX1xI9ssc3AIZtKPdE2chG1OT9S74O16b8GhWGab63NS5g4jyQgW5OiwUiX9ACL0FR24rVDaHo+BB0bRSHhQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.20.1.tgz",
+      "integrity": "sha512-58I2sRpzaQUN+jJmWbHfbWf9AKfzqCI8JAdFB0vbyY+u8tBRcuTt9LxzasvR0LGQpcRv97eyV7l61FQ3Ib7zVw==",
       "license": "MIT"
     },
     "node_modules/@tokenizer/token": {
@@ -19136,7 +19136,7 @@
         "@ethereum-sourcify/lib-sourcify": "^2.0.0",
         "@google-cloud/cloud-sql-connector": "1.7.1",
         "@shazow/whatsabi": "0.21.0",
-        "@solidity-parser/parser": "^0.20.0",
+        "@solidity-parser/parser": "0.20.1",
         "abitype": "1.0.8",
         "bunyan": "1.8.15",
         "chalk": "4.1.2",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -55,7 +55,7 @@
     "@ethereum-sourcify/lib-sourcify": "^2.0.0",
     "@google-cloud/cloud-sql-connector": "1.7.1",
     "@shazow/whatsabi": "0.21.0",
-    "@solidity-parser/parser": "^0.20.0",
+    "@solidity-parser/parser": "0.20.1",
     "abitype": "1.0.8",
     "bunyan": "1.8.15",
     "chalk": "4.1.2",

--- a/services/server/test/chains/etherscan-instances.spec.ts
+++ b/services/server/test/chains/etherscan-instances.spec.ts
@@ -10,6 +10,7 @@ import { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
 import { assertJobVerification } from "../helpers/assertions";
 import { toMatchLevel } from "../../src/server/services/utils/util";
 import sinon from "sinon";
+import { getAddress } from "ethers";
 
 const CUSTOM_PORT = 5679;
 
@@ -59,7 +60,7 @@ describe("Test each Etherscan instance", function () {
             verifyRes,
             resolveWorkers,
             chain,
-            address,
+            getAddress(address),
             expectedMatch,
           );
         });

--- a/services/server/test/helpers/assertions.ts
+++ b/services/server/test/helpers/assertions.ts
@@ -296,7 +296,9 @@ export async function assertJobVerification(
   testAddress: string,
   expectedMatch: MatchLevel,
 ) {
-  chai.expect(verifyResponse.status).to.equal(202);
+  chai
+    .expect(verifyResponse.status)
+    .to.equal(202, "Response body: " + JSON.stringify(verifyResponse.body));
   chai.expect(verifyResponse.body).to.have.property("verificationId");
   chai
     .expect(verifyResponse.body.verificationId)
@@ -308,7 +310,9 @@ export async function assertJobVerification(
     .request(serverFixture.server.app)
     .get(`/v2/verify/${verifyResponse.body.verificationId}`);
 
-  chai.expect(jobRes.status).to.equal(200);
+  chai
+    .expect(jobRes.status)
+    .to.equal(200, "Response body: " + JSON.stringify(verifyResponse.body));
   chai.expect(jobRes.body).to.deep.include({
     isJobCompleted: false,
     verificationId: verifyResponse.body.verificationId,
@@ -330,13 +334,13 @@ export async function assertJobVerification(
 
   const verifiedContract = {
     match: expectedMatch,
-    creationMatch: expectedMatch,
-    runtimeMatch: expectedMatch,
     chainId: testChainId,
     address: testAddress,
   };
 
-  chai.expect(jobRes2.status).to.equal(200);
+  chai
+    .expect(jobRes2.status)
+    .to.equal(200, "Response body: " + JSON.stringify(verifyResponse.body));
   chai.expect(jobRes2.body).to.include({
     isJobCompleted: true,
     verificationId: verifyResponse.body.verificationId,
@@ -348,7 +352,9 @@ export async function assertJobVerification(
     .request(serverFixture.server.app)
     .get(`/v2/contract/${testChainId}/${testAddress}`);
 
-  chai.expect(contractRes.status).to.equal(200);
+  chai
+    .expect(contractRes.status)
+    .to.equal(200, "Response body: " + JSON.stringify(verifyResponse.body));
   chai.expect(contractRes.body).to.include(verifiedContract);
 
   await assertContractSaved(

--- a/services/server/test/helpers/etherscanInstanceContracts.json
+++ b/services/server/test/helpers/etherscanInstanceContracts.json
@@ -476,7 +476,7 @@
     {
       "address": "0x06565ed324Ee9fb4DB0FF80B7eDbE4Cb007555a3",
       "type": "single",
-      "expectedStatus": "partial"
+      "expectedStatus": "perfect"
     },
     {
       "address": "0x9B1B4b0FD15eF697E2E61C29ee933b227C68dDb2",


### PR DESCRIPTION
A couple of problems were introduced with the API v2 Etherscan import:

- Errors from the newly introduced Solidity parser were not caught. This could cause the server to crash.
- The Solidity parser had a bug in version 0.20.0 that made it not work with a few contracts that use `at` as an identifier.
- The etherscan instance tests needed some fixes