### PR TITLE
Fix traceId not logged inside worker when verifying via Etherscan import

### DIFF
--- a/services/server/src/server/services/workers/verificationWorker.ts
+++ b/services/server/src/server/services/workers/verificationWorker.ts
@@ -256,7 +256,7 @@ async function _verifyFromEtherscan({
     processedResult = processSolidityResultFromEtherscan(etherscanResult, true);
   }
 
-  return verifyFromJsonInput({
+  return _verifyFromJsonInput({
     chainId,
     address,
     jsonInput: processedResult.jsonInput,


### PR DESCRIPTION
Fixes #2074


Call internal `_verifyFromJsonInput` inside `_verifyFromEtherscan` instead of public function. Needed because the traceId was overwritten with undefined when calling the public function.
