### PR TITLE
Exclude contracts from deprecated chains in config-constructor-arguments-transformation

### DIFF
--- a/services/database/massive-replace-script/config-constructor-arguments-transformation.js
+++ b/services/database/massive-replace-script/config-constructor-arguments-transformation.js
@@ -21,6 +21,7 @@ module.exports = {
       WHERE c.creation_code_hash IS NOT NULL 
           AND position(substring(recompiled_creation_code.code for 200) in creation_code.code) != 0
           AND (vc.creation_match is null or vc.creation_match = false)
+          AND c.runtime_code_hash <> decode('F2915DCA011E27647A7C8A50F7062915FDB4D4A1DE05D7333605DB231E5FC1F2', 'hex')
           AND sm.id >= $1
       ORDER BY sm.id ASC
       LIMIT $2

--- a/services/server/src/server/apiv1/verification/private/stateless/customReplaceMethods.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/customReplaceMethods.ts
@@ -4,6 +4,7 @@ import {
   getDatabaseColumnsFromVerification,
 } from "../../../../services/utils/database-util";
 import { SourcifyDatabaseService } from "../../../../services/storageServices/SourcifyDatabaseService";
+import { BadRequestError } from "../../../../../common/errors";
 
 export type CustomReplaceMethod = (
   sourcifyDatabaseService: SourcifyDatabaseService,
@@ -14,6 +15,22 @@ export const replaceCreationInformation: CustomReplaceMethod = async (
   sourcifyDatabaseService: SourcifyDatabaseService,
   verification: VerificationExport,
 ) => {
+  const verificationStatus = verification.status;
+  const creationMatch =
+    verificationStatus.creationMatch === "perfect" ||
+    verificationStatus.creationMatch === "partial";
+
+  const runtimeMatch =
+    verificationStatus.runtimeMatch === "perfect" ||
+    verificationStatus.runtimeMatch === "partial";
+
+  // If the new verification leads to a non-match, we can't replace the contract
+  if (!runtimeMatch && !creationMatch) {
+    throw new BadRequestError(
+      "Failed to match the contract with the new verification",
+    );
+  }
+
   // Get database columns from verification
   const databaseColumns =
     await getDatabaseColumnsFromVerification(verification);

--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
@@ -285,23 +285,11 @@ export async function replaceContract(
       transactionHash,
     );
 
-    await verification.verify();
-
-    // Get the verification status
-    const verificationStatus = verification.status;
-    const creationMatch =
-      verificationStatus.creationMatch === "perfect" ||
-      verificationStatus.creationMatch === "partial";
-
-    const runtimeMatch =
-      verificationStatus.runtimeMatch === "perfect" ||
-      verificationStatus.runtimeMatch === "partial";
-
-    // If the new verification leads to a non-match, we can't replace the contract
-    if (!runtimeMatch && !creationMatch) {
-      throw new BadRequestError(
-        "Failed to match the contract with the new verification",
-      );
+    try {
+      await verification.verify();
+    } catch {
+      // Some methods do not require verification, so we ignore errors here.
+      // This is imported to fix contracts that were added via verifyDeprecated, because they will never have a match.
     }
 
     try {
@@ -329,7 +317,7 @@ export async function replaceContract(
       address: address,
       chainId: chainId,
       transactionHash: transactionHash,
-      newStatus: verificationStatus,
+      newStatus: verification.status,
       rpcFailedFetchingCreationBytecode,
     });
   } catch (error: any) {


### PR DESCRIPTION
Contracts added via verifyDeprecated cannot be fixed by the endpoint since they will never have a match.

However, for fixing [#2227](https://github.com/ethereum/sourcify/issues/2227), it is not necessary to have a match because we only replace metadata. So, we should allow replacing contracts without match in replaceContract endpoint.