### PR TITLE
Handle `:` characters in contract paths correctly

### DIFF
--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -114,7 +114,10 @@ export abstract class AbstractCompilation {
         this.compilationTarget.name
       ]
     ) {
-      logWarn('Contract not found in compiler output');
+      logWarn('Contract not found in compiler output', {
+        path: this.compilationTarget.path,
+        name: this.compilationTarget.name,
+      });
       throw new CompilationError({
         code: 'contract_not_found_in_compiler_output',
       });

--- a/packages/lib-sourcify/src/Validation/SolidityMetadataContract.ts
+++ b/packages/lib-sourcify/src/Validation/SolidityMetadataContract.ts
@@ -30,6 +30,7 @@ import {
   getVariationsByContentHash,
 } from './variationsUtils';
 import { logDebug } from '../logger';
+import { splitFullyQualifiedName } from '../utils';
 
 export class SolidityMetadataContract {
   metadata: Metadata;
@@ -331,7 +332,8 @@ export class SolidityMetadataContract {
         }
 
         // After Solidity v0.7.5: { "ERC20.sol:ERC20": "0x..."}
-        const [contractPath, contractName] = libraryKey.split(':');
+        const { contractPath, contractName } =
+          splitFullyQualifiedName(libraryKey);
         if (!libraries[contractPath]) {
           libraries[contractPath] = {};
         }

--- a/packages/lib-sourcify/src/utils.ts
+++ b/packages/lib-sourcify/src/utils.ts
@@ -6,3 +6,18 @@
 export function isEmpty(obj: object): boolean {
   return !Object.keys(obj).length && obj.constructor === Object;
 }
+
+/**
+ * Splits a fully qualified name into a contract path and a contract name.
+ * @param fullyQualifiedName The fully qualified name to split.
+ * @returns An object containing the contract path and the contract name.
+ */
+export function splitFullyQualifiedName(fullyQualifiedName: string): {
+  contractPath: string;
+  contractName: string;
+} {
+  const splitIdentifier = fullyQualifiedName.split(':');
+  const contractName = splitIdentifier[splitIdentifier.length - 1];
+  const contractPath = splitIdentifier.slice(0, -1).join(':');
+  return { contractPath, contractName };
+}

--- a/packages/lib-sourcify/test/Validation/SolidityMetadataContract.spec.ts
+++ b/packages/lib-sourcify/test/Validation/SolidityMetadataContract.spec.ts
@@ -312,6 +312,28 @@ describe('SolidityMetadataContract', () => {
         ERC20: '0x1234567890123456789012345678901234567890',
       });
     });
+
+    it('should handle ":" inside library paths correctly', () => {
+      const metadata = {
+        ...validMetadata,
+        settings: {
+          ...validMetadata.settings,
+          libraries: {
+            'contracts/path:with:colons.sol:LibraryName':
+              '0x1234567890123456789012345678901234567890',
+          },
+        },
+      };
+      const contract = new SolidityMetadataContract(metadata, validSources);
+      contract.createJsonInputFromMetadata();
+      expect(
+        contract.solcJsonInput?.settings?.libraries?.[
+          'contracts/path:with:colons.sol'
+        ] as any,
+      ).to.deep.equal({
+        LibraryName: '0x1234567890123456789012345678901234567890',
+      });
+    });
   });
 
   describe('createJsonInputFromMetadata', () => {

--- a/services/server/src/server/apiv2/verification/verification.handlers.ts
+++ b/services/server/src/server/apiv2/verification/verification.handlers.ts
@@ -4,6 +4,7 @@ import type {
   CompilationTarget,
   Metadata,
 } from "@ethereum-sourcify/lib-sourcify";
+import { splitFullyQualifiedName } from "@ethereum-sourcify/lib-sourcify";
 import { TypedResponse } from "../../types";
 import logger from "../../../common/logger";
 import { Request } from "express";
@@ -44,9 +45,9 @@ export async function verifyFromJsonInputEndpoint(
 
   // The contract path can include a colon itself. Therefore,
   // we need to take the last element as the contract name.
-  const splitIdentifier = req.body.contractIdentifier.split(":");
-  const contractName = splitIdentifier[splitIdentifier.length - 1];
-  const contractPath = splitIdentifier.slice(0, -1).join(":");
+  const { contractName, contractPath } = splitFullyQualifiedName(
+    req.body.contractIdentifier,
+  );
   const compilationTarget: CompilationTarget = {
     name: contractName,
     path: contractPath,

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -2,6 +2,7 @@ import {
   VerificationStatus,
   StringMap,
   VerificationExport,
+  splitFullyQualifiedName,
 } from "@ethereum-sourcify/lib-sourcify";
 import logger from "../../../common/logger";
 import AbstractDatabaseService from "./AbstractDatabaseService";
@@ -350,7 +351,7 @@ export class SourcifyDatabaseService
             "__$" + keccak256Str(key).slice(2).slice(0, 34) + "$__";
         } else {
           // Solidity < 0.5.0 is __MyLib__________ (total 40 characters)
-          const libName = key.split(":")[1];
+          const { contractName: libName } = splitFullyQualifiedName(key);
           const trimmedLibName = libName.slice(0, 36); // in case it's longer
           formattedKey = "__" + trimmedLibName.padEnd(38, "_");
         }


### PR DESCRIPTION
Closes #2043

