### PR TITLE
fix: remove redundant migration command from etherscan instance nightly ci test

### DIFF
--- a/.circleci/nightly.yml
+++ b/.circleci/nightly.yml
@@ -104,7 +104,7 @@ jobs:
           command: npx lerna run build
       - run:
           name: test
-          command: cd ./services/server && npm run postgres-test:migrate && npm run test:etherscan-instances
+          command: cd ./services/server && npm run test:etherscan-instances
           environment:
             DOCKER_HOST_POSTGRES_TEST_PORT: 5432
             SOURCIFY_POSTGRES_HOST: "localhost"


### PR DESCRIPTION
Fix for the nightly CI run:
https://app.circleci.com/pipelines/github/ethereum/sourcify/9129/workflows/ae6ef024-617d-4c1e-850a-8d668ca4ace6/jobs/53631