### PR TITLE
Clean compiler version in compilation classes

### DIFF
--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -21,12 +21,17 @@ import {
 } from '@ethereum-sourcify/compilers-types';
 import { logInfo, logSilly, logWarn } from '../logger';
 
+function cleanCompilerVersion(version: string): string {
+  // Remove non-numerical characters from the beginning of the version string
+  return version.replace(/^[^\d]*/, '');
+}
+
 export abstract class AbstractCompilation {
   /**
    * Constructor parameters
    */
   abstract compiler: ISolidityCompiler | IVyperCompiler;
-  abstract compilerVersion: string;
+  compilerVersion: string;
   abstract compilationTarget: CompilationTarget;
   jsonInput: SolidityJsonInput | VyperJsonInput;
 
@@ -50,7 +55,11 @@ export abstract class AbstractCompilation {
     forceEmscripten?: boolean,
   ): Promise<void>;
 
-  constructor(jsonInput: SolidityJsonInput | VyperJsonInput) {
+  constructor(
+    compilerVersion: string,
+    jsonInput: SolidityJsonInput | VyperJsonInput,
+  ) {
+    this.compilerVersion = cleanCompilerVersion(compilerVersion);
     this.jsonInput = structuredClone(jsonInput);
   }
 

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -33,14 +33,14 @@ export class PreRunCompilation extends AbstractCompilation {
 
   public constructor(
     public compiler: ISolidityCompiler | IVyperCompiler,
-    public compilerVersion: string,
+    compilerVersion: string,
     jsonInput: SolidityJsonInput | VyperJsonInput,
     jsonOutput: SolidityOutput | VyperOutput,
     public compilationTarget: CompilationTarget,
     public _creationBytecodeCborAuxdata: CompiledContractCborAuxdata,
     public _runtimeBytecodeCborAuxdata: CompiledContractCborAuxdata,
   ) {
-    super(jsonInput);
+    super(compilerVersion, jsonInput);
     this.compilerOutput = jsonOutput;
     this.language = jsonInput.language as CompilationLanguage;
     switch (this.language) {

--- a/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
@@ -36,11 +36,11 @@ export class SolidityCompilation extends AbstractCompilation {
 
   public constructor(
     public compiler: ISolidityCompiler,
-    public compilerVersion: string,
+    compilerVersion: string,
     jsonInput: SolidityJsonInput,
     public compilationTarget: CompilationTarget,
   ) {
-    super(jsonInput);
+    super(compilerVersion, jsonInput);
     this.initSolidityJsonInput();
   }
 

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -162,11 +162,11 @@ export class VyperCompilation extends AbstractCompilation {
 
   public constructor(
     public compiler: IVyperCompiler,
-    public compilerVersion: string,
+    compilerVersion: string,
     jsonInput: VyperJsonInput,
     public compilationTarget: CompilationTarget,
   ) {
-    super(jsonInput);
+    super(compilerVersion, jsonInput);
 
     // Vyper beta and rc versions are not semver compliant, so we need to handle them differently
     this.compilerVersionCompatibleWithSemver = returnFixedVyperVersion(

--- a/packages/lib-sourcify/test/Compilation/SolidityCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/SolidityCompilation.spec.ts
@@ -325,4 +325,32 @@ describe('SolidityCompilation', () => {
     const immutableRefs = compilation.immutableReferences;
     expect(immutableRefs).to.deep.equal({ '3': [{ length: 32, start: 608 }] });
   });
+
+  it('should clean compiler version with v prefix', () => {
+    const contractPath = path.join(__dirname, '..', 'sources', 'Storage');
+    const metadata = JSON.parse(
+      fs.readFileSync(path.join(contractPath, 'metadata.json'), 'utf8'),
+    );
+    const sources = {
+      'project:/contracts/Storage.sol': {
+        content: fs.readFileSync(
+          path.join(contractPath, 'sources', 'Storage.sol'),
+          'utf8',
+        ),
+      },
+    };
+
+    const compilation = new SolidityCompilation(
+      solc,
+      'v0.8.4+commit.c7e474f2',
+      {
+        language: 'Solidity',
+        sources,
+        settings: getSolcSettingsFromMetadata(metadata),
+      },
+      getCompilationTargetFromMetadata(metadata),
+    );
+
+    expect(compilation.compilerVersion).to.equal('0.8.4+commit.c7e474f2');
+  });
 });

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -647,4 +647,44 @@ describe('VyperCompilation', () => {
       version: 1,
     });
   });
+
+  it('should clean compiler version with v prefix', () => {
+    const contractPath = path.join(
+      __dirname,
+      '..',
+      'sources',
+      'Vyper',
+      'testcontract',
+    );
+    const contractFileName = 'test.vy';
+    const contractContent = fs.readFileSync(
+      path.join(contractPath, contractFileName),
+      'utf8',
+    );
+
+    const compilation = new VyperCompilation(
+      vyperCompiler,
+      'v0.3.10+commit.91361694',
+      {
+        language: 'Vyper',
+        sources: {
+          [contractFileName]: {
+            content: contractContent,
+          },
+        },
+        settings: {
+          evmVersion: 'istanbul',
+          outputSelection: {
+            '*': ['evm.bytecode'],
+          },
+        },
+      },
+      {
+        name: contractFileName.split('.')[0],
+        path: contractFileName,
+      },
+    );
+
+    expect(compilation.compilerVersion).to.equal('0.3.10+commit.91361694');
+  });
 });


### PR DESCRIPTION
See #2253

This fixes the problem of version strings that include a `v` at the beginning leading to failed downloads of the solc binary.