### PR TITLE
Change Codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,11 @@
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 70%


### PR DESCRIPTION
Closes #2073 

Easing the Codecov PR status checks a bit.

- allows project wide coverage to drop by max 0.5 % per PR
- requires to have at least 70 % coverage on the PR changes

