### PR TITLE
Initialize git submodules before running down migration test in CI

### DIFF
--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -162,6 +162,8 @@ jobs:
           name: Test that down migrations work
           command: |
             cd services/database
+            # Initialize git submodules
+            git submodule update --init
             # Drop db from previous test
             npm run migrate:drop-db
             # Apply migrations


### PR DESCRIPTION
Missed that when I commented out the schema validation test (#2313)