### PR TITLE
Fix wrong package being published when CIRCLE_TAG=@ethereum-sourcify/compilers-types@1.0.4

### DIFF
--- a/.circleci/scripts/publish_to_npm.sh
+++ b/.circleci/scripts/publish_to_npm.sh
@@ -48,7 +48,7 @@ packages=(
 # Publish packages
 for package in "${packages[@]}"; do
   IFS=':' read -r local_path npm_package <<<"$package"
-  if [[ $CIRCLE_TAG == ${npm_package}* ]]; then # Only publish if tag starts with package name. Otherwise it will publish all at once.
+  if [[ $CIRCLE_TAG == *"${npm_package}@"* ]]; then # Only publish if tag contains exact package name followed by @.
     echo "$CIRCLE_TAG matches $npm_package, publishing $npm_package"
   else
     echo "Skipping $npm_package as CIRCLE_TAG doesn't start with $npm_package"


### PR DESCRIPTION
Since the matching function basically looks for "starts with" it was trying to publish /compilers package again and the CI was failing.

Fix by changing to package name followed by @
