### PR TITLE
Add notices on release to not squash merge

### DIFF
--- a/scripts/release/git_utils.sh
+++ b/scripts/release/git_utils.sh
@@ -152,6 +152,19 @@ open_pr_to_staging() {
   local branch_name=$1
   local title=$2
   echo "Opening PR to staging..."
-  gh pr create --title "$title" --body "" --head "$branch_name" --base staging
+  
+  # Create PR body with clear instructions about merge strategy
+  local pr_body="🚨 **CRITICAL: USE MERGE COMMIT, NOT SQUASH** 🚨
+
+**IMPORTANT:** This PR contains release commits with git tags that point to specific commit hashes in this branch. 
+
+**YOU MUST USE \"CREATE A MERGE COMMIT\" WHEN MERGING THIS PR.**
+
+❌ **DO NOT** use \"Squash and merge\" - this will break the git tags and release history.
+✅ **DO** use \"Create a merge commit\" to preserve the commit history and tag references.
+
+The tags in this branch point to specific commits, and squashing would invalidate these references."
+
+  gh pr create --title "$title" --body "$pr_body" --head "$branch_name" --base staging
   echo "Opened PR to staging"
 }

--- a/scripts/release/main.sh
+++ b/scripts/release/main.sh
@@ -34,7 +34,7 @@ prompt_execute_or_skip "commiting the changelogs" commit_changelogs
 prompt_execute_or_skip "choosing same versions in lerna to create git tags and updating dependencies" run_lerna_version
 prompt_execute_or_skip "publishing the branch" publish_branch_and_open_pr_to_staging
 
-prompt_execute_or_skip "asking if release PR is merged" ask_if_release_pr_merged
+prompt_execute_or_skip "asking if release PR is merged (Do a MERGE COMMIT not SQUASH)" ask_if_release_pr_merged
 prompt_execute_or_skip "pushing the tags to GitHub" push_tags_in_order
 prompt_execute_or_skip "creating GitHub releases" create_github_releases
 


### PR DESCRIPTION
I just squashed the release PR when merging commitlogs etc. to staging. We must not squash to keep the commit hashes on staging, otherwise the tag's commit hashes won't be on any branch. 

Adding clear notices to avoid this in to future. It's not possible to create a branch rule etc.

Tagging @marcocastignoli since we discussed this in person with Manuel.