### PR TITLE
Remove json input from API v1 verify/solc-json log

### DIFF
--- a/services/server/src/server/apiv1/verification/solc-json/stateless/solc-json.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/solc-json/stateless/solc-json.stateless.handlers.ts
@@ -44,7 +44,6 @@ export async function verifySolcJsonEndpoint(req: Request, res: Response) {
     contractName: contractName,
     compilerVersion: compilerVersion,
     creatorTxHash: creatorTxHash,
-    solcJson: solcJson,
   });
 
   const contractPath = getContractPathFromSources(


### PR DESCRIPTION
Introduced in #2216, but we should reduce the log size