### PR TITLE
V2 address lookup on all chains endpoint

### DIFF
--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -147,7 +147,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerErrorResponse'
       security: []
-  '/v2/contract/allChains/{address}':
+  '/v2/contract/all-chains/{address}':
     get:
       tags:
         - Contract Lookup

--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -147,6 +147,68 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerErrorResponse'
       security: []
+  '/v2/contract/allChains/{address}':
+    get:
+      tags:
+        - Contract Lookup
+      summary: Get verified contract at an address on all chains
+      description: |-
+        Returns all verified deployments at an address on all Sourcify chains (including deprecated ones).
+
+        Success returns an array of VerifiedContractMinimal objects under `results` field.
+
+        If not verified on any chain, the `results` array will be empty.
+      operationId: get-contract-all-chains
+      parameters:
+        - $ref: '#/components/parameters/address'
+      responses:
+        '200':
+          description: Returns all verified deployments at an address on all Sourcify chains
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/VerifiedContractMinimal'
+              examples:
+                Example 1:
+                  value:
+                    results:
+                      - match: exact_match
+                        creationMatch: match
+                        runtimeMatch: exact_match
+                        chainId: '1'
+                        address: '0xDFEBAd708F803af22e81044aD228Ff77C83C935c'
+                        verifiedAt: '2024-07-24T12:00:00Z'
+                      - match: match
+                        creationMatch: match
+                        runtimeMatch: match
+                        chainId: '11155111'
+                        address: '0xDFEBAd708F803af22e81044aD228Ff77C83C935c'
+                        verifiedAt: '2025-02-10T14:45:00Z'
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items: {}
+              examples:
+                Example 1:
+                  value:
+                    results: []                            
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
   '/v2/contracts/{chainId}':
     get:
       tags:
@@ -884,7 +946,10 @@ components:
                 message: You are sending too many requests
                 errorId: 1ac6b91a-0605-4459-93dc-18f210a70192
     ListVerifiedContracts:
-      description: ''
+      description: |-
+        Returns an array of VerifiedContractMinimal objects under `results` field.
+
+        If not verified on any chain, the `results` array will be empty.
       content:
         application/json:
           schema:

--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -172,6 +172,7 @@ paths:
                   results:
                     type: array
                     items:
+                      # Not using ref:ListVerifiedContracts because its example has different addresses in results. Here we want to have the same address in results. The definitions are the same.
                       $ref: '#/components/schemas/VerifiedContractMinimal'
               examples:
                 Example 1:
@@ -183,12 +184,14 @@ paths:
                         chainId: '1'
                         address: '0xDFEBAd708F803af22e81044aD228Ff77C83C935c'
                         verifiedAt: '2024-07-24T12:00:00Z'
+                        matchId: '421'
                       - match: match
                         creationMatch: match
                         runtimeMatch: match
                         chainId: '11155111'
                         address: '0xDFEBAd708F803af22e81044aD228Ff77C83C935c'
                         verifiedAt: '2025-02-10T14:45:00Z'
+                        matchId: '5531'
         '400':
           $ref: '#/components/responses/BadRequestResponse'
         '404':
@@ -969,12 +972,14 @@ components:
                     chainId: '11155111'
                     address: '0xDFEBAd708F803af22e81044aD228Ff77C83C935c'
                     verifiedAt: '2024-07-24T12:00:00Z'
+                    matchId: '421'
                   - match: match
                     creationMatch: match
                     runtimeMatch: match
                     chainId: '11155111'
                     address: '0x2738d13E81e30bC615766A0410e7cF199FD59A83'
                     verifiedAt: '2024-07-24T12:00:00Z'
+                    matchId: '5531'
     InternalServerErrorResponse:
       description: ''
       content:

--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -195,7 +195,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequestResponse'
         '404':
-          description: Not Found
+          description: No verified contract found on any chain for the provided address
           content:
             application/json:
               schema:

--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: 2.0.0
+  version: 2.1.0
   title: Sourcify APIv2
   description: |-
     Welcome to the Sourcify's APIv2.

--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -53,6 +53,8 @@ paths:
     $ref: "apiv2.yaml#/paths/~1v2~1verify~1{verificationId}"
   /v2/contract/{chainId}/{address}:
     $ref: "apiv2.yaml#/paths/~1v2~1contract~1{chainId}~1{address}"
