### PR TITLE
Move `signature_type` to `compiled_contracts_signatures` table in signature table migration

### DIFF
--- a/services/database/migrations/20250828092603_add_signature_tables.sql
+++ b/services/database/migrations/20250828092603_add_signature_tables.sql
@@ -16,17 +16,12 @@ CREATE TABLE signatures (
   /* the signature text, e.g. 'transfer(address,uint256)' */
   signature VARCHAR NOT NULL,
 
-  /* type of signature: function, event, error, constructor */
-  signature_type signature_type_enum NOT NULL,
-
   /* timestamps */
   created_at timestamptz NOT NULL DEFAULT NOW(),
-  updated_at timestamptz NOT NULL DEFAULT NOW(),
-
-  CONSTRAINT signatures_pseudo_pkey UNIQUE (signature, signature_type)
+  updated_at timestamptz NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX signatures_hash_4_type_idx ON signatures (signature_hash_4, signature_type);
+CREATE INDEX signatures_hash_4_idx ON signatures (signature_hash_4);
 
 CREATE TRIGGER update_set_updated_at
   BEFORE UPDATE ON signatures
@@ -44,14 +39,16 @@ CREATE TABLE compiled_contracts_signatures (
   compilation_id UUID NOT NULL REFERENCES compiled_contracts(id),
   signature_hash_32 BYTEA NOT NULL REFERENCES signatures(signature_hash_32),
 
+  /* type of signature: function, event, error, constructor */
+  signature_type signature_type_enum NOT NULL,
+
   /* timestamp */
   created_at timestamptz NOT NULL DEFAULT NOW(),
 
-  CONSTRAINT compiled_contracts_signatures_pseudo_pkey UNIQUE (compilation_id, signature_hash_32)
+  CONSTRAINT compiled_contracts_signatures_pseudo_pkey UNIQUE (compilation_id, signature_hash_32, signature_type)
 );
 
 CREATE INDEX compiled_contracts_signatures_signature_idx ON compiled_contracts_signatures (signature_hash_32);
-CREATE INDEX compiled_contracts_signatures_compilation_idx ON compiled_contracts_signatures (compilation_id);
 
 -- migrate:down
 

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,4 +1,4 @@
-\restrict kgmY5Es1RqaV2ek1n2W1DYtdjrChsTn3Lku4HCOmWiEIMmK4Y1uY24lNTQUygKe
+\restrict PYokmnZc6G4LjXZxF2X72J3sNWn7BfoXus3Yobm230bWdZXyNBTS6tQMOt6LEn2
 
 -- Dumped from database version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
 -- Dumped by pg_dump version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
@@ -924,6 +924,7 @@ CREATE TABLE public.compiled_contracts_signatures (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     compilation_id uuid NOT NULL,
     signature_hash_32 bytea NOT NULL,
+    signature_type public.signature_type_enum NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
@@ -1003,7 +1004,6 @@ CREATE TABLE public.signatures (
     signature_hash_32 bytea NOT NULL,
     signature_hash_4 bytea GENERATED ALWAYS AS (SUBSTRING(signature_hash_32 FROM 1 FOR 4)) STORED,
     signature character varying NOT NULL,
-    signature_type public.signature_type_enum NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -1259,7 +1259,7 @@ ALTER TABLE ONLY public.compiled_contracts_signatures
 --
 
 ALTER TABLE ONLY public.compiled_contracts_signatures
-    ADD CONSTRAINT compiled_contracts_signatures_pseudo_pkey UNIQUE (compilation_id, signature_hash_32);
+    ADD CONSTRAINT compiled_contracts_signatures_pseudo_pkey UNIQUE (compilation_id, signature_hash_32, signature_type);
 
 
 --
@@ -1332,14 +1332,6 @@ ALTER TABLE ONLY public.session
 
 ALTER TABLE ONLY public.signatures
     ADD CONSTRAINT signatures_pkey PRIMARY KEY (signature_hash_32);
-
-
---
--- Name: signatures signatures_pseudo_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.signatures
-    ADD CONSTRAINT signatures_pseudo_pkey UNIQUE (signature, signature_type);
 
 
 --
@@ -1443,13 +1435,6 @@ CREATE INDEX compiled_contracts_runtime_code_hash ON public.compiled_contracts U
 
 
 --
--- Name: compiled_contracts_signatures_compilation_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX compiled_contracts_signatures_compilation_idx ON public.compiled_contracts_signatures USING btree (compilation_id);
-
-
---
 -- Name: compiled_contracts_signatures_signature_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1506,10 +1491,10 @@ CREATE INDEX contracts_runtime_code_hash ON public.contracts USING btree (runtim
 
 
 --
--- Name: signatures_hash_4_type_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: signatures_hash_4_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX signatures_hash_4_type_idx ON public.signatures USING btree (signature_hash_4, signature_type);
+CREATE INDEX signatures_hash_4_idx ON public.signatures USING btree (signature_hash_4);
 
 
 --
@@ -2006,7 +1991,7 @@ ALTER TABLE ONLY public.verified_contracts
 -- PostgreSQL database dump complete
 --
 
-\unrestrict kgmY5Es1RqaV2ek1n2W1DYtdjrChsTn3Lku4HCOmWiEIMmK4Y1uY24lNTQUygKe
+\unrestrict PYokmnZc6G4LjXZxF2X72J3sNWn7BfoXus3Yobm230bWdZXyNBTS6tQMOt6LEn2
 
 
 --


### PR DESCRIPTION
Related to #2316 

We decided to move `signature_type` to the `compiled_contracts_signatures` table, because it is a compilation attribute and it would otherwise not be possible to add the same signature for different types to the database.

I removed `compiled_contracts_signatures_compilation_idx` because the pseudo pkey constraint already creates an index with it as the leftmost column.
