### PR TITLE
Document creation tx hash in API v2 spec

### DIFF
--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -9,6 +9,8 @@ paths:
         Submit a contract for verification via the [Solidity standard JSON input](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description) or [Vyper JSON input](https://docs.vyperlang.org/en/stable/compiling-a-contract.html#input-json-description).
 
         There are no "single file" or "multi-part" verification endpoints because those are essentially wrappers around the Solidity compiler's JSON interface. The verification frontend can provide files and settings options to resemble these.
+      
+        You can optionally pass the `creationTransactionHash` to make Sourcify reliably fetching the creation bytecode. Otherwise, it will try to fetch it itself which is dependent on external services.
         
         **Note**: The `outputSelection` field in the `stdJsonInput.settings` will be overridden during verification to ensure all necessary artifacts are generated. 
       operationId: verify
@@ -318,8 +320,9 @@ components:
                 description: The fully qualified file path and contract name to indicate which contract to verify.
                 example: 'contracts/Storage.sol:Storage'
               creationTransactionHash:
-                $ref: '#/components/schemas/Keccak256'
-                description: The hash of the transaction that created this contract. Optional.
+                allOf:
+                  - $ref: '#/components/schemas/Keccak256'
+                  - description: The hash of the transaction that created this contract. Optional.
             required:
               - stdJsonInput
               - compilerVersion
@@ -398,8 +401,9 @@ components:
                 type: object
                 description: 'The [metadata](https://docs.soliditylang.org/en/latest/metadata.html) as an object.'
               creationTransactionHash:
-                $ref: '#/components/schemas/Keccak256'
-                description: The hash of the transaction that created this contract. Optional.
+                allOf:
+                  - $ref: '#/components/schemas/Keccak256'
+                  - description: The hash of the transaction that created this contract. Optional.
             required:
               - sources
               - metadata
@@ -463,8 +467,9 @@ components:
                     type: string
                     format: uuid
                   error:
-                    $ref: '#/components/schemas/MatchingErrorResponse'
-                    description: 'Optional, when the verification fails for some reason.'
+                    allOf:
+                      - $ref: '#/components/schemas/MatchingErrorResponse'
+                      - description: 'Optional, when the verification fails for some reason.'
                   jobStartTime:
                     type: string
                     format: date-time
@@ -581,8 +586,9 @@ components:
                         type: string
                         example: 'solc'
                       compilerVersion:
-                        $ref: '#/components/schemas/CompilerVersion'
-                        description: 'The server accepts v prefixed but should only respond without the v prefix'
+                        allOf:
+                          - $ref: '#/components/schemas/CompilerVersion'
+                          - description: 'The server accepts v prefixed but should only respond without the v prefix'
                       compilerSettings:
                         type: object
                       name:
@@ -677,8 +683,9 @@ components:
                                       linkReferences:
                                         $ref: '#/components/schemas/LinkReferences'
                                       object:
-                                        $ref: '#/components/schemas/HexStringWithout0x'
-                                        description: 'Without the 0x prefix, as in the compiler output format'
+                                        allOf:
+                                          - $ref: '#/components/schemas/HexStringWithout0x'
+                                          - description: 'Without the 0x prefix, as in the compiler output format'
                                   deployedBytecode:
                                     type: object
                                     description: In Sourcify we refer to this field more explicitly as "runtime bytecode"
@@ -688,8 +695,9 @@ components:
                                       linkReferences:
                                         $ref: '#/components/schemas/LinkReferences'
                                       object:
-                                        $ref: '#/components/schemas/HexStringWithout0x'
-                                        description: 'Without the 0x prefix, as in the compiler output format'
+                                        allOf:
+                                          - $ref: '#/components/schemas/HexStringWithout0x'
+                                          - description: 'Without the 0x prefix, as in the compiler output format'
                                       immutableReferences:
                                         type: object
                                         additionalProperties:
@@ -1255,8 +1263,9 @@ components:
         linkReferences:
           $ref: '#/components/schemas/LinkReferences'
         cborAuxdata:
-          $ref: '#/components/schemas/CborAuxdataObject'
-          description: CborAuxdata that is found on the recompiled bytecode.
+          allOf:
+            - $ref: '#/components/schemas/CborAuxdataObject'
+            - description: CborAuxdata that is found on the recompiled bytecode.
         transformations:
           $ref: '#/components/schemas/CreationTransformations'
         transformationValues:
@@ -1401,8 +1410,9 @@ components:
         linkReferences:
           $ref: '#/components/schemas/LinkReferences'
         cborAuxdata:
-          $ref: '#/components/schemas/CborAuxdataObject'
-          description: CborAuxdata that is found on the recompiled bytecode.
+          allOf:
+            - $ref: '#/components/schemas/CborAuxdataObject'
+            - description: CborAuxdata that is found on the recompiled bytecode.
         immutableReferences:
           type: object
           additionalProperties:


### PR DESCRIPTION
This came up during the Hardhat v3 integration review.

Also adds an `allOf` property to all fields that use a property besides a ref because they are pruned otherwise. Noticed this because there was no description about the creationtxHash parameter on the API docs.