### PR TITLE
Upgrade CI orb `path-filtering`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # the path-filtering orb is required to continue a pipeline based on
 # the path of an updated fileset see https://circleci.com/docs/2.0/using-dynamic-configuration/
 orbs:
-  path-filtering: circleci/path-filtering@0.1.7
+  path-filtering: circleci/path-filtering@1.3.0
   continuation: circleci/continuation@0.5.0
 
 # Can add multiple workflows in setup since only one of these will run. Otherwise it's not possible: https://support.circleci.com/hc/en-us/articles/360060934851--Max-number-of-workflows-exceeded-error


### PR DESCRIPTION
We seem to be  affected by this problem which broke our staging build: https://support.circleci.com/hc/en-us/articles/36392688494747-Python-3-8-is-not-supported-on-the-path-filtering-orb

