### PR TITLE
In the release script don't merge staging to master

### DIFF
--- a/scripts/release/git_utils.sh
+++ b/scripts/release/git_utils.sh
@@ -76,38 +76,17 @@ create_gh_deploy_pr() {
   fi
 }
 
-merge_locally() {
-  echo "Locally merging staging into master"
-  git merge staging
-  echo "Merged staging into master"
-}
-
-switch_to_staging() {
-  echo "Switching to staging..."
-  git checkout staging
-  echo "Checked out staging"
-}
-
-push_to_master() {
-  # Push to master
-  echo "Pushing to master..."
-  git push origin master
-  echo "Pushed to master"
-}
-
 ask_if_release_pr_merged() {
   echo "Now please review and approve the release new versions PR to staging."
+}
+
+ask_if_master_pr_merged() {
+  echo "Now please review and approve the 'Deploy latest to production' PR to master."
 }
 
 push_to_staging() {
   echo "Pushing to staging..."
   git push origin staging
-}
-
-switch_to_master() {
-  echo "Switching to master..."
-  git checkout master
-  echo "Checked out master"
 }
 
 create_new_branch() {
@@ -175,12 +154,4 @@ open_pr_to_staging() {
   echo "Opening PR to staging..."
   gh pr create --title "$title" --body "" --head "$branch_name" --base staging
   echo "Opened PR to staging"
-}
-
-switch_to_staging_and_pull() {
-  echo "Switching to staging..."
-  git checkout staging
-  echo "Checked out staging"
-  git pull
-  echo "Pulled latest staging"
 }

--- a/scripts/release/main.sh
+++ b/scripts/release/main.sh
@@ -38,10 +38,7 @@ prompt_execute_or_skip "asking if release PR is merged" ask_if_release_pr_merged
 prompt_execute_or_skip "pushing the tags to GitHub" push_tags_in_order
 prompt_execute_or_skip "creating GitHub releases" create_github_releases
 
-prompt_execute_or_skip "switching to staging and pulling latest" switch_to_staging_and_pull
-prompt_execute_or_skip "switching to master" switch_to_master
-prompt_execute_or_skip "merging staging to master locally" merge_locally
-prompt_execute_or_skip "pushing the commits to master" push_to_master
+prompt_execute_or_skip "asking if 'Deploy latest to production' PR is merged" ask_if_master_pr_merged
 
 # Clean up the temporary package data file
 prompt_execute_or_skip "cleaning up temporary release data" cleanup_package_data_file


### PR DESCRIPTION
Previously, the final steps of the release process included merging staging into master. With this PR, we replace those steps by requiring the user to manually approve and merge the pull request directly on GitHub.