### PR TITLE
Turn off writing to repositoryV1 and V2

### DIFF
--- a/services/server/src/config/master.js
+++ b/services/server/src/config/master.js
@@ -12,20 +12,20 @@ module.exports = {
     read: RWStorageIdentifiers.SourcifyDatabase,
     writeOrWarn: [
       WStorageIdentifiers.AllianceDatabase,
-      RWStorageIdentifiers.RepositoryV1,
+      // RWStorageIdentifiers.RepositoryV1, // We no longer write to the repositoryV1
       WStorageIdentifiers.S3Repository,
     ],
     writeOrErr: [
-      WStorageIdentifiers.RepositoryV2,
+      // WStorageIdentifiers.RepositoryV2, // We no longer write to the repositoryV2
       RWStorageIdentifiers.SourcifyDatabase,
     ],
   },
-  repositoryV1: {
-    path: "/home/app/data/repository",
-  },
-  repositoryV2: {
-    path: "/home/app/data/repositoryV2",
-  },
+  // repositoryV1: {
+  //   path: "/home/app/data/repository",
+  // },
+  // repositoryV2: {
+  //   path: "/home/app/data/repositoryV2",
+  // },
   solcRepo: "/home/app/data/compilers/solc",
   solJsonRepo: "/home/app/data/compilers/soljson",
   vyperRepo: "/home/app/data/compilers/vyper",

--- a/services/server/src/config/staging.js
+++ b/services/server/src/config/staging.js
@@ -13,19 +13,19 @@ module.exports = {
     writeOrWarn: [
       WStorageIdentifiers.AllianceDatabase,
       WStorageIdentifiers.S3Repository,
-      RWStorageIdentifiers.RepositoryV1,
+      // RWStorageIdentifiers.RepositoryV1, // We no longer write to the repositoryV1
     ],
     writeOrErr: [
-      WStorageIdentifiers.RepositoryV2,
+      // WStorageIdentifiers.RepositoryV2, // We no longer write to the repositoryV2
       RWStorageIdentifiers.SourcifyDatabase,
     ],
   },
-  repositoryV1: {
-    path: "/home/app/data/repository",
-  },
-  repositoryV2: {
-    path: "/home/app/data/repositoryV2",
-  },
+  // repositoryV1: {
+  //   path: "/home/app/data/repository",
+  // },
+  // repositoryV2: {
+  //   path: "/home/app/data/repositoryV2",
+  // },
   solcRepo: "/home/app/data/compilers/solc",
   solJsonRepo: "/home/app/data/compilers/soljson",
   vyperRepo: "/home/app/data/compilers/vyper",


### PR DESCRIPTION
Following #2422 we are turning off the NAS and the filesystem, as they are not required. We will continue writing files to IPFS via the S3StorageService.