+  /v2/contract/allChains/{address}:
+    $ref: "apiv2.yaml#/paths/~1v2~1contract~1allChains~1{address}"
   /v2/contracts/{chainId}:
     $ref: "apiv2.yaml#/paths/~1v2~1contracts~1{chainId}"
   /verify:

--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -53,8 +53,8 @@ paths:
     $ref: "apiv2.yaml#/paths/~1v2~1verify~1{verificationId}"
   /v2/contract/{chainId}/{address}:
     $ref: "apiv2.yaml#/paths/~1v2~1contract~1{chainId}~1{address}"
-  /v2/contract/allChains/{address}:
-    $ref: "apiv2.yaml#/paths/~1v2~1contract~1allChains~1{address}"
+  /v2/contract/all-chains/{address}:
+    $ref: "apiv2.yaml#/paths/~1v2~1contract~1all-chains~1{address}"
   /v2/contracts/{chainId}:
     $ref: "apiv2.yaml#/paths/~1v2~1contracts~1{chainId}"
   /verify:

--- a/services/server/src/server/apiv2/lookup/lookup.handlers.ts
+++ b/services/server/src/server/apiv2/lookup/lookup.handlers.ts
@@ -44,7 +44,7 @@ export async function listContractsEndpoint(
   });
   const services = req.app.get("services") as Services;
 
-  const contracts = await services.storage.performServiceOperation(
+  const resultsObject = await services.storage.performServiceOperation(
     "getContractsByChainId",
     [
       req.params.chainId,
@@ -54,7 +54,7 @@ export async function listContractsEndpoint(
     ],
   );
 
-  res.status(StatusCodes.OK).json(contracts);
+  res.status(StatusCodes.OK).json(resultsObject);
 }
 
 interface GetContractRequest extends Request {
@@ -161,4 +161,35 @@ export async function getContractEndpoint(
   }
 
   res.status(StatusCodes.OK).json(contract);
+}
+
+interface GetContractAllChainsRequest extends Request {
+  params: {
+    address: string;
+  };
+}
+
+type GetContractAllChainsResponse = TypedResponse<{
+  results: VerifiedContractMinimal[];
+}>;
+
+export async function getContractAllChainsEndpoint(
+  req: GetContractAllChainsRequest,
+  res: GetContractAllChainsResponse,
+) {
+  logger.debug("getContractAllChainsEndpoint", {
+    address: req.params.address,
+  });
+  const services = req.app.get("services") as Services;
+  const resultsObject = await services.storage.performServiceOperation(
+    "getContractsAllChains",
+    [req.params.address],
+  );
+
+  if (resultsObject.results.length === 0) {
+    res.status(StatusCodes.NOT_FOUND).json(resultsObject);
+    return;
+  }
+
+  res.status(StatusCodes.OK).json(resultsObject);
 }

--- a/services/server/src/server/apiv2/lookup/lookup.routes.ts
+++ b/services/server/src/server/apiv2/lookup/lookup.routes.ts
@@ -14,7 +14,7 @@ import { Router } from "express";
 const router = Router();
 
 router
-  .route("/contract/allChains/:address")
+  .route("/contract/all-chains/:address")
   .get(validateAddress, getContractAllChainsEndpoint);
 
 router.route("/contracts/:chainId").get(validateChainId, listContractsEndpoint);

--- a/services/server/src/server/apiv2/lookup/lookup.routes.ts
+++ b/services/server/src/server/apiv2/lookup/lookup.routes.ts
@@ -3,11 +3,19 @@ import {
   validateChainId,
   validateFieldsAndOmit,
 } from "../middlewares";
-import { getContractEndpoint, listContractsEndpoint } from "./lookup.handlers";
+import {
+  getContractAllChainsEndpoint,
+  getContractEndpoint,
+  listContractsEndpoint,
+} from "./lookup.handlers";
 
 import { Router } from "express";
 
 const router = Router();
+
+router
+  .route("/contract/allChains/:address")
+  .get(validateAddress, getContractAllChainsEndpoint);
 
 router.route("/contracts/:chainId").get(validateChainId, listContractsEndpoint);
 

--- a/services/server/src/server/services/StorageService.ts
+++ b/services/server/src/server/services/StorageService.ts
@@ -104,6 +104,9 @@ export interface RWStorageService extends WStorageService {
     fields?: Field[],
     omit?: Field[],
   ): Promise<VerifiedContract>;
+  getContractsAllChains?(
+    address: string,
+  ): Promise<{ results: VerifiedContractMinimal[] }>;
   getVerificationJob?(verificationId: string): Promise<VerificationJob | null>;
   getVerificationJobsByChainAndAddress?(
     chainId: string,

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -747,7 +747,7 @@ export class SourcifyDatabaseService
       creationMatch: toMatchLevel(row.creation_match),
       runtimeMatch: toMatchLevel(row.runtime_match),
       matchId: row.id,
-      chainId: row.chain_id.toString(),
+      chainId: row.chain_id,
       address: getAddress(row.address),
       verifiedAt: row.verified_at,
     }));

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -735,6 +735,26 @@ export class SourcifyDatabaseService
     return result;
   };
 
