### PR TITLE
Fix missing compilation.metadata field in upgrade script

### DIFF
--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -473,12 +473,6 @@ export class Verification {
       this.compilation.creationBytecode,
     );
 
-    this.creationMatch = matchBytecodesResult.match;
-    this.creationLibraryMap = matchBytecodesResult.libraryMap;
-    this.creationTransformations = matchBytecodesResult.transformations;
-    this.creationTransformationValues =
-      matchBytecodesResult.transformationValues;
-
     if (
       matchBytecodesResult.match === 'partial' ||
       matchBytecodesResult.match === 'perfect'
@@ -490,13 +484,15 @@ export class Verification {
           this.compilation.metadata,
         );
       this.creationTransformations = [
-        ...this.creationTransformations,
+        ...matchBytecodesResult.transformations,
         ...constructorTransformationResult.transformations,
       ];
       this.creationTransformationValues = {
-        ...this.creationTransformationValues,
+        ...matchBytecodesResult.transformationValues,
         ...constructorTransformationResult.transformationValues,
       };
+      this.creationMatch = matchBytecodesResult.match;
+      this.creationLibraryMap = matchBytecodesResult.libraryMap;
     }
   }
 

--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
@@ -135,11 +135,11 @@ export async function verifyDeprecated(
 }
 
 /**
- * Upgrades a contract by fetching the sourcify_match from the database and then verifying it again with the new verification parameters.
- * Mocks both the compilation and the sourcifyChain information so that recompilation and rpc calls are not performed.
+ * This function is used to fix the creation information (match, transformations list, transformations values, metadata match) of contract with misaligned creation data.
  *
- * Finally, it updates the creation fields (match, transformations list, transformations values, metadata match) in
- * the verified_contracts and the sourcify_matches tables with the new verification creation fields results.
+ * We beging by mocking both the compilation and the sourcifyChain information with data from the database, so that recompilation and rpc calls are not performed.
+ * Then we verify the contract again with the new mocked compilation and sourcifyChain objects.
+ * Finally we upgrade the misaligned contract by UPDATING the verified_contracts and sourcify_matches creation fields.
  */
 export async function upgradeContract(
   req: LegacyVerifyRequest,
@@ -268,6 +268,7 @@ export async function upgradeContract(
     );
 
     compilation.compilerOutput = {
+      sources: compilationArtifacts.sources,
       contracts: {
         [compilationTarget.path]: {
           [compilationTarget.name]: {

--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
@@ -134,6 +134,13 @@ export async function verifyDeprecated(
   }
 }
 
+/**
+ * Upgrades a contract by fetching the sourcify_match from the database and then verifying it again with the new verification parameters.
+ * Mocks both the compilation and the sourcifyChain information so that recompilation and rpc calls are not performed.
+ *
+ * Finally, it updates the creation fields (match, transformations list, transformations values, metadata match) in
+ * the verified_contracts and the sourcify_matches tables with the new verification creation fields results.
+ */
 export async function upgradeContract(
   req: LegacyVerifyRequest,
   res: Response,

--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
@@ -295,6 +295,10 @@ export async function upgradeContract(
       // Override so that it doesn't generate auxdata positions
     };
 
+    Object.defineProperty(compilation, "metadata", {
+      value: verifiedContract.metadata,
+    });
+
     Object.defineProperty(compilation, "creationBytecodeCborAuxdata", {
       value: creationCodeArtifacts.cborAuxdata,
     });


### PR DESCRIPTION
See #2091

In the upgrade script the `compilation.metadata` object was not mocked. `extractConstructorArgumentsTransformation` needs the metadata.abi object in order to extract the constructor arguments from the onchain creation bytecode. Without the metadata the constructorArguments transformation coulnd't be found.

This PR adds the metadata field on the mock compilation