### PR TITLE
Fix npm not publishing sourcify-server because of prefix check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,13 +201,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Check Tag Prefix
-          command: |
-            if [[ "$CIRCLE_TAG" != "@ethereum-sourcify"* ]]; then
-              echo "Skipping npm-publish as tag does not start with @ethereum-sourcify"
-              circleci-agent step halt
-            fi
-      - run:
           name: install dependencies
           command: npm install
       - run:

--- a/.circleci/scripts/publish_to_npm.sh
+++ b/.circleci/scripts/publish_to_npm.sh
@@ -51,7 +51,7 @@ for package in "${packages[@]}"; do
   if [[ $CIRCLE_TAG == *"${npm_package}@"* ]]; then # Only publish if tag contains exact package name followed by @.
     echo "$CIRCLE_TAG matches $npm_package, publishing $npm_package"
   else
-    echo "Skipping $npm_package as CIRCLE_TAG doesn't start with $npm_package"
+    echo "Skipping $npm_package as CIRCLE_TAG $CIRCLE_TAG doesn't start with $npm_package"
     continue
   fi
 


### PR DESCRIPTION
Turns out we haven't been publishing sourcify-server since 8 months because of a `@ethereum-sourcify` prefix check in our CI :(

https://www.npmjs.com/package/sourcify-server