### PR TITLE
Update Dockerfiles from Bullseye to Bookworm for Vyper compiler compatibility

### DIFF
--- a/services/monitor/Dockerfile
+++ b/services/monitor/Dockerfile
@@ -1,5 +1,5 @@
 # Needs to be run from the project root context e.g. `cd sourcify/ && docker build -f services/monitor/Dockerfile .`
-FROM node:22.5.1-bullseye as builder
+FROM node:22.5.1-bookworm as builder
 RUN mkdir -p /home/app
 WORKDIR /home/app
 
@@ -11,7 +11,7 @@ RUN npx lerna run build --scope sourcify-monitor
 ######################
 ## Production image ##
 ######################
-FROM node:22.5.1-bullseye-slim as production
+FROM node:22.5.1-bookworm-slim as production
 
 RUN mkdir -p /home/app/services/monitor
 

--- a/services/server/Dockerfile
+++ b/services/server/Dockerfile
@@ -1,7 +1,7 @@
 # Needs to be run from the project root context e.g. `cd sourcify/ && docker build -f services/monitor/Dockerfile .`
 
 # Builder image
-FROM node:22.5.1-bullseye as builder
+FROM node:22.5.1-bookworm as builder
 
 RUN mkdir -p /home/app
 WORKDIR /home/app
@@ -15,7 +15,7 @@ RUN npx lerna run build --scope sourcify-server
 ######################
 ## Production image ##
 ######################
-FROM node:22.5.1-bullseye-slim as production
+FROM node:22.5.1-bookworm-slim as production
 
 RUN mkdir -p /home/app/services/server
 

--- a/services/server/Dockerfile.debug
+++ b/services/server/Dockerfile.debug
@@ -5,7 +5,7 @@
 # Assuming server is running on port 5555
 # Run with: docker run -it -p 9229:9229 -p 5555:5555 --volume /path/to/local/sourcify/git/repo:/home/app sourcify-server-debug
 # Finally run "Docker: Attach to Server" in VSCode debugger
-FROM node:22.5.1-bullseye
+FROM node:22.5.1-bookworm
 WORKDIR /home/app/services/server
 
 CMD ["node", "--inspect=0.0.0.0:9229", "./dist/server/cli.js"]

--- a/services/server/docker-compose.local.yml
+++ b/services/server/docker-compose.local.yml
@@ -17,7 +17,7 @@ services:
 
   # Needed to separate the migration because node must have PID 1 in service server
   run-migrations:
-    image: node:22.5.1-bullseye-slim
+    image: node:22.5.1-bookworm-slim
     volumes:
       - ../database:/home/app/services/database
     environment:

--- a/services/server/docker-compose.yml
+++ b/services/server/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   # Needed to separate the migration because node must have PID 1 in service server
   run-migrations:
-    image: node:22.5.1-bullseye-slim
+    image: node:22.5.1-bookworm-slim
     volumes:
       - ../database:/home/app/services/database
     environment:


### PR DESCRIPTION
Fixes #2258, #2229

Upgrades the server Docker base image from node:22.5.1-bullseye to node:22.5.1-bookworm to resolve glibc compatibility issues with Vyper compiler binaries.

Problem:
  - Vyper compiler binaries (v0.4.3+) require glibc 2.35+ for proper execution
  - Debian Bullseye ships with glibc 2.31, causing runtime errors when downloading and executing Vyper binaries programmatically
  - Error: GLIBC_2.35' not found prevents Vyper compilation functionality

Solution:
  - Debian Bookworm provides a newer version of glibc, meeting Vyper's requirements
  - Updates both builder and production stages to use bookworm-based images
  - Maintains compatibility with existing Node.js 22.5.1 runtime