+  getContractsAllChains = async (
+    address: string,
+  ): Promise<{ results: VerifiedContractMinimal[] }> => {
+    const result = await this.database.getSourcifyMatchesAllChains(
+      bytesFromString(address),
+    );
+
+    const results: VerifiedContractMinimal[] = result.rows.map((row) => ({
+      match: getTotalMatchLevel(row.creation_match, row.runtime_match),
+      creationMatch: toMatchLevel(row.creation_match),
+      runtimeMatch: toMatchLevel(row.runtime_match),
+      matchId: row.id,
+      chainId: row.chain_id.toString(),
+      address: getAddress(row.address),
+      verifiedAt: row.verified_at,
+    }));
+
+    return { results };
+  };
+
   getVerificationJob = async (
     verificationId: string,
   ): Promise<VerificationJob | null> => {

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -12,6 +12,7 @@ import {
   STORED_PROPERTIES_TO_SELECTORS,
   StoredProperties,
   Tables,
+  GetSourcifyMatchesAllChainsResult,
 } from "./database-util";
 import { createHash } from "crypto";
 import { AuthTypes, Connector } from "@google-cloud/cloud-sql-connector";
@@ -209,6 +210,33 @@ ${
 }
         `,
       [chain, address],
+    );
+  }
+
+  /**
+   * Query for looking for all sourcify matches for a given address on all chains.
+   * This is used for the /v2/contract/allChains/{address} endpoint.
+   */
+  async getSourcifyMatchesAllChains(
+    address: Bytes,
+  ): Promise<QueryResult<GetSourcifyMatchesAllChainsResult>> {
+    const selectors = [
+      STORED_PROPERTIES_TO_SELECTORS["id"],
+      STORED_PROPERTIES_TO_SELECTORS["creation_match"],
+      STORED_PROPERTIES_TO_SELECTORS["runtime_match"],
+      STORED_PROPERTIES_TO_SELECTORS["address"],
+      STORED_PROPERTIES_TO_SELECTORS["chain_id"],
+      STORED_PROPERTIES_TO_SELECTORS["verified_at"],
+    ];
+    return await this.pool.query(
+      `SELECT 
+        ${selectors.join(", ")}
+      FROM ${this.schema}.contract_deployments
+      JOIN ${this.schema}.verified_contracts ON verified_contracts.deployment_id = contract_deployments.id
+      JOIN ${this.schema}.sourcify_matches ON sourcify_matches.verified_contract_id = verified_contracts.id
+      WHERE contract_deployments.address = $1
+      `,
+      [address],
     );
   }
 

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -199,6 +199,15 @@ export type GetSourcifyMatchByChainAddressResult = Tables.SourcifyMatch &
     onchain_runtime_code: string;
   };
 
+export type GetSourcifyMatchesAllChainsResult = Pick<
+  Tables.SourcifyMatch,
+  "id" | "creation_match" | "runtime_match"
+> &
+  Pick<Tables.ContractDeployment, "chain_id"> & {
+    address: string;
+    verified_at: string;
+  };
+
 export type GetSourcifyMatchesByChainResult = Pick<
   Tables.SourcifyMatch,
   "id" | "creation_match" | "runtime_match"
@@ -229,7 +238,10 @@ export type GetSourcifyMatchByChainAddressWithPropertiesResult = Partial<
       | "runtime_transformations"
       | "runtime_values"
     > &
-    Pick<Tables.ContractDeployment, "block_number" | "transaction_index"> & {
+    Pick<
+      Tables.ContractDeployment,
+      "block_number" | "transaction_index" | "chain_id"
+    > & {
       verified_at: string;
       address: string;
       onchain_creation_code: string;
@@ -293,6 +305,7 @@ export const STORED_PROPERTIES_TO_SELECTORS = {
   id: "sourcify_matches.id",
   creation_match: "sourcify_matches.creation_match",
   runtime_match: "sourcify_matches.runtime_match",
+  chain_id: "contract_deployments.chain_id",
   verified_at:
     'to_char(sourcify_matches.created_at, \'YYYY-MM-DD"T"HH24:MI:SS"Z"\') as verified_at',
   address:

--- a/services/server/test/helpers/LocalChainFixture.ts
+++ b/services/server/test/helpers/LocalChainFixture.ts
@@ -42,6 +42,7 @@ const DEFAULT_CHAIN_ID = "31337";
 
 export type LocalChainFixtureOptions = {
   chainId?: string;
+  port?: number;
 };
 
 export class LocalChainFixture {
@@ -59,7 +60,8 @@ export class LocalChainFixture {
   defaultContractArtifact = storageContractArtifact;
   defaultContractJsonInput = storageJsonInput;
 
-  private _chainId?: string;
+  private _chainId: string;
+  private _port: number;
   private _localSigner?: JsonRpcSigner;
   private _defaultContractAddress?: string;
   private _defaultContractCreatorTx?: string;
@@ -114,6 +116,7 @@ export class LocalChainFixture {
    */
   constructor(options: LocalChainFixtureOptions = {}) {
     this._chainId = options.chainId ?? DEFAULT_CHAIN_ID;
+    this._port = options.port ?? HARDHAT_PORT;
 
     before(async () => {
       // Init IPFS mock with all the necessary pinned files
@@ -129,7 +132,7 @@ export class LocalChainFixture {
           });
       }
 
-      this.hardhatNodeProcess = await startHardhatNetwork(HARDHAT_PORT);
+      this.hardhatNodeProcess = await startHardhatNetwork(this._port);
 
       const sourcifyChainHardhat = LOCAL_CHAINS[1];
       const ethersNetwork = new Network(
@@ -137,7 +140,7 @@ export class LocalChainFixture {
         sourcifyChainHardhat.chainId,
       );
       this._localSigner = await new JsonRpcProvider(
-        `http://localhost:${HARDHAT_PORT}`,
+        `http://localhost:${this._port}`,
         ethersNetwork,
         { staticNetwork: ethersNetwork },
       ).getSigner();

