### PR TITLE
Replace script config for fixing missing constructor args transformations

### DIFF
--- a/services/database/.env.template
+++ b/services/database/.env.template
@@ -27,3 +27,4 @@ DBMATE_SCHEMA_FILE=./sourcify-database.sql
 # API configuration
 API_BASE_URL=https://staging.sourcify.dev/server
 API_AUTH_TOKEN=token_here
+STORE_FAILED_CONTRACT_IDS=false

--- a/services/database/massive-replace-script/README.md
+++ b/services/database/massive-replace-script/README.md
@@ -66,7 +66,7 @@ module.exports = {
 
 ```bash
 cd services/database
-CONFIG_FILE_PATH=./massive-replace-script/config-replace-creation-information.js npm run massive-replace
+CONFIG_FILE_PATH=./config-replace-creation-information.js npm run massive-replace
 ```
 
 ## How It Works

--- a/services/database/massive-replace-script/config-constructor-arguments-transformation.js
+++ b/services/database/massive-replace-script/config-constructor-arguments-transformation.js
@@ -1,0 +1,42 @@
+// Configuration for fixing missing constructorArguments transformation
+// This configuration targets contracts where creation code exists but creation_match is null/false
+// and the recompiled creation code matches the onchain creation code
+// Related to: https://github.com/ethereum/sourcify/issues/2086
+
+module.exports = {
+  query: async (sourcePool, sourcifySchema, currentVerifiedContract, n) => {
+    return await sourcePool.query(
+      `
+      SELECT 
+          cd.chain_id,
+          cd.address,
+          sm.id as verified_contract_id
+      FROM ${sourcifySchema}.verified_contracts vc
+      JOIN ${sourcifySchema}.contract_deployments cd ON vc.deployment_id = cd.id
+      JOIN ${sourcifySchema}.contracts c ON cd.contract_id = c.id
+      JOIN ${sourcifySchema}.code creation_code ON c.creation_code_hash = creation_code.code_hash
+      JOIN ${sourcifySchema}.compiled_contracts cc ON vc.compilation_id = cc.id
+      JOIN ${sourcifySchema}.code recompiled_creation_code ON cc.creation_code_hash = recompiled_creation_code.code_hash
+      INNER JOIN ${sourcifySchema}.sourcify_matches sm ON sm.verified_contract_id = vc.id
+      WHERE c.creation_code_hash IS NOT NULL 
+          AND position(substring(recompiled_creation_code.code for 200) in creation_code.code) != 0
+          AND (vc.creation_match is null or vc.creation_match = false)
+          AND sm.id >= $1
+      ORDER BY sm.id ASC
+      LIMIT $2
+    `,
+      [currentVerifiedContract, n],
+    );
+  },
+  buildRequestBody: (contract) => {
+    return {
+      chainId: contract.chain_id.toString(),
+      address: `0x${contract.address.toString("hex")}`,
+      forceCompilation: false,
+      forceRPCRequest: false,
+      customReplaceMethod: "replace-creation-information",
+    };
+  },
+  description:
+    "Fixes missing constructorArguments transformation for contracts where creation code exists but creation_match is null/false. See https://github.com/ethereum/sourcify/issues/2086",
+};

--- a/services/database/massive-replace-script/massive-replace-script.ts
+++ b/services/database/massive-replace-script/massive-replace-script.ts
@@ -160,14 +160,15 @@ async function processContract(
 
       let secondToWait = 2;
       // Process the batch in parallel
-      try {
-        const processingPromises = verifiedContracts.map((contract) =>
-          processContract(contract, config),
-        );
-        await Promise.all(processingPromises);
-      } catch (batchError) {
-        secondToWait = 5; // Increase wait time on error
-        console.error("Error processing batch:", batchError);
+      const processingPromises = verifiedContracts.map((contract) =>
+        processContract(contract, config),
+      );
+      const results = await Promise.allSettled(processingPromises);
+      for (const result of results) {
+        if (result.status === "rejected") {
+          console.error("Error processing contract:", result.reason);
+          secondToWait = 5; // Increase wait time on error
+        }
       }
 
       // Update the counter file only after the batch successfully completes

--- a/services/server/src/server/apiv1/verification/private/stateless/customReplaceMethods.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/customReplaceMethods.ts
@@ -21,7 +21,7 @@ export const replaceCreationInformation: CustomReplaceMethod = async (
   await sourcifyDatabaseService.withTransaction(async (poolClient) => {
     if (!databaseColumns.onchainCreationCode) {
       throw new Error(
-        "Creation match is null, cannot replace creation information",
+        "No onchain creation code, cannot replace creation information",
       );
     }
     // Get existing verified contract to find deployment_id

--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
@@ -266,7 +266,7 @@ export async function replaceContract(
       const transactionHashFromDatabase = (sourcifyChain as SourcifyChainMock)
         .contractDeployment?.transaction_hash;
       if (transactionHashFromDatabase) {
-        transactionHash = `0x${transactionHashFromDatabase}`;
+        transactionHash = transactionHashFromDatabase;
       }
     } else {
       // Use the chainRepository to get the sourcifyChain object and fetch the contract's information from the RPC


### PR DESCRIPTION
See #2208

This adds a new configuration for the massive replace script to fix the contracts of the linked issue. We found one problem in the `replace-contract` endpoint that led to writing an empty transaction hash when replacing. This is also addressed by correctly assigning the transaction hash which is retrieved from the database. Additionally, this adds smaller adjustments to the massive replace script like an option to store info about contracts which failed replacing.