### PR TITLE
Update namespace and artifact registry URL to use argotorg for Docker images

### DIFF
--- a/.circleci/scripts/build_and_publish_docker_images.sh
+++ b/.circleci/scripts/build_and_publish_docker_images.sh
@@ -15,7 +15,7 @@ else
     exit 1 # Exit with a non-zero status to indicate an error.
 fi
 
-NAMESPACE="ghcr.io/ethereum/sourcify"
+NAMESPACE="ghcr.io/argotorg/sourcify"
 IMAGE_NAME="$NAMESPACE/$SERVICE"
 # Login to Github Container Registry
 echo $GITHUB_CR_PAT | docker login ghcr.io --username kuzdogan --password-stdin

--- a/.circleci/scripts/deploy_to_gcp.sh
+++ b/.circleci/scripts/deploy_to_gcp.sh
@@ -10,7 +10,7 @@ set -e
 # Define the list of services
 services=("server" "monitor")
 
-ARTIFACT_REGISTRY_URL="europe-west1-docker.pkg.dev/sourcify-project/ghcr-proxy/ethereum/sourcify/"
+ARTIFACT_REGISTRY_URL="europe-west1-docker.pkg.dev/sourcify-project/ghcr-proxy/argotorg/sourcify/"
 
 if [ "$CIRCLE_BRANCH" == "staging" ]; then
     ENVIRONMENT='staging'

--- a/.circleci/scripts/publish_multiarch_images.sh
+++ b/.circleci/scripts/publish_multiarch_images.sh
@@ -2,10 +2,10 @@
 set -e
 
 # Based on: https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
-# Images are built for each architecture (amd64, arm64) and pushed to Github Container Registry under their arch e.g. ghcr.io/ethereum/sourcify/server:staging-amd64
-# Here we pull and retag the images with the arch suffix removed e.g. ghcr.io/ethereum/sourcify/server:staging
+# Images are built for each architecture (amd64, arm64) and pushed to Github Container Registry under their arch e.g. ghcr.io/argotorg/sourcify/server:staging-amd64
+# Here we pull and retag the images with the arch suffix removed e.g. ghcr.io/argotorg/sourcify/server:staging
 
-NAMESPACE="ghcr.io/ethereum/sourcify"
+NAMESPACE="ghcr.io/argotorg/sourcify"
 # Define the list of services
 services=("server" "monitor")
 


### PR DESCRIPTION
We are moving from `ethereum/sourcify` to `argotorg/sourcify`, we need to update the Docker images accordingly.