### PR TITLE
Update lib-sourcify link to point to the correct staging branch

### DIFF
--- a/services/server/README.md
+++ b/services/server/README.md
@@ -2,7 +2,7 @@
 
 Sourcify's server for verifying Solidity and Vyper smart contracts.
 
-The server uses [lib-sourcify](https://github.com/ethereum/sourcify/tree/main/packages/lib-sourcify) under the hood for contract verification logic. It provides REST API endpoints for users to submit new contracts for verification or retrieve verified contracts. The data is stored in a PostgreSQL database.
+The server uses [lib-sourcify](https://github.com/ethereum/sourcify/tree/staging/packages/lib-sourcify) under the hood for contract verification logic. It provides REST API endpoints for users to submit new contracts for verification or retrieve verified contracts. The data is stored in a PostgreSQL database.
 
 ## Quick Start with Docker Compose
 


### PR DESCRIPTION
Replaced the outdated link to lib-sourcify in the services/server/README.md file. The link now points to the staging branch (https://github.com/ethereum/sourcify/tree/staging/packages/lib-sourcify) instead of main, ensuring users are directed to the latest development version of the library.