### PR TITLE
Remove `update_at` column from signature table migration

### DIFF
--- a/services/database/migrations/20250828092603_add_signature_tables.sql
+++ b/services/database/migrations/20250828092603_add_signature_tables.sql
@@ -16,17 +16,11 @@ CREATE TABLE signatures (
   /* the signature text, e.g. 'transfer(address,uint256)' */
   signature VARCHAR NOT NULL,
 
-  /* timestamps */
-  created_at timestamptz NOT NULL DEFAULT NOW(),
-  updated_at timestamptz NOT NULL DEFAULT NOW()
+  /* timestamp */
+  created_at timestamptz NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX signatures_hash_4_idx ON signatures (signature_hash_4);
-
-CREATE TRIGGER update_set_updated_at
-  BEFORE UPDATE ON signatures
-  FOR EACH ROW
-  EXECUTE FUNCTION trigger_set_updated_at();
 
 /*
     The `compiled_contracts_signatures` table links a compiled_contract to its associated signatures.

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,4 +1,4 @@
-\restrict sBpQGzZuR3NWFLlVRerofedBhegIanLiA6lNiSNHlANaPWU1wyJoqn0vf2dj7j8
+\restrict TnBpHlrqaAKIKzkVi8UXta6dKKilKvtqbOUl1OV1fco96HyAydsxcgxnhLcaLzA
 
 -- Dumped from database version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
 -- Dumped by pg_dump version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
@@ -1003,8 +1003,7 @@ CREATE TABLE public.signatures (
     signature_hash_32 bytea NOT NULL,
     signature_hash_4 bytea GENERATED ALWAYS AS (SUBSTRING(signature_hash_32 FROM 1 FOR 4)) STORED,
     signature character varying NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -1805,13 +1804,6 @@ CREATE TRIGGER update_set_updated_at BEFORE UPDATE ON public.contracts FOR EACH 
 
 
 --
--- Name: signatures update_set_updated_at; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER update_set_updated_at BEFORE UPDATE ON public.signatures FOR EACH ROW EXECUTE FUNCTION public.trigger_set_updated_at();
-
-
---
 -- Name: sources update_set_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -1990,7 +1982,7 @@ ALTER TABLE ONLY public.verified_contracts
 -- PostgreSQL database dump complete
 --
 
-\unrestrict sBpQGzZuR3NWFLlVRerofedBhegIanLiA6lNiSNHlANaPWU1wyJoqn0vf2dj7j8
+\unrestrict TnBpHlrqaAKIKzkVi8UXta6dKKilKvtqbOUl1OV1fco96HyAydsxcgxnhLcaLzA
 
 
 --


### PR DESCRIPTION
We decided that it's not necessary to have it on the signature table as a signature should never be updated.