### PR TITLE
Release process fix 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ workspace/
 # Ignore the server local config file. See .nxignore
 **/config/local.js
 
+# Sourcify release script temporary file
+.release_package_data.tmp

--- a/scripts/release/main.sh
+++ b/scripts/release/main.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR=$(dirname "$0")
 
 source "${SCRIPT_DIR}/logging_utils.sh"
 source "${SCRIPT_DIR}/git_utils.sh"
+source "${SCRIPT_DIR}/release_data_utils.sh"
 source "${SCRIPT_DIR}/release.sh"
 
 ###
@@ -41,3 +42,6 @@ prompt_execute_or_skip "switching to staging and pulling latest" switch_to_stagi
 prompt_execute_or_skip "switching to master" switch_to_master
 prompt_execute_or_skip "merging staging to master locally" merge_locally
 prompt_execute_or_skip "pushing the commits to master" push_to_master
+
+# Clean up the temporary package data file
+prompt_execute_or_skip "cleaning up temporary release data" cleanup_package_data_file

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -80,7 +80,7 @@ update_packages_and_changelog() {
   GITHUB_PR_URL_FILES="${GITHUB_PR_URL}/files"
 
   # Get the list of changed packages
-  OUTPUT=$(npx lerna changed --all --long --parseable)
+  OUTPUT=$(npx lerna changed --all --long --parseable --include-merged-tags)
 
   if [ -z "$OUTPUT" ]; then
     echo "No packages need to be updated."
@@ -219,7 +219,7 @@ function run_lerna_version() {
   for pkg_name in "${!selected_versions[@]}"; do
     echo "$pkg_name: ${selected_versions[$pkg_name]}"
   done
-  npx lerna version --no-push
+  npx lerna version --no-push --include-merged-tags
 }
 
 ###

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -200,6 +200,11 @@ update_changelog() {
     echo ""
   fi
 
+  # Ensure the changelog entry ends with a newline
+  if [ -s "$changelog_entry_filename" ] && [ -n "$(tail -c1 "$changelog_entry_filename")" ]; then
+    echo "" >>"$changelog_entry_filename"
+  fi
+
   new_changelog_heading="## $pkg_name@${selected_versions["$pkg_name"]} - $today"
   changelog_file="${directory}/CHANGELOG.md"
 

--- a/scripts/release/release_data_utils.sh
+++ b/scripts/release/release_data_utils.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Utility functions for handling package data persistence via a temporary file.
+
+source "${SCRIPT_DIR}/logging_utils.sh"
+# Ensure SCRIPT_DIR is available, assuming this is sourced by main.sh where SCRIPT_DIR is defined.
+TEMP_PACKAGE_DATA_FILE="${SCRIPT_DIR}/.release_package_data.tmp"
+
+# Function to write all package data to the temp file
+# Args:
+#   $1: Name of the directories array
+#   $2: Name of the packageNames array
+#   $3: Name of the versions array (current versions)
+#   $4: Name of the selected_versions associative array (pkgName -> selectedVersion)
+write_package_data() {
+  local -n dirs_ref=$1     # Nameref for directories array
+  local -n names_ref=$2    # Nameref for packageNames array
+  local -n vers_ref=$3     # Nameref for versions array
+  local -n selected_ref=$4 # Nameref for selected_versions associative array
+
+  echo "Writing package data to $TEMP_PACKAGE_DATA_FILE"
+  # Clear the file or create it if it doesn't exist
+  >"$TEMP_PACKAGE_DATA_FILE"
+
+  for index in "${!names_ref[@]}"; do
+    local pkg_name="${names_ref[$index]}"
+    local dir="${dirs_ref[$index]}"
+    local current_ver="${vers_ref[$index]}"
+    local selected_ver="${selected_ref[$pkg_name]}" # Get selected version using package name as key
+
+    if [ -z "$pkg_name" ]; then
+      warn "Skipping empty package name at index $index during write."
+      continue
+    fi
+    # Format: directory:packageName:currentVersion:selectedVersion
+    echo "${dir}:${pkg_name}:${current_ver}:${selected_ver}" >>"$TEMP_PACKAGE_DATA_FILE"
+  done
+  echo "Package data written successfully to $TEMP_PACKAGE_DATA_FILE"
+}
+
+# Function to load package data from the temp file into global-like bash arrays
+# This will redefine/populate:
+#   packageNames (indexed array)
+#   directories (indexed array)
+#   versions (indexed array - stores current versions read from file)
+#   selected_versions (associative array: pkgName -> selectedVersion)
+load_package_data_into_arrays() {
+  if [ ! -f "$TEMP_PACKAGE_DATA_FILE" ]; then
+    log_error "Package data file not found: $TEMP_PACKAGE_DATA_FILE. Cannot load data."
+    # Ensure arrays are empty to prevent using stale in-memory data from a previous load or state
+    packageNames=()
+    directories=()
+    versions=()
+    unset selected_versions
+    declare -A selected_versions
+    return 1
+  fi
+
+  echo "Loading package data from $TEMP_PACKAGE_DATA_FILE"
+  # Clear existing global arrays before loading
+  packageNames=()
+  directories=()
+  versions=() # This will store the 'current_ver' from the file
+
+  # Clear the global associative array selected_versions by unsetting all its keys
+  for key_to_remove in "${!selected_versions[@]}"; do
+    unset selected_versions["$key_to_remove"]
+  done
+
+  local i=0
+  while IFS=: read -r dir name current_ver selected_ver; do
+    # Skip empty or malformed lines (e.g., if name is empty)
+    if [ -z "$name" ]; then
+      log_warning "Skipping line with empty package name in $TEMP_PACKAGE_DATA_FILE during load."
+      continue
+    fi
+    directories[$i]="$dir"
+    packageNames[$i]="$name"
+    versions[$i]="$current_ver"                # Storing the version that was current at time of writing
+    selected_versions["$name"]="$selected_ver" # Storing the selected new version
+    ((i++))
+  done <"$TEMP_PACKAGE_DATA_FILE"
+  echo "Package data loaded successfully. Processed $i package entries."
+}
+
+# Function to clean up the temporary package data file
+cleanup_package_data_file() {
+  if [ -f "$TEMP_PACKAGE_DATA_FILE" ]; then
+    echo "Cleaning up temporary package data file: $TEMP_PACKAGE_DATA_FILE"
+    rm "$TEMP_PACKAGE_DATA_FILE"
+    echo "Temporary file deleted successfully."
+  else
+    echo "Temporary package data file not found, no cleanup needed: $TEMP_PACKAGE_DATA_FILE"
+  fi
+}


### PR DESCRIPTION
Fixes to the release process following the last release call:

-  Use a temporary file for storing package version etc. in release scripts instead of memory variables
- use `--include-merge-tags` flag to correctly determine which packages are changes
- Fix GUI editors like `code` exiting before writing to temp changelog file.

I ran it to the extent that I can (without publishing a release etc.) and seems stable. We can check again on our next release if it goes well 🤞 