### PR TITLE
Allow to replace contracts on unsupported chains

### DIFF
--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.paths.yaml
@@ -159,7 +159,6 @@ paths:
                 chainId:
                   oneOf:
                     - type: string
-                      format: supported-chainId
                     - type: number
                   description: The chain ID of the contract
                   example: "1"
@@ -218,7 +217,6 @@ paths:
                   chainId:
                     oneOf:
                       - type: string
-                        format: supported-chainId
                       - type: number
                   transactionHash:
                     type: string


### PR DESCRIPTION
The issue in https://github.com/ethereum/sourcify/issues/2208 can actually be fixed on deprecated chains since it doesn't use the RPCs. Unfortunately, the endpoint prevents this currently. This removes the requirement of being a supported chain from the endpoint.