### PR TITLE
Include errors in the Compiler error log

### DIFF
--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -75,7 +75,7 @@ export abstract class AbstractCompilation {
       );
     } catch (e: any) {
       logWarn('Compiler error', {
-        error: e.message,
+        error: e.errors ? e.errors : e.message,
       });
       // Depending on the compiler implementation, the errors object could be undefined
       // In this case, we use the error message as a fallback


### PR DESCRIPTION
Previously, the “Compiler error” log message in `lib-sourcify` did not provide any useful error information. This PR updates the logging behavior to ensure that detailed error messages are included when a compiler error occurs.