### PR TITLE
Fix flaky tests

### DIFF
--- a/packages/compilers/.mocharc.json
+++ b/packages/compilers/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": [".spec.ts"],
   "require": ["ts-node/register"],
-  "timeout": 60000
+  "timeout": 120000
 }

--- a/services/server/.mocharc.json
+++ b/services/server/.mocharc.json
@@ -5,5 +5,5 @@
     "./test/load-env.js",
     "./test/global-mocks.ts"
   ],
-  "timeout": 60000
+  "timeout": 120000
 }


### PR DESCRIPTION
Fixes #2107

Regarding the flaky tests on the new verification endpoints: The issue seems to be that they are the first test in the describe block (server is started at the beginning of the describe block) and it takes some time to spin up the worker thread. The first tests per describe block run for around 1 minute because they need to wait for the thread to be ready. Therefore, they hit only sometimes the 1 minute timeout.

On the compilers package, we also have a test where the compilation takes over 1 minute sometimes. This wasn't a problem before we had the compilers package, because this test was inside the lib-sourcify tests and there we have not timeout configured.

This simply increases the Mocha timeouts to 2 minutes. Hopefully, this is enough.