### PR TITLE
fix: update Node.js engine version to >=22.0.0 in package.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18295,7 +18295,7 @@
         "npm-run-all2": "5.0.2"
       },
       "engines": {
-        "node": "22.5.1"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
@@ -18330,7 +18330,7 @@
         "npm-run-all2": "5.0.2"
       },
       "engines": {
-        "node": "22.5.1"
+        "node": ">=22.0.0"
       }
     },
     "packages/compilers-types": {
@@ -18399,7 +18399,7 @@
         "tree-kill": "1.2.2"
       },
       "engines": {
-        "node": "22.5.1"
+        "node": ">=22.0.0"
       }
     },
     "packages/lib-sourcify/node_modules/@types/node": {

--- a/packages/bytecode-utils/package.json
+++ b/packages/bytecode-utils/package.json
@@ -35,7 +35,7 @@
     "cov:check": "c8 report && c8 check-coverage --lines 100 --functions 100 --branches 100"
   },
   "engines": {
-    "node": "22.5.1"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@ethersproject/bytes": "5.8.0",

--- a/packages/compilers/package.json
+++ b/packages/compilers/package.json
@@ -23,7 +23,7 @@
     "cov:check": "c8 report && c8 check-coverage --lines 100 --functions 100 --branches 100"
   },
   "engines": {
-    "node": "22.5.1"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/lib-sourcify/package.json
+++ b/packages/lib-sourcify/package.json
@@ -31,7 +31,7 @@
     "cov:check": "c8 report && c8 check-coverage --lines 100 --functions 100 --branches 100"
   },
   "engines": {
-    "node": "22.5.1"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@ethereum-sourcify/bytecode-utils": "^1.3.9",


### PR DESCRIPTION
There were these warnings when you installed the packages:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@ethereum-sourcify/lib-sourcify@2.1.5',
npm warn EBADENGINE   required: { node: '22.5.1' },
npm warn EBADENGINE   current: { node: 'v22.17.1', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@ethereum-sourcify/bytecode-utils@1.3.9',
npm warn EBADENGINE   required: { node: '22.5.1' },
npm warn EBADENGINE   current: { node: 'v22.17.1', npm: '10.9.2' }
npm warn EBADENGINE }
```