--- a/services/server/test/helpers/ServerFixture.ts
+++ b/services/server/test/helpers/ServerFixture.ts
@@ -15,6 +15,7 @@ import { SolcLocal } from "../../src/server/services/compiler/local/SolcLocal";
 import { VyperLocal } from "../../src/server/services/compiler/local/VyperLocal";
 import path from "path";
 import { testS3Bucket, testS3Path } from "./S3ClientMock";
+import { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
 
 export type ServerFixtureOptions = {
   port: number;
@@ -22,6 +23,7 @@ export type ServerFixtureOptions = {
   writeOrWarn: StorageIdentifiers[];
   writeOrErr: StorageIdentifiers[];
   skipDatabaseReset: boolean;
+  chains: SourcifyChainMap;
 };
 
 export class ServerFixture {
@@ -89,7 +91,7 @@ export class ServerFixture {
         port: fixtureOptions_?.port || config.get<number>("server.port"),
         maxFileSize: config.get<number>("server.maxFileSize"),
         corsAllowedOrigins: config.get<string[]>("corsAllowedOrigins"),
-        chains: sourcifyChainsMap,
+        chains: fixtureOptions_?.chains || sourcifyChainsMap,
         solc: new SolcLocal(config.get("solcRepo"), config.get("solJsonRepo")),
         vyper: new VyperLocal(config.get("vyperRepo")),
         verifyDeprecated: true,

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -123,7 +123,9 @@ export async function verifyContract(
   expect(res.body.result.length).to.equal(1);
   expect(res.body.result[0].status).to.equal(partial ? "partial" : "perfect");
   expect(res.body.result[0].chainId).to.equal(chainFixture.chainId);
-  expect(res.body.result[0].address).to.equal(contractAddress);
+  if (contractAddress) {
+    expect(res.body.result[0].address).to.equal(contractAddress);
+  }
 }
 
 export async function deployAndVerifyContract(

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -10,7 +10,7 @@ import {
   Contract,
 } from "ethers";
 import { assertVerificationSession, assertVerification } from "./assertions";
-import chai from "chai";
+import chai, { expect } from "chai";
 import chaiHttp from "chai-http";
 import path from "path";
 import { promises as fs, readFileSync } from "fs";
@@ -94,7 +94,7 @@ export async function verifyContract(
   creatorTxHash?: string,
   partial: boolean = false,
 ) {
-  await chai
+  const res = await chai
     .request(serverFixture.server.app)
     .post("/")
     .field("address", contractAddress || chainFixture.defaultContractAddress)
@@ -116,6 +116,14 @@ export async function verifyContract(
         ? chainFixture.defaultContractModifiedSource
         : chainFixture.defaultContractSource,
     );
+  expect(
+    res.status,
+    `Verification failed for ${contractAddress} on chain ${chainFixture.chainId}`,
+  ).to.equal(200);
+  expect(res.body.result.length).to.equal(1);
+  expect(res.body.result[0].status).to.equal(partial ? "partial" : "perfect");
+  expect(res.body.result[0].chainId).to.equal(chainFixture.chainId);
+  expect(res.body.result[0].address).to.equal(contractAddress);
 }
 
 export async function deployAndVerifyContract(

--- a/services/server/test/integration/apiv2/lookup.spec.ts
+++ b/services/server/test/integration/apiv2/lookup.spec.ts
@@ -21,7 +21,7 @@ import {
 
 chai.use(chaiHttp);
 
-describe("GET /v2/contract/allChains/:address", function () {
+describe("GET /v2/contract/all-chains/:address", function () {
   const TEST_CHAIN_IDs = [11111, 22222, 33333];
   const TEST_CHAIN_PORTS = [8546, 8547, 8548];
   const chainFixtures = TEST_CHAIN_IDs.map(
@@ -57,7 +57,7 @@ describe("GET /v2/contract/allChains/:address", function () {
 
     const res = await chai
       .request(serverFixture.server.app)
-      .get(`/v2/contract/allChains/${validAddress}`);
+      .get(`/v2/contract/all-chains/${validAddress}`);
     chai.expect(res.status).to.equal(404);
     chai.expect(res.body.results).to.be.an.instanceOf(Array);
     chai.expect(res.body.results.length).to.equal(0);
@@ -80,7 +80,7 @@ describe("GET /v2/contract/allChains/:address", function () {
     // Check the contract is listed on all chains
     const res = await chai
       .request(serverFixture.server.app)
-      .get(`/v2/contract/allChains/${addresses[0]}`);
+      .get(`/v2/contract/all-chains/${addresses[0]}`);
     chai.expect(res.status).to.equal(200);
     chai.expect(res.body.results).to.be.an.instanceOf(Array);
     chai.expect(res.body.results.length).to.equal(chainFixtures.length);

--- a/services/server/test/integration/apiv2/lookup/all-chains.spec.ts
+++ b/services/server/test/integration/apiv2/lookup/all-chains.spec.ts
@@ -1,0 +1,92 @@
+import chai, { expect } from "chai";
+import chaiHttp from "chai-http";
+import { deployAndVerifyContract } from "../../../helpers/helpers";
+import { LocalChainFixture } from "../../../helpers/LocalChainFixture";
+import { ServerFixture } from "../../../helpers/ServerFixture";
+import { getAddress } from "ethers";
+import {
+  SourcifyChain,
+  SourcifyChainMap,
+} from "@ethereum-sourcify/lib-sourcify";
+
+chai.use(chaiHttp);
+
+describe("GET /v2/contract/all-chains/:address", function () {
+  const TEST_CHAIN_IDs = [11111, 22222, 33333];
+  const TEST_CHAIN_PORTS = [8546, 8547, 8548];
+  const chainFixtures = TEST_CHAIN_IDs.map(
+    (chainId, index) =>
+      new LocalChainFixture({
+        chainId: chainId.toString(),
+        port: TEST_CHAIN_PORTS[index],
+      }),
+  );
+  const serverFixture = new ServerFixture({
+    chains: TEST_CHAIN_IDs.reduce((acc, chainId, index) => {
+      acc[chainId.toString()] = new SourcifyChain({
+        name: `Test Chain ${chainId}`,
+        title: `Test Chain ${chainId}`,
+        supported: true,
+        chainId: chainId,
+        rpc: [`http://localhost:${TEST_CHAIN_PORTS[index]}`],
+        rpcWithoutApiKeys: [`http://localhost:${TEST_CHAIN_PORTS[index]}`],
+      });
+      return acc;
+    }, {} as SourcifyChainMap),
+  });
+
+  // Note: LocalChainFixture and ServerFixture have their own before/after hooks
+  // built into their constructors, so no additional setup needed here
+
+  it("should return a 404 and empty results when the contract is not found", async function () {
+    const randomAddress =
+      chainFixtures[0].defaultContractAddress.slice(0, -8) + "aaaaaaaa";
+    const validAddress = getAddress(randomAddress.toLowerCase());
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contract/all-chains/${validAddress}`);
+    chai.expect(res.status).to.equal(404);
+    chai.expect(res.body.results).to.be.an.instanceOf(Array);
+    chai.expect(res.body.results.length).to.equal(0);
+  });
+
+  it("should return the deployed and verified contract on the same address on all chains", async function () {
+    // Deploy the contract on all chains in parallel
+    const addresses = await Promise.all(
+      chainFixtures.map((chainFixture) =>
+        deployAndVerifyContract(chainFixture, serverFixture, false),
+      ),
+    );
+    expect(addresses.length).to.equal(TEST_CHAIN_IDs.length); // Make sure all are deployed
+
+    // Check all addresses are the same
+    const firstAddress = addresses[0];
+    addresses.forEach((address) => {
+      expect(address).to.equal(firstAddress);
+    });
+
+    // Check the contract is listed on all chains
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contract/all-chains/${addresses[0]}`);
+    chai.expect(res.status).to.equal(200);
+
+    chai
+      .expect(res.body.results.length, "Not all chains are verified")
+      .to.equal(TEST_CHAIN_IDs.length);
+    TEST_CHAIN_IDs.forEach((chainId) => {
+      const matchingResult = res.body.results.find(
+        (result: any) => result.chainId === chainId.toString(),
+      );
+
+      chai.expect(matchingResult).to.include({
+        match: "exact_match",
+        creationMatch: "exact_match",
+        runtimeMatch: "exact_match",
+        address: addresses[0],
+        chainId: chainId.toString(),
+      });
+    });
+  });
+});

--- a/services/server/test/integration/apiv2/lookup/contracts-by-chain.spec.ts
+++ b/services/server/test/integration/apiv2/lookup/contracts-by-chain.spec.ts
@@ -1,0 +1,165 @@
+import chai from "chai";
+import chaiHttp from "chai-http";
+import { deployAndVerifyContract } from "../../../helpers/helpers";
+import { LocalChainFixture } from "../../../helpers/LocalChainFixture";
+import { ServerFixture } from "../../../helpers/ServerFixture";
+import Sinon from "sinon";
+
+chai.use(chaiHttp);
+
+describe("GET /v2/contracts/:chainId", function () {
+  const chainFixture = new LocalChainFixture();
+  const serverFixture = new ServerFixture();
+  const sandbox = Sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should list verified contracts per chain", async function () {
+    const address = await deployAndVerifyContract(
+      chainFixture,
+      serverFixture,
+      true, // partial match
+    );
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}`);
+
+    chai.expect(res.status).to.equal(200);
+    chai.expect(res.body.results).to.be.an.instanceOf(Array);
+    chai.expect(res.body.results.length).to.equal(1);
+    chai.expect(res.body.results[0]).to.include({
+      match: "match",
+      creationMatch: "match",
+      runtimeMatch: "match",
+      chainId: chainFixture.chainId,
+      address,
+      matchId: "1",
+    });
+    chai.expect(res.body.results[0]).to.have.property("verifiedAt");
+  });
+
+  it("should list exact matches", async function () {
+    const address = await deployAndVerifyContract(
+      chainFixture,
+      serverFixture,
+      false, // exact match
+    );
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}`);
+
+    chai.expect(res.status).to.equal(200);
+    chai.expect(res.body.results).to.be.an.instanceOf(Array);
+    chai.expect(res.body.results.length).to.equal(1);
+    chai.expect(res.body.results[0]).to.include({
+      match: "exact_match",
+      creationMatch: "exact_match",
+      runtimeMatch: "exact_match",
+      chainId: chainFixture.chainId,
+      address,
+      matchId: "1",
+    });
+    chai.expect(res.body.results[0]).to.have.property("verifiedAt");
+  });
+
+  it(`should handle pagination when listing contracts`, async function () {
+    const contractAddresses: string[] = [];
+
+    // Deploy 5 contracts
+    for (let i = 0; i < 5; i++) {
+      const address = await deployAndVerifyContract(
+        chainFixture,
+        serverFixture,
+        true,
+      );
+      contractAddresses.push(address);
+    }
+
+    // Test limit
+    const res0 = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}?limit=3`);
+    chai.expect(res0.body.results).to.be.an.instanceOf(Array);
+    chai.expect(res0.body.results.length).to.equal(3);
+    chai.expect(res0.body.results[0].matchId).to.equal("5");
+    chai.expect(res0.body.results[1].matchId).to.equal("4");
+    chai.expect(res0.body.results[2].matchId).to.equal("3");
+
+    // Test afterMatchId with desc
+    const res1 = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}?limit=2&afterMatchId=4`);
+    chai.expect(res1.body.results[0].matchId).to.equal("3");
+    chai.expect(res1.body.results[1].matchId).to.equal("2");
+
+    // Test afterMatchId with asc
+    const res2 = await chai
+      .request(serverFixture.server.app)
+      .get(
+        `/v2/contracts/${chainFixture.chainId}?limit=2&afterMatchId=1&sort=asc`,
+      );
+    chai.expect(res2.body.results[0].matchId).to.equal("2");
+    chai.expect(res2.body.results[1].matchId).to.equal("3");
+
+    // Test ascending order
+    const oldestContractsFirst = contractAddresses;
+    const resAsc = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}?sort=asc`);
+
+    chai.expect(resAsc.body.results).to.be.an.instanceOf(Array);
+    chai
+      .expect(resAsc.body.results.length)
+      .to.equal(oldestContractsFirst.length);
+    for (let i = 0; i < oldestContractsFirst.length; i++) {
+      chai.expect(resAsc.body.results[i]).to.include({
+        match: "match",
+        creationMatch: "match",
+        runtimeMatch: "match",
+        chainId: chainFixture.chainId,
+        address: oldestContractsFirst[i],
+        matchId: (i + 1).toString(),
+      });
+    }
+
+    // Test descending order
+    const resDesc = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}?sort=desc`);
+
+    const newestContractsFirst = Array.from(contractAddresses).reverse();
+    chai.expect(resDesc.body.results).to.be.an.instanceOf(Array);
+    chai
+      .expect(resDesc.body.results.length)
+      .to.equal(newestContractsFirst.length);
+    for (let i = 0; i < newestContractsFirst.length; i++) {
+      chai.expect(resDesc.body.results[i]).to.include({
+        match: "match",
+        creationMatch: "match",
+        runtimeMatch: "match",
+        chainId: chainFixture.chainId,
+        address: newestContractsFirst[i],
+        matchId: (newestContractsFirst.length - i).toString(),
+      });
+    }
+  });
+
+  it("should return a 404 when the chain is not found", async function () {
+    const unknownChainId = "5";
+    const chainMap = serverFixture.server.chainRepository.sourcifyChainMap;
+    sandbox.stub(chainMap, unknownChainId).value(undefined);
+
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${unknownChainId}`);
+
+    chai.expect(res.status).to.equal(404);
+    chai.expect(res.body.customCode).to.equal("unsupported_chain");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
+});


### PR DESCRIPTION
Closes #2114 

Adding a new enpoint under `/v2/contract/allChains/:address`. Let me know if you have feedback regarding the endpoint naming choice.

The endpoint returns an array of VerifiedContractMinimal under the `results` field on the response body. If there are no contracts at this address on any chain, it returns `404` with an results array that is empty `[]`. Idk if this is good practice and we should return `200`?

- Bumps the APIv2 version to v2.1.0
- Implements the queries, handlers, and the endpoint.
- Add tests

I appreciate a detailed look on the DB query. 

Todo:
- [ ] We need to add "address" as a new index on the `contract_deployments` table. Both on VerA and Sourcify IMO. We should see how we incorporate this as part of a migration etc.