### PR TITLE
Remove constructor type from signature tables migration

### DIFF
--- a/services/database/migrations/20250828092603_add_signature_tables.sql
+++ b/services/database/migrations/20250828092603_add_signature_tables.sql
@@ -1,6 +1,6 @@
 -- migrate:up
 
-CREATE TYPE signature_type_enum AS ENUM ('function','event','error','constructor');
+CREATE TYPE signature_type_enum AS ENUM ('function','event','error');
 
 /*
     The `signatures` table stores signature information for compiled_contracts.
@@ -39,7 +39,7 @@ CREATE TABLE compiled_contracts_signatures (
   compilation_id UUID NOT NULL REFERENCES compiled_contracts(id),
   signature_hash_32 BYTEA NOT NULL REFERENCES signatures(signature_hash_32),
 
-  /* type of signature: function, event, error, constructor */
+  /* type of signature: function, event, error */
   signature_type signature_type_enum NOT NULL,
 
   /* timestamp */

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,4 +1,4 @@
-\restrict PYokmnZc6G4LjXZxF2X72J3sNWn7BfoXus3Yobm230bWdZXyNBTS6tQMOt6LEn2
+\restrict sBpQGzZuR3NWFLlVRerofedBhegIanLiA6lNiSNHlANaPWU1wyJoqn0vf2dj7j8
 
 -- Dumped from database version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
 -- Dumped by pg_dump version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
@@ -35,8 +35,7 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 CREATE TYPE public.signature_type_enum AS ENUM (
     'function',
     'event',
-    'error',
-    'constructor'
+    'error'
 );
 
 
@@ -1991,7 +1990,7 @@ ALTER TABLE ONLY public.verified_contracts
 -- PostgreSQL database dump complete
 --
 
-\unrestrict PYokmnZc6G4LjXZxF2X72J3sNWn7BfoXus3Yobm230bWdZXyNBTS6tQMOt6LEn2
+\unrestrict sBpQGzZuR3NWFLlVRerofedBhegIanLiA6lNiSNHlANaPWU1wyJoqn0vf2dj7j8
 
 
 --


### PR DESCRIPTION
Related to #2316 
We decided to remove the constructor type again because it's not a callable signature