### PR TITLE
Do not log the full VerificationExport in StorageService

### DIFF
--- a/services/server/src/server/services/StorageService.ts
+++ b/services/server/src/server/services/StorageService.ts
@@ -351,7 +351,11 @@ export class StorageService {
         service.storeVerification(verification, jobData).catch((e) => {
           logger.error(`Error storing to ${service.IDENTIFIER}`, {
             error: e,
-            verification,
+            contractAddress: verification.address,
+            chainId: verification.chainId,
+            runtimeMatch: verification.status.runtimeMatch,
+            creationMatch: verification.status.creationMatch,
+            jobData,
           });
           throw e;
         }),
@@ -363,7 +367,11 @@ export class StorageService {
         service.storeVerification(verification, jobData).catch((e) => {
           logger.warn(`Error storing to ${service.IDENTIFIER}`, {
             error: e,
-            verification,
+            contractAddress: verification.address,
+            chainId: verification.chainId,
+            runtimeMatch: verification.status.runtimeMatch,
+            creationMatch: verification.status.creationMatch,
+            jobData,
           });
         }),
       );


### PR DESCRIPTION
I saw this log was too big and getting truncated in GCP and therefore it was not possible to find it via trace id
