### PR TITLE
Verify via SolidityCompilation directly inside /verify/solc-json endpoint

### DIFF
--- a/services/server/src/server/services/utils/parsing-util.ts
+++ b/services/server/src/server/services/utils/parsing-util.ts
@@ -1,0 +1,47 @@
+import { Sources } from "@ethereum-sourcify/lib-sourcify";
+import logger from "../../../common/logger";
+import SolidityParser from "@solidity-parser/parser";
+
+/**
+ * Returns undefined if the contract is not found in the sources
+ */
+export const getContractPathFromSources = (
+  contractName: string,
+  sources: Sources,
+): string | undefined => {
+  logger.debug("parsing-util: Parsing sources for finding the contract path", {
+    contractName,
+  });
+  const startTime = Date.now();
+  let contractPath: string | undefined;
+  for (const [path, { content }] of Object.entries(sources)) {
+    try {
+      const ast = SolidityParser.parse(content);
+      SolidityParser.visit(ast, {
+        ContractDefinition: (node) => {
+          if (node.name === contractName) {
+            contractPath = path;
+            return false; // Stop visiting
+          }
+        },
+      });
+    } catch (error) {
+      // Just continue, because the relevant contract might be in a different source file.
+      logger.warn(
+        "parsing-util: Error parsing source code. Ignoring this source.",
+        {
+          path,
+          error,
+        },
+      );
+    }
+  }
+  const endTime = Date.now();
+  logger.debug("parsing-util: Parsing for all sources done", {
+    contractName,
+    contractPath,
+    timeInMs: endTime - startTime,
+  });
+
+  return contractPath;
+};

--- a/services/server/test/unit/utils/etherscan-util.spec.ts
+++ b/services/server/test/unit/utils/etherscan-util.spec.ts
@@ -317,25 +317,6 @@ describe("etherscan util", function () {
   });
 
   describe("getContractPathFromSourcesOrThrow", () => {
-    it("should return the correct contract path", () => {
-      const sources = {
-        // It should not derive it from the path
-        "SolidityContract.sol": {
-          content: "contract WrongContract {}",
-        },
-        "path/file.sol": {
-          content: "contract WrongContract {}\ncontract SolidityContract {}",
-        },
-      };
-
-      const result = getContractPathFromSourcesOrThrow(
-        "SolidityContract",
-        sources,
-        true,
-      );
-      expect(result).to.equal("path/file.sol");
-    });
-
     it("should throw when the contract path is not found in the provided sources", () => {
       const sources = {
         "path/file.sol": {

--- a/services/server/test/unit/utils/parsing-util.spec.ts
+++ b/services/server/test/unit/utils/parsing-util.spec.ts
@@ -1,0 +1,33 @@
+import { getContractPathFromSources } from "../../../src/server/services/utils/parsing-util";
+import { expect } from "chai";
+
+describe("getContractPathFromSources", () => {
+  it("should return the correct contract path", () => {
+    const sources = {
+      // It should not derive it from the path
+      "SolidityContract.sol": {
+        content: "contract WrongContract {}",
+      },
+      "path/file.sol": {
+        content: "contract WrongContract {}\ncontract SolidityContract {}",
+      },
+    };
+
+    const result = getContractPathFromSources("SolidityContract", sources);
+    expect(result).to.equal("path/file.sol");
+  });
+
+  it("should return undefined when the contract path is not found in the provided sources", () => {
+    const sources = {
+      "path/file.sol": {
+        content: "contract SolidityContract {}",
+      },
+    };
+
+    const result = getContractPathFromSources(
+      "AnotherSolidityContract",
+      sources,
+    );
+    expect(result).to.be.undefined;
+  });
+});


### PR DESCRIPTION
See #2206 

The breaking request of #2206 fails on the unzip method as far as I can tell from the logs. The unzip is called with Metadata files that we get from recompiling the contract a first time. The first recompilation via the provided std json works. Since the processing via Metadata is a workaround from legacy code, we can remove this step and directly call the actual compilation for the std json, and verify from there. This should hopefully fix the server for this request, otherwise I added logging to check what the provided parameters and then we can debug further.