### PR TITLE
Remove metadata only outputSettings in etherscan-utils

### DIFF
--- a/packages/compilers-types/src/SolidityTypes.ts
+++ b/packages/compilers-types/src/SolidityTypes.ts
@@ -88,7 +88,7 @@ export interface SoliditySettings {
   debug?: Debug;
   metadata?: SettingsMetadata;
   libraries?: Libraries;
-  outputSelection: OutputSelection;
+  outputSelection?: OutputSelection;
   modelChecker?: ModelChecker;
 }
 

--- a/services/server/src/server/services/utils/etherscan-util.ts
+++ b/services/server/src/server/services/utils/etherscan-util.ts
@@ -127,11 +127,6 @@ export const getSolcJsonInputFromEtherscanResult = (
       enabled: etherscanResult.OptimizationUsed === "1",
       runs: parseInt(etherscanResult.Runs),
     },
-    outputSelection: {
-      "*": {
-        "*": ["metadata", "evm.deployedBytecode.object"],
-      },
-    },
     evmVersion:
       etherscanResult.EVMVersion.toLowerCase() !== "default"
         ? etherscanResult.EVMVersion
@@ -312,14 +307,6 @@ export const processSolidityResultFromEtherscan = (
   if (isEtherscanJsonInput(sourceCodeObject)) {
     logger.debug("Etherscan solcJsonInput contract found");
     solcJsonInput = parseEtherscanJsonInput(sourceCodeObject);
-
-    if (solcJsonInput?.settings) {
-      // Tell compiler to output metadata and bytecode
-      solcJsonInput.settings.outputSelection["*"]["*"] = [
-        "metadata",
-        "evm.deployedBytecode.object",
-      ];
-    }
 
     contractPath = getContractPathFromSourcesOrThrow(
       contractName,


### PR DESCRIPTION
This is an old behavior from metadata-based verification times. We used to first compile the etherscan result to get the metadata. Now we generate std-json in these functions and the outputSelection field is always overridden by the SolidityCompilation and VyperCompilation:

https://github.com/ethereum/sourcify/blob/5e362a8707ff10af76673c9ae1c05250dffcb0ff/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts#L48-L68

https://github.com/ethereum/sourcify/blob/5e362a8707ff10af76673c9ae1c05250dffcb0ff/packages/lib-sourcify/src/Compilation/VyperCompilation.ts#L84-L99