### PR TITLE
Add massive replace script with configuration and API integration

### DIFF
--- a/services/database/.env.template
+++ b/services/database/.env.template
@@ -20,3 +20,17 @@ DATABASE_URL=postgres://username:password@127.0.0.1:5432/database_name?sslmode=d
 
 # Keep this for updating the schema dump after adding a new migration
 DBMATE_SCHEMA_FILE=./sourcify-database.sql
+
+
+##### Massive replace script configuration
+# Database configuration
+SOURCIFY_HOST=localhost
+SOURCIFY_DB=sourcify
+SOURCIFY_USER=sourcify
+SOURCIFY_PASSWORD=sourcify
+SOURCIFY_PORT=5432
+SOURCIFY_SCHEMA=public
+
+# API configuration
+API_BASE_URL=https://staging.sourcify.dev/server
+API_AUTH_TOKEN=token_here

--- a/services/database/.gitignore
+++ b/services/database/.gitignore
@@ -1,1 +1,2 @@
 migrations-temp/
+massive-replace-script/CURRENT_VERIFIED_CONTRACT

--- a/services/database/massive-replace-script/README.md
+++ b/services/database/massive-replace-script/README.md
@@ -1,0 +1,79 @@
+# Massive Replace Script
+
+This script allows you to call the `/private/replace-contract` endpoint for multiple contracts based on a configuration file.
+
+## Environment Variables
+
+Create a `.env` file or set the following environment variables:
+
+```bash
+# Database connection
+SOURCIFY_HOST=localhost
+SOURCIFY_DB=sourcify
+SOURCIFY_USER=sourcify
+SOURCIFY_PASSWORD=password
+SOURCIFY_PORT=5432
+SOURCIFY_SCHEMA=public
+
+# API configuration
+API_BASE_URL=http://localhost:5000
+API_AUTH_TOKEN=your_bearer_token_here
+
+# Script configuration
+CONFIG_FILE_PATH=/path/to/your/config.js
+CURRENT_VERIFIED_CONTRACT_PATH=/path/to/counter/directory
+```
+
+## Configuration File
+
+The configuration file should export an object with the following structure:
+
+```javascript
+module.exports = {
+  // Function that executes the query to extract affected contracts
+  query: async (sourcePool, sourcifySchema, currentVerifiedContract, n) => {
+    return await sourcePool.query(
+      `
+      SELECT 
+          cd.chain_id,
+          cd.address,
+          cd.transaction_hash,
+          -- other fields as needed
+          vc.id as verified_contract_id
+      FROM ${sourcifySchema}.contract_deployments cd
+      -- your joins and conditions
+      WHERE vc.id >= $1
+      ORDER BY vc.id ASC
+      LIMIT $2
+    `,
+      [currentVerifiedContract, n],
+    );
+  },
+
+  // The customReplaceMethod to use in the API call
+  customReplaceMethod: "replace-creation-information",
+
+  // Optional description
+  description: "Description of what this configuration does",
+};
+```
+
+## Usage
+
+1. Set up your environment variables
+2. Choose or create a configuration file
+3. Run the script from the database service directory:
+
+```bash
+cd services/database
+CONFIG_FILE_PATH=./massive-replace-script/config-replace-creation-information.js npm run massive-replace
+```
+
+## How It Works
+
+1. The script loads the configuration file specified by `CONFIG_FILE_PATH`
+2. It connects to the database using the provided credentials
+3. It runs the configured query to get batches of contracts (200 at a time by default)
+4. For each contract, it calls the `/private/replace-contract` API endpoint
+5. It tracks progress using a counter file in `CURRENT_VERIFIED_CONTRACT_PATH`
+6. The script continues until no more contracts are found

