### PR TITLE
Log client identification headers for verify.sourcify.dev UI requests

### DIFF
--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -210,7 +210,7 @@ export class Server {
       const clientType = req.headers["x-client-type"] as string;
 
       if (clientSource) {
-        logger.info("verify.sourcify.dev UI client request", {
+        logger.info("Client request via header", {
           method: req.method,
           path: req.path,
           clientSource,


### PR DESCRIPTION
Turns out GCP does not log custom headers and they need to be logged inside the service

See https://github.com/sourcifyeth/verify.sourcify.dev/commit/0ae11add1df284f487594f40bb0963fc06da845e