### PR TITLE
fix: update lint command to use 'check' instead of 'lint' in CI configurations

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -280,7 +280,7 @@ jobs:
           command: npx lerna run build
       - run:
           name: lint
-          command: npx lerna run lint
+          command: npx lerna run check
       - run:
           name: test
           command: npx lerna run test --stream

--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -50,7 +50,7 @@ jobs:
           command: npx lerna run build
       - run:
           name: lint
-          command: npx lerna run lint
+          command: npx lerna run check
       - run:
           name: test
           command: npx lerna run test --stream


### PR DESCRIPTION
Our CI wasn't running the linting step because we used the wrong name. See here for example: https://app.circleci.com/pipelines/github/ethereum/sourcify/9122/workflows/099a1479-1c58-4eb8-876e-e034aa94277d/jobs/53585/parallel-runs/0/steps/0-105