--- a/services/database/massive-replace-script/config-replace-creation-information.js
+++ b/services/database/massive-replace-script/config-replace-creation-information.js
@@ -1,0 +1,47 @@
+// Configuration for replace-creation-information use case
+// This configuration targets contracts where creation_code_hash equals runtime_code_hash
+// and updates their creation information
+
+module.exports = {
+  query: async (sourcePool, sourcifySchema, currentVerifiedContract, n) => {
+    return await sourcePool.query(
+      `
+      SELECT 
+          cd.chain_id,
+          cd.address,
+          cd.transaction_hash,
+          c.creation_code_hash,
+          c.runtime_code_hash,
+          vc.runtime_match,
+          vc.creation_match,
+          sm.runtime_match as sourcify_runtime_match,
+          sm.creation_match as sourcify_creation_match,
+          cd.created_at,
+          vc.id as verified_contract_id
+      FROM ${sourcifySchema}.contract_deployments cd
+      JOIN ${sourcifySchema}.contracts c ON cd.contract_id = c.id
+      JOIN ${sourcifySchema}.verified_contracts vc ON vc.deployment_id = cd.id
+      LEFT JOIN ${sourcifySchema}.sourcify_matches sm ON sm.verified_contract_id = vc.id
+      WHERE c.creation_code_hash = c.runtime_code_hash
+          AND c.creation_code_hash IS NOT NULL
+          AND c.runtime_code_hash IS NOT NULL
+          AND vc.id >= $1
+          AND vc.id IN (678564, 678714)
+      ORDER BY vc.id ASC
+      LIMIT $2
+    `,
+      [currentVerifiedContract, n],
+    );
+  },
+  buildRequestBody: (contract) => {
+    return {
+      chainId: contract.chain_id.toString(),
+      address: `0x${contract.address.toString("hex")}`,
+      forceCompilation: false,
+      forceRPCRequest: true,
+      customReplaceMethod: "replace-creation-information",
+    };
+  },
+  description:
+    "Updates existing verified contracts with creation bytecode information for contracts where creation and runtime bytecode are identical",
+};

