### PR TITLE
Skip schema validation in CI

### DIFF
--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -129,33 +129,35 @@ jobs:
           command: |
             cd services/database
             npm install
-      - run:
-          name: Validate schema is in sync with migrations
-          command: |
-            cd services/database
-            # Initialize git submodules
-            git submodule update --init
-            # Apply migrations using npm script
-            npm run migrate:up
-            # Force dump in case problems were ignored
-            npx dbmate dump
+      # Skipping the following tests because postgres 16.10 introduced changes to pg_dump
+      # which prevents us to have consistent dumps.
+      # - run:
+      #     name: Validate schema is in sync with migrations
+      #     command: |
+      #       cd services/database
+      #       # Initialize git submodules
+      #       git submodule update --init
+      #       # Apply migrations using npm script
+      #       npm run migrate:up
+      #       # Force dump in case problems were ignored
+      #       npx dbmate dump
 
-            # Check if the schema file has changed
-            if git diff --exit-code sourcify-database.sql; then
-              echo "✅ Schema validation passed - sourcify-database.sql is in sync with migrations"
-            else
-              echo "❌ Schema file is out of sync with migrations!"
-              echo ""
-              echo "The sourcify-database.sql file does not match what the migrations produce."
-              echo ""
-              echo "To fix this, run a postgres instance locally."
-              echo "Then apply the migrations to a clean database:"
-              echo "  cd services/database && npm run migrate:up"
-              echo ""
-              echo "Then include the updated schema in your commit:"
-              echo "  git add sourcify-database.sql && git commit -m 'Update schema'"
-              exit 1
-            fi
+      #       # Check if the schema file has changed
+      #       if git diff --exit-code sourcify-database.sql; then
+      #         echo "✅ Schema validation passed - sourcify-database.sql is in sync with migrations"
+      #       else
+      #         echo "❌ Schema file is out of sync with migrations!"
+      #         echo ""
+      #         echo "The sourcify-database.sql file does not match what the migrations produce."
+      #         echo ""
+      #         echo "To fix this, run a postgres instance locally."
+      #         echo "Then apply the migrations to a clean database:"
+      #         echo "  cd services/database && npm run migrate:up"
+      #         echo ""
+      #         echo "Then include the updated schema in your commit:"
+      #         echo "  git add sourcify-database.sql && git commit -m 'Update schema'"
+      #         exit 1
+      #       fi
       - run:
           name: Test that down migrations work
           command: |


### PR DESCRIPTION
pg_dump had some changes in the recent postgres release and doesn't produce a consistent result anymore. For that reason we get a failing CI here: https://app.circleci.com/pipelines/github/ethereum/sourcify/9290/workflows/f03100ba-b7d8-4894-a2b6-b77021fd89b7/jobs/54501

This skips the CI schema validation:

For  reference, pg_dump adds these lines since 16.10:

```
\restrict wzpNUSKP7T1c6qgyqXCflEagKcM9dkwutqIx5cIHPVh7KHWPDu4pd6WdTgxRfqu

-- Dumped from database version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
-- Dumped by pg_dump version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
```

for the restrict command there is actually an option to use a specific key (a new security feature), but dbmate would need to add support, or we could work around it by running the dump ourselves.
But we would still have the issue of the version comments which don't have an option to opt out.