### PR TITLE
Clarify that a Postgres database is required for API v2

### DIFF
--- a/services/server/README.md
+++ b/services/server/README.md
@@ -18,9 +18,7 @@ Sourcify's server for verifying contracts.
 npm install
 ```
 
-2. Change the server storage backend to a filesystem for easy start. Create a `src/config/local.js`:
-
-See the [Config](#config) section below for details.
+2. Change the server storage backend to a filesystem for easy start (API v2 won't be available). Create a `src/config/local.js`. See the [Config](#config) section below for details.
 
 ```js
 const {
@@ -58,6 +56,8 @@ npm start
 The server config is defined in [`src/config/default.js`](src/config/default.js).
 
 To override the default config, you can create a `local.js` file and override the default config. The parameters are overridden one by one, so you only need to override the parameters you want to change.
+
+Note that you need to set the read storage option to `RWStorageIdentifiers.SourcifyDatabase` and run a PostgreSQL database to make API v2 available. See [Database](#database).
 
 Once you've written your own config, you must build the server again for changes to take effect:
 
@@ -215,7 +215,7 @@ There are two types of storages: `RWStorageIdentifiers` and `WStorageIdentifiers
 - `WStorageIdentifiers.RepositoryV2` - a filesystem for serving source files and metadata on IPFS. Since pinning files on IPFS is done over a file system, Sourcify saves these files here. This repository does not save source file names as given in the metadata file (e.g. `contracts/MyContract.sol`) but saves each file with their keccak256 hash. This is done to avoid file name issues, as source file names can be arbitrary strings.
 
 - `WStorageIdentifiers.AllianceDatabase` - the PostgreSQL for the [Verifier Alliance](https://verifieralliance.org)
-- `RWStorageIdentifiers.SourcifyDatabase` - the PostgreSQL database that is an extension of the Verifier Alliance database.
+- `RWStorageIdentifiers.SourcifyDatabase` - the PostgreSQL database that is an extension of the Verifier Alliance database. Required for API v2. See [Database](#database).
 
 `RWStorageIdentifiers` can both be used as a source of truth (`read`) and store (`writeOr...`) the verified contracts. `WStorageIdentifiers` can only store (write) verified contracts. For instance, Sourcify can write to the [Verifier Alliance](https://verifieralliance.org) whenever it receives a verified contract, but this can't be the source of truth for the Sourcify APIs.
 

--- a/services/server/src/server/apiv2/routes.ts
+++ b/services/server/src/server/apiv2/routes.ts
@@ -2,8 +2,24 @@ import { Router } from "express";
 import lookupRoutes from "./lookup/lookup.routes";
 import jobsRoutes from "./jobs/jobs.routes";
 import verificationRoutes from "./verification/verification.routes";
+import { Services } from "../services/services";
+import { RWStorageIdentifiers } from "../services/storageServices/identifiers";
+import { RouteNotFoundError } from "./errors";
 
 const router: Router = Router();
+
+router.use((req, res, next) => {
+  const services = req.app.get("services") as Services;
+  if (
+    services.storage.enabledServices.read !==
+    RWStorageIdentifiers.SourcifyDatabase
+  ) {
+    throw new RouteNotFoundError(
+      "API v2 is disabled because the server has no database configured as read service.",
+    );
+  }
+  next();
+});
 
 router.use("/", lookupRoutes);
 router.use("/", jobsRoutes);

--- a/services/server/test/integration/apiv2/v2.common.spec.ts
+++ b/services/server/test/integration/apiv2/v2.common.spec.ts
@@ -1,0 +1,25 @@
+import chai from "chai";
+import chaiHttp from "chai-http";
+import { ServerFixture } from "../../helpers/ServerFixture";
+import { RWStorageIdentifiers } from "../../../src/server/services/storageServices/identifiers";
+
+chai.use(chaiHttp);
+
+describe("/v2 with no database configured", function () {
+  const serverFixture = new ServerFixture({
+    skipDatabaseReset: true,
+    read: RWStorageIdentifiers.RepositoryV1,
+    writeOrErr: [RWStorageIdentifiers.RepositoryV1],
+  });
+
+  it("should return a 404", async function () {
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/1`);
+
+    chai.expect(res.status).to.equal(404);
+    chai.expect(res.body.customCode).to.equal("route_not_found");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
+});


### PR DESCRIPTION
Closes #1981

This does two things:

- Clarify in server README that a database is required for API v2
- Return a 404 on /v2 endpoints if no database is configured


I also checked if the example configuration in the README works. I had no problems with running it.