--- a/services/database/massive-replace-script/massive-replace-script.ts
+++ b/services/database/massive-replace-script/massive-replace-script.ts
@@ -1,0 +1,204 @@
+import pg from "pg";
+import fs from "fs";
+import path from "path";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+interface ReplaceConfig {
+  query: (
+    sourcePool: pg.Pool,
+    sourcifySchema: string,
+    currentVerifiedContract: number,
+    n: number,
+  ) => Promise<pg.QueryResult>;
+  buildRequestBody: (contract: any) => any;
+  description?: string;
+}
+
+const CURRENT_VERIFIED_CONTRACT_PATH =
+  process.env.CURRENT_VERIFIED_CONTRACT_PATH || __dirname;
+
+const { Pool } = pg;
+
+// Load current verified contract counter from file
+const COUNTER_FILE = path.join(
+  CURRENT_VERIFIED_CONTRACT_PATH,
+  "CURRENT_VERIFIED_CONTRACT",
+);
+let CURRENT_VERIFIED_CONTRACT = 1;
+if (fs.existsSync(COUNTER_FILE)) {
+  CURRENT_VERIFIED_CONTRACT = parseInt(
+    fs.readFileSync(COUNTER_FILE, "utf8"),
+    10,
+  );
+}
+
+const N = 200; // Number of contracts to process at a time
+
+const SOURCIFY_SCHEMA = process.env.SOURCIFY_SCHEMA || "public";
+
+const SOURCE_DB_CONFIG = {
+  host: process.env.SOURCIFY_HOST,
+  database: process.env.SOURCIFY_DB,
+  user: process.env.SOURCIFY_USER,
+  password: process.env.SOURCIFY_PASSWORD,
+  port: process.env.SOURCIFY_PORT
+    ? parseInt(process.env.SOURCIFY_PORT, 10)
+    : undefined,
+};
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5555";
+const API_AUTH_TOKEN = process.env.API_AUTH_TOKEN;
+
+if (!API_AUTH_TOKEN) {
+  throw new Error("API_AUTH_TOKEN is not set");
+}
+
+const CONFIG_FILE_PATH = process.env.CONFIG_FILE_PATH!;
+
+if (!CONFIG_FILE_PATH) {
+  throw new Error("CONFIG_FILE_PATH is not set");
+}
+
+function loadConfiguration(): ReplaceConfig {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const configModule = require(CONFIG_FILE_PATH);
+    return configModule;
+  } catch (error) {
+    console.error("Error loading configuration file:", error);
+    throw new Error("Failed to load configuration");
+  }
+}
+
+async function callReplaceContractAPI(requestBody: any): Promise<any> {
+  const url = `${API_BASE_URL}/private/replace-contract`;
+
+  if (!API_AUTH_TOKEN) {
+    throw new Error("API_AUTH_TOKEN is not set");
+  }
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_AUTH_TOKEN}`,
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `API call failed: ${response.status} ${response.statusText} - ${errorText}`,
+      );
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Error calling replace-contract API:", error);
+    throw error;
+  }
+}
+
+async function processContract(
+  contract: any,
+  config: ReplaceConfig,
+): Promise<void> {
+  const address = `0x${contract.address.toString("hex")}`;
+  try {
+    console.log(
+      `Processing contract: chainId=${contract.chain_id}, address=0x${address}, verifiedContractId=${contract.verified_contract_id || contract.id}`,
+    );
+
+    const requestBody = config.buildRequestBody(contract);
+    const result = await callReplaceContractAPI(requestBody);
+
+    console.log(`✅ Successfully processed contract ${address}:`, result);
+  } catch (error) {
+    console.error(`❌ Failed to process contract ${address}:`, error);
+    throw error;
+  }
+}
+
+(async () => {
+  // Load configuration
+  const config = loadConfiguration();
+  console.log(
+    `Using configuration: ${config.description || "Custom replacement"}`,
+  );
+
+  // Connect to source DB using a Pool
+  const sourcePool = new Pool(SOURCE_DB_CONFIG);
+  sourcePool.on("error", (err) => {
+    console.error("Unexpected error on idle source client", err);
+    process.exit(-1);
+  });
+
+  try {
+    // Process contracts
+    let verifiedContractCount = 1;
+    while (verifiedContractCount > 0) {
+      const startIterationTime = performance.now();
+
+      console.log(`Processing next ${N} contracts`);
+      console.log(`Current contract id: ${CURRENT_VERIFIED_CONTRACT}`);
+
+      // Use the query from configuration
+      const { rows: verifiedContracts, rowCount } = await config.query(
+        sourcePool,
+        SOURCIFY_SCHEMA,
+        CURRENT_VERIFIED_CONTRACT,
+        N,
+      );
+
+      verifiedContractCount = rowCount || 0;
+
+      // Process the batch in parallel
+      try {
+        const processingPromises = verifiedContracts.map((contract) =>
+          processContract(contract, config),
+        );
+        await Promise.all(processingPromises);
+
+        // Update the counter file only after the batch successfully completes
+        if (verifiedContracts.length > 0) {
+          const lastProcessedId =
+            verifiedContracts[verifiedContracts.length - 1]
+              .verified_contract_id ||
+            verifiedContracts[verifiedContracts.length - 1].id;
+          CURRENT_VERIFIED_CONTRACT = parseInt(lastProcessedId) + 1;
+
+          // Use async write to avoid blocking
+          fs.writeFile(
+            COUNTER_FILE,
+            CURRENT_VERIFIED_CONTRACT.toString(),
+            "utf8",
+            (err) => {
+              if (err) {
+                console.error("Error writing counter file:", err);
+              }
+            },
+          );
+        }
+      } catch (batchError) {
+        console.error("Error processing batch:", batchError);
+      }
+
+      const endIterationTime = performance.now();
+      const iterationTimeTaken = endIterationTime - startIterationTime;
+      console.log(
+        `Rate: processing ${
+          N / (iterationTimeTaken / 1000)
+        } contracts per second`,
+      );
+    }
+    console.log("Contracts processed successfully.");
+  } catch (error) {
+    console.error("Error processing contracts:", error);
+  } finally {
+    // End the pool
+    if (sourcePool) await sourcePool.end();
+  }
+})();

--- a/services/database/package.json
+++ b/services/database/package.json
@@ -13,7 +13,8 @@
     "migrate:create-db": "dbmate create",
     "migrate:drop-db": "dbmate drop",
     "migrate:load-schema": "dbmate load",
-    "migrate:status": "npm run migrate:setup && DBMATE_MIGRATIONS_DIR=./migrations-temp dbmate status"
+    "migrate:status": "npm run migrate:setup && DBMATE_MIGRATIONS_DIR=./migrations-temp dbmate status",
+    "massive-replace": "ts-node massive-replace-script/massive-replace-script.ts"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
I just thought of creating a generic massive-replace script that calls the new `/private/replace-contract` endpoint efficiently. The script is configurable by passing a config file so we can re-use it to run other fixes on sourcify.

```js
// Configuration for replace-creation-information use case
// This configuration targets contracts where creation_code_hash equals runtime_code_hash
// and updates their creation information

module.exports = {
  query: async (sourcePool, sourcifySchema, currentVerifiedContract, n) => {
    return await sourcePool.query(
      `
      SELECT 
          [...]
          AND vc.id >= $1
          [...]
      LIMIT $2
    `,
      [currentVerifiedContract, n],
    );
  },
  buildRequestBody: (contract) => {
    return {
      chainId: contract.chain_id.toString(),
      address: `0x${contract.address.toString("hex")}`,
      forceCompilation: false,
      forceRPCRequest: true,
      customReplaceMethod: "replace-creation-information",
    };
  },
  description:
    "Updates existing verified contracts with creation bytecode information for contracts where creation and runtime bytecode are identical",
};

```