### PR TITLE
Make pg max connections configurable and set to 15 default

### DIFF
--- a/services/server/.env.dev
+++ b/services/server/.env.dev
@@ -11,6 +11,7 @@ SOURCIFY_POSTGRES_USER="sourcify"
 SOURCIFY_POSTGRES_PASSWORD="sourcify"
 SOURCIFY_POSTGRES_PORT=5432
 # SOURCIFY_POSTGRES_SCHEMA=custom-schema # by default "public" is used
+# SOURCIFY_POSTGRES_MAX_CONNECTIONS=5 # Default set to 15
 
 ###############################
 ### Required variables end ####
@@ -56,6 +57,7 @@ CONCURRENT_VERIFICATIONS_PER_WORKER=
 # ALLIANCE_GOOGLE_CLOUD_SQL_DATABASE=
 # ALLIANCE_GOOGLE_CLOUD_SQL_USER=
 # ALLIANCE_GOOGLE_CLOUD_SQL_PASSWORD=
+# ALLIANCE_DB_MAX_CONNECTIONS=5 # Default set to 15
 
 # Simple authentication token for the /private/** endpoints
 SOURCIFY_PRIVATE_TOKEN=

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -136,6 +136,9 @@ const server = new Server(
         port: parseInt(process.env.SOURCIFY_POSTGRES_PORT || "5432"),
       },
       schema: process.env.SOURCIFY_POSTGRES_SCHEMA as string,
+      maxConnections: process.env.SOURCIFY_POSTGRES_MAX_CONNECTIONS
+        ? parseInt(process.env.SOURCIFY_POSTGRES_MAX_CONNECTIONS)
+        : undefined,
     },
     allianceDatabaseServiceOptions: {
       googleCloudSql: {
@@ -153,6 +156,9 @@ const server = new Server(
         port: parseInt(process.env.ALLIANCE_POSTGRES_PORT || "5432"),
       },
       schema: process.env.ALLIANCE_POSTGRES_SCHEMA as string,
+      maxConnections: process.env.ALLIANCE_DB_MAX_CONNECTIONS
+        ? parseInt(process.env.ALLIANCE_DB_MAX_CONNECTIONS)
+        : undefined,
     },
   },
 );

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -33,6 +33,7 @@ export interface DatabaseOptions {
     password: string;
   };
   schema?: string;
+  maxConnections?: number;
 }
 
 export class Database {
@@ -47,7 +48,7 @@ export class Database {
   private postgresDatabase?: string;
   private postgresUser?: string;
   private postgresPassword?: string;
-
+  private maxConnections?: number;
   constructor(options: DatabaseOptions) {
     this.googleCloudSqlInstanceName = options.googleCloudSql?.instanceName;
     this.googleCloudSqlUser = options.googleCloudSql?.user;
@@ -61,6 +62,7 @@ export class Database {
     if (options.schema) {
       this.schema = options.schema;
     }
+    this.maxConnections = options.maxConnections;
   }
 
   get pool(): Pool {
@@ -90,8 +92,8 @@ export class Database {
         ...clientOpts,
         user: this.googleCloudSqlUser,
         database: this.googleCloudSqlDatabase,
-        max: 5,
         password: this.googleCloudSqlPassword,
+        max: this.maxConnections || 15,
       });
     } else if (this.postgresHost) {
       this._pool = new Pool({
@@ -100,7 +102,7 @@ export class Database {
         database: this.postgresDatabase,
         user: this.postgresUser,
         password: this.postgresPassword,
-        max: 5,
+        max: this.maxConnections || 15,
       });
     } else {
       throw new Error("Alliance Database is disabled");


### PR DESCRIPTION
While working on the separate 4bytes DB I came across the code where we create the DB pool with a max connection `max: 5`. 

I tried tracking down why this was set to 5 (default is 10). I found it was set 2 years ago here and kept the same but couldn't see why this was set to a lesser value https://github.com/argotorg/sourcify/blob/9e96c8e6412f7ab1b1aedd74cb1ed9432e67aa8d/src/server/services/alliance-database-util.ts

I believe this was a reason why the responses to the signature queries started getting longer when we had the surge. Our prod. db has a lot more max connections available and if needed this should have been utilized.

<img width="371" height="242" alt="image" src="https://github.com/user-attachments/assets/d628af70-cc4e-4136-b078-2984416ae2b7" />

Therefore I'm setting this to a higher value, and making it configurable.
