### PR TITLE
Turn `@typescript-eslint/consistent-type-imports` rule on

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": ["warn"],
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/consistent-type-imports": "error",
   },
   env: {
     node: true,

--- a/packages/compilers/src/index.ts
+++ b/packages/compilers/src/index.ts
@@ -1,4 +1,5 @@
-import { setLogger, setLevel, ILogger } from './logger';
+import type { ILogger } from './logger';
+import { setLogger, setLevel } from './logger';
 export const setCompilersLogger = setLogger;
 export const setCompilersLoggerLevel = setLevel;
 export type ICompilersLogger = ILogger;

--- a/packages/compilers/src/lib/common.ts
+++ b/packages/compilers/src/lib/common.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import { logDebug, logError, logSilly } from '../logger';
-import { OutputError } from '@ethereum-sourcify/compilers-types';
+import type { OutputError } from '@ethereum-sourcify/compilers-types';
 
 /**
  * Fetches a resource with an exponential timeout.

--- a/packages/compilers/src/lib/solidityCompiler.ts
+++ b/packages/compilers/src/lib/solidityCompiler.ts
@@ -3,10 +3,11 @@ import path from 'path';
 import fs from 'fs';
 import { spawnSync } from 'child_process';
 import semver from 'semver';
-import { Worker, WorkerOptions } from 'worker_threads';
+import type { WorkerOptions } from 'worker_threads';
+import { Worker } from 'worker_threads';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
 import { asyncExec, CompilerError, fetchWithBackoff } from './common';
-import {
+import type {
   SolidityJsonInput,
   SolidityOutput,
 } from '@ethereum-sourcify/compilers-types';

--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { spawnSync } from 'child_process';
 import { asyncExec, CompilerError, fetchWithBackoff } from './common';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
-import {
+import type {
   VyperJsonInput,
   VyperOutput,
 } from '@ethereum-sourcify/compilers-types';

--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -1,14 +1,14 @@
-import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
-import {
+import type { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
+import type {
   CompilationTarget,
   CompiledContractCborAuxdata,
   CompilationLanguage,
   StringMap,
-  CompilationError,
   ISolidityCompiler,
   IVyperCompiler,
 } from './CompilationTypes';
-import {
+import { CompilationError } from './CompilationTypes';
+import type {
   ImmutableReferences,
   SolidityJsonInput,
   SolidityOutput,

--- a/packages/lib-sourcify/src/Compilation/CompilationTypes.ts
+++ b/packages/lib-sourcify/src/Compilation/CompilationTypes.ts
@@ -1,13 +1,11 @@
-import {
+import type {
   SolidityJsonInput,
   SolidityOutput,
   VyperJsonInput,
   VyperOutput,
 } from '@ethereum-sourcify/compilers-types';
-import {
-  SourcifyLibError,
-  SourcifyLibErrorParameters,
-} from '../SourcifyLibError';
+import type { SourcifyLibErrorParameters } from '../SourcifyLibError';
+import { SourcifyLibError } from '../SourcifyLibError';
 
 export interface CompiledContractCborAuxdata {
   [key: string]: {

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -1,6 +1,6 @@
 import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 import { AbstractCompilation } from './AbstractCompilation';
-import {
+import type {
   ImmutableReferences,
   LinkReferences,
   Metadata,
@@ -10,7 +10,7 @@ import {
   VyperJsonInput,
   VyperOutput,
 } from '@ethereum-sourcify/compilers-types';
-import {
+import type {
   CompilationLanguage,
   CompilationTarget,
   CompiledContractCborAuxdata,

--- a/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
@@ -1,19 +1,19 @@
 import { AuxdataStyle, splitAuxdata } from '@ethereum-sourcify/bytecode-utils';
 import semver from 'semver';
 import { AbstractCompilation } from './AbstractCompilation';
-import {
+import type {
   ImmutableReferences,
   SolidityJsonInput,
   SolidityOutput,
   SolidityOutputContract,
   LinkReferences,
 } from '@ethereum-sourcify/compilers-types';
-import {
-  CompilationError,
+import type {
   CompilationLanguage,
   CompilationTarget,
   ISolidityCompiler,
 } from './CompilationTypes';
+import { CompilationError } from './CompilationTypes';
 import {
   findAuxdataPositions,
   findAuxdatasInLegacyAssembly,

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -7,20 +7,20 @@ import {
   splitAuxdata,
 } from '@ethereum-sourcify/bytecode-utils';
 import semver, { gte } from 'semver';
-import {
+import type {
   VyperJsonInput,
   VyperOutput,
   VyperOutputContract,
   ImmutableReferences,
   LinkReferences,
 } from '@ethereum-sourcify/compilers-types';
-import {
-  CompilationError,
+import type {
   CompilationLanguage,
   CompilationTarget,
   CompiledContractCborAuxdata,
   IVyperCompiler,
 } from './CompilationTypes';
+import { CompilationError } from './CompilationTypes';
 
 export function returnFixedVyperVersion(compilerVersion: string): string {
   if (semver.valid(compilerVersion)) {

--- a/packages/lib-sourcify/src/Compilation/auxdataUtils.ts
+++ b/packages/lib-sourcify/src/Compilation/auxdataUtils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CompilerAuxdataDiff,
   CompiledContractCborAuxdata,
 } from './CompilationTypes';

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -1,3 +1,4 @@
+import type { EthersError } from 'ethers';
 import {
   FetchRequest,
   JsonRpcProvider,
@@ -5,10 +6,9 @@ import {
   TransactionReceipt,
   TransactionResponse,
   getAddress,
-  EthersError,
 } from 'ethers';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
-import {
+import type {
   CallFrame,
   FetchContractCreationTxMethods,
   FetchRequestRPC,

--- a/packages/lib-sourcify/src/SourcifyLibError.ts
+++ b/packages/lib-sourcify/src/SourcifyLibError.ts
@@ -1,7 +1,7 @@
-import { OutputError } from '@ethereum-sourcify/compilers-types';
-import { CompilationErrorCode } from './Compilation/CompilationTypes';
-import { ValidationErrorCode } from './Validation/ValidationTypes';
-import { VerificationErrorCode } from './Verification/VerificationTypes';
+import type { OutputError } from '@ethereum-sourcify/compilers-types';
+import type { CompilationErrorCode } from './Compilation/CompilationTypes';
+import type { ValidationErrorCode } from './Validation/ValidationTypes';
+import type { VerificationErrorCode } from './Verification/VerificationTypes';
 
 export type SourcifyLibErrorCode =
   | ValidationErrorCode

--- a/packages/lib-sourcify/src/Validation/SolidityMetadataContract.ts
+++ b/packages/lib-sourcify/src/Validation/SolidityMetadataContract.ts
@@ -2,21 +2,24 @@ import { id as keccak256str } from 'ethers';
 import semver from 'semver';
 import { performFetch } from './fetchUtils';
 import { SolidityCompilation } from '../Compilation/SolidityCompilation';
-import {
+import type {
   Libraries,
   SolidityJsonInput,
   Metadata,
   MetadataCompilerSettings,
   MetadataSourceMap,
 } from '@ethereum-sourcify/compilers-types';
-import { ISolidityCompiler, StringMap } from '../Compilation/CompilationTypes';
-import {
+import type {
+  ISolidityCompiler,
+  StringMap,
+} from '../Compilation/CompilationTypes';
+import type {
   InvalidSources,
   IpfsGateway,
   MissingSources,
   PathContent,
-  ValidationError,
 } from './ValidationTypes';
+import { ValidationError } from './ValidationTypes';
 import {
   AuxdataStyle,
   decode as decodeBytecode,

--- a/packages/lib-sourcify/src/Validation/ValidationTypes.ts
+++ b/packages/lib-sourcify/src/Validation/ValidationTypes.ts
@@ -1,7 +1,5 @@
-import {
-  SourcifyLibErrorParameters,
-  SourcifyLibError,
-} from '../SourcifyLibError';
+import type { SourcifyLibErrorParameters } from '../SourcifyLibError';
+import { SourcifyLibError } from '../SourcifyLibError';
 
 export interface PathBuffer {
   path: string;

--- a/packages/lib-sourcify/src/Validation/processFiles.ts
+++ b/packages/lib-sourcify/src/Validation/processFiles.ts
@@ -1,15 +1,15 @@
 // Tools to assemble SolidityMetadataContract(s) from files.
 
-import { StringMap } from '../Compilation/CompilationTypes';
+import type { StringMap } from '../Compilation/CompilationTypes';
 import { SolidityCompilation } from '../Compilation/SolidityCompilation';
-import {
+import type {
   Sources,
   SolidityJsonInput,
   Metadata,
 } from '@ethereum-sourcify/compilers-types';
 import { logDebug, logInfo } from '../logger';
 import { SolidityMetadataContract } from './SolidityMetadataContract';
-import {
+import type {
   InvalidSources,
   MissingSources,
   PathBuffer,

--- a/packages/lib-sourcify/src/Validation/variationsUtils.ts
+++ b/packages/lib-sourcify/src/Validation/variationsUtils.ts
@@ -1,4 +1,4 @@
-import { PathContent, VariedPathContent } from './ValidationTypes';
+import type { PathContent, VariedPathContent } from './ValidationTypes';
 import { id as keccak256str } from 'ethers';
 
 export const CONTENT_VARIATORS = [

--- a/packages/lib-sourcify/src/Validation/zipUtils.ts
+++ b/packages/lib-sourcify/src/Validation/zipUtils.ts
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
 import { logDebug } from '../logger';
-import { PathBuffer } from './ValidationTypes';
+import type { PathBuffer } from './ValidationTypes';
 
 export async function unzipFiles(files: PathBuffer[]) {
   const allUnzipped: PathBuffer[] = [];

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -1,13 +1,14 @@
 import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
-import {
+import type {
   ImmutableReferences,
   LinkReferences,
 } from '@ethereum-sourcify/compilers-types';
-import {
+import type {
   CompiledContractCborAuxdata,
   StringMap,
 } from '../Compilation/CompilationTypes';
-import { AbiCoder, id as keccak256Str, Interface, InterfaceAbi } from 'ethers';
+import type { InterfaceAbi } from 'ethers';
+import { AbiCoder, id as keccak256Str, Interface } from 'ethers';
 import { logError } from '../logger';
 
 const abiCoder = AbiCoder.defaultAbiCoder();

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -1,36 +1,34 @@
-import { AbstractCompilation } from '../Compilation/AbstractCompilation';
+import type { AbstractCompilation } from '../Compilation/AbstractCompilation';
 import { logDebug, logInfo, logWarn } from '../logger';
-import { SourcifyChain } from '../SourcifyChain/SourcifyChain';
+import type { SourcifyChain } from '../SourcifyChain/SourcifyChain';
 import { lt } from 'semver';
+import type { SolidityDecodedObject } from '@ethereum-sourcify/bytecode-utils';
 import {
   splitAuxdata,
   AuxdataStyle,
   decode as decodeBytecode,
-  SolidityDecodedObject,
 } from '@ethereum-sourcify/bytecode-utils';
-import {
+import type {
   CompiledContractCborAuxdata,
   ISolidityCompiler,
   StringMap,
 } from '../Compilation/CompilationTypes';
 
+import type { Transformation, TransformationValues } from './Transformations';
 import {
   extractAuxdataTransformation,
   extractCallProtectionTransformation,
   extractConstructorArgumentsTransformation,
   extractImmutablesTransformation,
   extractLibrariesTransformation,
-  Transformation,
-  TransformationValues,
 } from './Transformations';
-import {
+import type {
   BytecodeMatchingResult,
-  SolidityBugType,
-  VerificationError,
   VerificationExport,
   VerificationStatus,
 } from './VerificationTypes';
-import {
+import { SolidityBugType, VerificationError } from './VerificationTypes';
+import type {
   VyperOutputContract,
   ImmutableReferences,
   SolidityOutputContract,

--- a/packages/lib-sourcify/src/Verification/VerificationTypes.ts
+++ b/packages/lib-sourcify/src/Verification/VerificationTypes.ts
@@ -1,11 +1,11 @@
-import { JsonFragment } from 'ethers';
-import {
+import type { JsonFragment } from 'ethers';
+import type {
   CompilationLanguage,
   CompilationTarget,
   CompiledContractCborAuxdata,
   StringMap,
 } from '../Compilation/CompilationTypes';
-import {
+import type {
   ImmutableReferences,
   SoliditySettings,
   StorageLayout,
@@ -17,11 +17,9 @@ import {
   SolidityOutputSource,
   VyperOutputSource,
 } from '@ethereum-sourcify/compilers-types';
-import {
-  SourcifyLibErrorParameters,
-  SourcifyLibError,
-} from '../SourcifyLibError';
-import { Transformation, TransformationValues } from './Transformations';
+import type { SourcifyLibErrorParameters } from '../SourcifyLibError';
+import { SourcifyLibError } from '../SourcifyLibError';
+import type { Transformation, TransformationValues } from './Transformations';
 
 export interface BytecodeMatchingResult {
   match: 'perfect' | 'partial' | null;

--- a/packages/lib-sourcify/src/index.ts
+++ b/packages/lib-sourcify/src/index.ts
@@ -1,5 +1,6 @@
 // Logger exports
-import { setLogger, setLevel, ILogger, getLevel } from './logger';
+import type { ILogger } from './logger';
+import { setLogger, setLevel, getLevel } from './logger';
 export const setLibSourcifyLogger = setLogger;
 export const setLibSourcifyLoggerLevel = setLevel;
 export const getLibSourcifyLoggerLevel = getLevel;

--- a/packages/lib-sourcify/src/utils/etherscan/EtherscanTypes.ts
+++ b/packages/lib-sourcify/src/utils/etherscan/EtherscanTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SolidityJsonInput,
   VyperJsonInput,
 } from '@ethereum-sourcify/compilers-types';

--- a/packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts
+++ b/packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts
@@ -1,18 +1,17 @@
-import {
+import type {
   ISolidityCompiler,
   IVyperCompiler,
   SolidityJsonInput,
   VyperJsonInput,
-  VyperCompilation,
-  SolidityCompilation,
   Sources,
 } from '../..';
+import { VyperCompilation, SolidityCompilation } from '../..';
 import { logInfo, logDebug, logWarn, logError } from '../../logger';
-import {
-  EtherscanImportError,
+import type {
   EtherscanResult,
   ProcessedEtherscanResult,
 } from './EtherscanTypes';
+import { EtherscanImportError } from './EtherscanTypes';
 
 interface VyperVersion {
   compiler_version: string;

--- a/packages/lib-sourcify/test/Compilation/SolidityCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/SolidityCompilation.spec.ts
@@ -4,11 +4,9 @@ import path from 'path';
 import fs from 'fs';
 import { SolidityCompilation } from '../../src/Compilation/SolidityCompilation';
 import { solc } from '../utils';
-import {
-  CompilationTarget,
-  CompilationError,
-} from '../../src/Compilation/CompilationTypes';
-import {
+import type { CompilationTarget } from '../../src/Compilation/CompilationTypes';
+import { CompilationError } from '../../src/Compilation/CompilationTypes';
+import type {
   SolidityJsonInput,
   Metadata,
 } from '@ethereum-sourcify/compilers-types';

--- a/packages/lib-sourcify/test/SourcifyChain.spec.ts
+++ b/packages/lib-sourcify/test/SourcifyChain.spec.ts
@@ -9,7 +9,7 @@ import {
   startHardhatNetwork,
   stopHardhatNetwork,
 } from './hardhat-network-helper';
-import { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'child_process';
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);

--- a/packages/lib-sourcify/test/Validation/SolidityMetadataContract.spec.ts
+++ b/packages/lib-sourcify/test/Validation/SolidityMetadataContract.spec.ts
@@ -2,9 +2,10 @@ import { expect, use } from 'chai';
 import { SolidityMetadataContract } from '../../src/Validation/SolidityMetadataContract';
 import { id as keccak256str } from 'ethers';
 import nock from 'nock';
-import { ISolidityCompiler } from '../../src/Compilation/CompilationTypes';
-import { Metadata } from '@ethereum-sourcify/compilers-types';
-import { getErrorMessageFromCode, PathContent } from '../../src';
+import type { ISolidityCompiler } from '../../src/Compilation/CompilationTypes';
+import type { Metadata } from '@ethereum-sourcify/compilers-types';
+import type { PathContent } from '../../src';
+import { getErrorMessageFromCode } from '../../src';
 import chaiAsPromised from 'chai-as-promised';
 
 use(chaiAsPromised);

--- a/packages/lib-sourcify/test/Validation/zipUtils.spec.ts
+++ b/packages/lib-sourcify/test/Validation/zipUtils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { unzipFiles } from '../../src/Validation/zipUtils';
 import JSZip from 'jszip';
-import { PathBuffer } from '../../src';
+import type { PathBuffer } from '../../src';
 
 describe('zipUtils', () => {
   describe('isZip', () => {

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, before, after } from 'mocha';
 import { expect, use } from 'chai';
 import { Verification } from '../../src/Verification/Verification';
-import { ChildProcess } from 'child_process';
-import { JsonRpcSigner } from 'ethers';
+import type { ChildProcess } from 'child_process';
+import type { JsonRpcSigner } from 'ethers';
 import path from 'path';
 import {
   deployFromAbiAndBytecode,
@@ -14,16 +14,17 @@ import {
   stopHardhatNetwork,
 } from '../hardhat-network-helper';
 import { SolidityMetadataContract } from '../../src/Validation/SolidityMetadataContract';
-import { SolidityOutput } from '@ethereum-sourcify/compilers-types';
+import type { SolidityOutput } from '@ethereum-sourcify/compilers-types';
 import fs from 'fs';
 import { VyperCompilation } from '../../src/Compilation/VyperCompilation';
-import { PathContent } from '../../src/Validation/ValidationTypes';
+import type { PathContent } from '../../src/Validation/ValidationTypes';
 import chaiAsPromised from 'chai-as-promised';
 import {
   findSolcPlatform,
   useSolidityCompiler,
 } from '@ethereum-sourcify/compilers';
-import { ISolidityCompiler, SourcifyChain } from '../../src';
+import type { ISolidityCompiler } from '../../src';
+import { SourcifyChain } from '../../src';
 import Sinon from 'sinon';
 
 use(chaiAsPromised);

--- a/packages/lib-sourcify/test/hardhat-network-helper.ts
+++ b/packages/lib-sourcify/test/hardhat-network-helper.ts
@@ -1,5 +1,6 @@
 import treeKill from 'tree-kill';
-import { ChildProcess, spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
 
 export function startHardhatNetwork(port: number) {
   return new Promise<ChildProcess>((resolve) => {

--- a/packages/lib-sourcify/test/utils.ts
+++ b/packages/lib-sourcify/test/utils.ts
@@ -1,19 +1,20 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import path from 'path';
 import { expect } from 'chai';
-import { ContractFactory, Signer } from 'ethers';
+import type { Signer } from 'ethers';
+import { ContractFactory } from 'ethers';
 import {
   useSolidityCompiler,
   useVyperCompiler,
 } from '@ethereum-sourcify/compilers';
-import {
+import type {
   SolidityJsonInput,
   SolidityOutput,
   VyperJsonInput,
   VyperOutput,
 } from '@ethereum-sourcify/compilers-types';
-import { Verification } from '../src/Verification/Verification';
-import {
+import type { Verification } from '../src/Verification/Verification';
+import type {
   CompiledContractCborAuxdata,
   ISolidityCompiler,
   IVyperCompiler,

--- a/packages/lib-sourcify/test/utils/etherscan-util.spec.ts
+++ b/packages/lib-sourcify/test/utils/etherscan-util.spec.ts
@@ -2,11 +2,10 @@ import { expect, use } from 'chai';
 import chaiHttp from 'chai-http';
 import nock from 'nock';
 import chaiAsPromised from 'chai-as-promised';
+import type { SolidityJsonInput, VyperJsonInput } from '../../src';
 import {
   SolidityCompilation,
-  SolidityJsonInput,
   VyperCompilation,
-  VyperJsonInput,
   EtherscanUtils,
 } from '../../src';
 // Import SourcifyChain from built package to match the type expected by mockEtherscanApi

--- a/services/4byte/src/FourByteServer.ts
+++ b/services/4byte/src/FourByteServer.ts
@@ -1,4 +1,4 @@
-import http from "http";
+import type http from "http";
 import logger from "./logger";
 import { SignatureDatabase } from "./SignatureDatabase";
 import express from "express";

--- a/services/4byte/src/SignatureDatabase.ts
+++ b/services/4byte/src/SignatureDatabase.ts
@@ -1,7 +1,7 @@
 import { Pool } from "pg";
 import { id as keccak256str } from "ethers";
-import { SignatureType } from "./utils/signature-util";
-import { DatabaseConfig } from "./FourByteServer";
+import type { SignatureType } from "./utils/signature-util";
+import type { DatabaseConfig } from "./FourByteServer";
 import logger from "./logger";
 
 export interface SignatureLookupRow {

--- a/services/4byte/src/api/handlers.ts
+++ b/services/4byte/src/api/handlers.ts
@@ -1,7 +1,7 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
-import { Logger } from "winston";
-import {
+import type { Logger } from "winston";
+import type {
   SignatureLookupRow,
   SignatureStatsRow,
   SignatureInsertResult,
@@ -12,7 +12,7 @@ import {
 } from "../utils/signature-util";
 import { bytesFromString } from "../utils/database-util";
 import { sendSignatureApiFailure } from "./validation";
-import { SignatureDatabase } from "../SignatureDatabase";
+import type { SignatureDatabase } from "../SignatureDatabase";
 
 interface SignatureItem {
   name: string;

--- a/services/4byte/src/api/validation.ts
+++ b/services/4byte/src/api/validation.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { StatusCodes } from "http-status-codes";
 
 export function sendSignatureApiFailure(res: Response, error: string): void {

--- a/services/4byte/src/logger.ts
+++ b/services/4byte/src/logger.ts
@@ -1,4 +1,5 @@
-import { createLogger, transports, format, Logger } from "winston";
+import type { Logger } from "winston";
+import { createLogger, transports, format } from "winston";
 import chalk from "chalk";
 
 export enum LogLevels {

--- a/services/4byte/test/integration/4bytes-api.spec.ts
+++ b/services/4byte/test/integration/4bytes-api.spec.ts
@@ -1,10 +1,8 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
 import { id as keccak256str } from "ethers";
-import {
-  FourByteServerFixture,
-  TestSignature,
-} from "../helpers/FourByteServerFixture";
+import type { TestSignature } from "../helpers/FourByteServerFixture";
+import { FourByteServerFixture } from "../helpers/FourByteServerFixture";
 import { SignatureType } from "../../src/utils/signature-util";
 
 chai.use(chaiHttp);

--- a/services/monitor/src/ChainMonitor.ts
+++ b/services/monitor/src/ChainMonitor.ts
@@ -1,20 +1,21 @@
 import { FileHash } from "./util";
-import { Block, TransactionResponse, getCreateAddress } from "ethers";
+import type { Block, TransactionResponse } from "ethers";
+import { getCreateAddress } from "ethers";
 import assert from "assert";
 import { EventEmitter } from "stream";
 import {
   AuxdataStyle,
   decode as bytecodeDecode,
 } from "@ethereum-sourcify/bytecode-utils";
-import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import logger from "./logger";
-import {
+import type {
   KnownDecentralizedStorageFetchers,
   MonitorConfig,
   SourcifyRequestOptions,
 } from "./types";
 import PendingContract from "./PendingContract";
-import { Logger } from "winston";
+import type { Logger } from "winston";
 
 function createsContract(tx: TransactionResponse): boolean {
   return !tx.to;

--- a/services/monitor/src/DecentralizedStorageFetcher.ts
+++ b/services/monitor/src/DecentralizedStorageFetcher.ts
@@ -1,6 +1,6 @@
-import { FileHash } from "./util";
+import type { FileHash } from "./util";
 import logger from "./logger";
-import {
+import type {
   DecentralizedStorageConfig,
   DecentralizedStorageOrigin,
 } from "./types";
@@ -8,7 +8,7 @@ import assert from "assert";
 import { EventEmitter } from "stream";
 import { GatewayFetcher } from "./GatewayFetcher";
 import defaultConfig from "./defaultConfig";
-import { Logger } from "winston";
+import type { Logger } from "winston";
 
 /**
  * Fetcher for a certain type of Decentralized Storage (e.g. IPFS)

--- a/services/monitor/src/GatewayFetcher.ts
+++ b/services/monitor/src/GatewayFetcher.ts
@@ -1,7 +1,7 @@
-import { Logger } from "winston";
+import type { Logger } from "winston";
 import logger from "./logger";
 import { TimeoutError } from "./util";
-import { GatewayFetcherConfig } from "./types";
+import type { GatewayFetcherConfig } from "./types";
 
 export class GatewayFetcher {
   public url: string;

--- a/services/monitor/src/Monitor.ts
+++ b/services/monitor/src/Monitor.ts
@@ -1,14 +1,12 @@
 import DecentralizedStorageFetcher from "./DecentralizedStorageFetcher";
 import assert from "assert";
 import { EventEmitter } from "stream";
-import {
-  FetchRequestRPC,
-  SourcifyChain,
-} from "@ethereum-sourcify/lib-sourcify";
+import type { FetchRequestRPC } from "@ethereum-sourcify/lib-sourcify";
+import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import logger from "./logger";
 import "./loggerServer"; // Start the dynamic log level server
 import ChainMonitor from "./ChainMonitor";
-import {
+import type {
   KnownDecentralizedStorageFetchers,
   MonitorChain,
   MonitorConfig,

--- a/services/monitor/src/PendingContract.ts
+++ b/services/monitor/src/PendingContract.ts
@@ -1,11 +1,14 @@
 import logger from "./logger";
 import { FileHash } from "./util";
-import { Metadata, MetadataSourceMap } from "@ethereum-sourcify/lib-sourcify";
+import type {
+  Metadata,
+  MetadataSourceMap,
+} from "@ethereum-sourcify/lib-sourcify";
 import { id as keccak256str } from "ethers";
-import { KnownDecentralizedStorageFetchers } from "./types";
+import type { KnownDecentralizedStorageFetchers } from "./types";
 import assert from "assert";
 import dotenv from "dotenv";
-import { Logger } from "winston";
+import type { Logger } from "winston";
 
 dotenv.config();
 

--- a/services/monitor/src/index.ts
+++ b/services/monitor/src/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import fs from "fs";
 import Monitor from "./Monitor";
-import { PassedMonitorConfig } from "./types";
+import type { PassedMonitorConfig } from "./types";
 import path from "path";
 
 // Initialize a new commander object

--- a/services/monitor/src/logger.ts
+++ b/services/monitor/src/logger.ts
@@ -3,7 +3,8 @@
 // Has the concept of "moduleName" for logging such as ChainMonitor
 //
 
-import { createLogger, transports, format, Logger } from "winston";
+import type { Logger } from "winston";
+import { createLogger, transports, format } from "winston";
 import chalk from "chalk";
 import {
   setLibSourcifyLogger,

--- a/services/monitor/src/types.ts
+++ b/services/monitor/src/types.ts
@@ -1,4 +1,4 @@
-import DecentralizedStorageFetcher from "./DecentralizedStorageFetcher";
+import type DecentralizedStorageFetcher from "./DecentralizedStorageFetcher";
 
 export type KnownDecentralizedStorageFetchers = {
   [type in DecentralizedStorageOrigin]?: DecentralizedStorageFetcher;

--- a/services/monitor/src/util.ts
+++ b/services/monitor/src/util.ts
@@ -1,5 +1,5 @@
-import { SolidityDecodedObject } from "@ethereum-sourcify/bytecode-utils";
-import { DecentralizedStorageOrigin } from "./types";
+import type { SolidityDecodedObject } from "@ethereum-sourcify/bytecode-utils";
+import type { DecentralizedStorageOrigin } from "./types";
 
 export type FetchedFileCallback = (fetchedFile: string) => any;
 

--- a/services/monitor/test/Monitor.spec.ts
+++ b/services/monitor/test/Monitor.spec.ts
@@ -1,8 +1,10 @@
 import { expect } from "chai";
-import sinon, { SinonSandbox } from "sinon";
+import type { SinonSandbox } from "sinon";
+import sinon from "sinon";
 import Monitor, { authenticateRpcs } from "../src/Monitor";
 import logger from "../src/logger";
-import { FetchRequest, JsonRpcProvider, JsonRpcSigner, Network } from "ethers";
+import type { JsonRpcSigner } from "ethers";
+import { FetchRequest, JsonRpcProvider, Network } from "ethers";
 import {
   deployFromAbiAndBytecode,
   nockInterceptorForVerification,
@@ -12,11 +14,11 @@ import {
   startHardhatNetwork,
   stopHardhatNetwork,
 } from "./hardhat-network-helper";
-import { ChildProcess } from "child_process";
+import type { ChildProcess } from "child_process";
 import storageContractArtifact from "./sources/Storage/1_Storage.json";
 import nock from "nock";
-import { RpcObject } from "../src/types";
-import { FetchRequestRPC } from "@ethereum-sourcify/lib-sourcify";
+import type { RpcObject } from "../src/types";
+import type { FetchRequestRPC } from "@ethereum-sourcify/lib-sourcify";
 
 const HARDHAT_PORT = 8546;
 // Configured in hardhat.config.js

--- a/services/monitor/test/hardhat-network-helper.ts
+++ b/services/monitor/test/hardhat-network-helper.ts
@@ -1,5 +1,6 @@
 import treeKill from "tree-kill";
-import { ChildProcess, spawn } from "child_process";
+import type { ChildProcess } from "child_process";
+import { spawn } from "child_process";
 
 export function startHardhatNetwork(port: number) {
   return new Promise<ChildProcess>((resolve, reject) => {

--- a/services/monitor/test/helpers.ts
+++ b/services/monitor/test/helpers.ts
@@ -1,4 +1,5 @@
-import { ContractFactory, JsonRpcSigner } from "ethers";
+import type { JsonRpcSigner } from "ethers";
+import { ContractFactory } from "ethers";
 import nock from "nock";
 import { expect } from "chai";
 

--- a/services/server/src/common/errors/BadGatewayError.ts
+++ b/services/server/src/common/errors/BadGatewayError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class BadGatewayError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/BadRequestError.ts
+++ b/services/server/src/common/errors/BadRequestError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class BadRequestError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/ConflictError.ts
+++ b/services/server/src/common/errors/ConflictError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class ConflictError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/ContractIsAlreadyBeingVerifiedError.ts
+++ b/services/server/src/common/errors/ContractIsAlreadyBeingVerifiedError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class ContractIsAlreadyBeingVerifiedError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/GenericErrorHandler.ts
+++ b/services/server/src/common/errors/GenericErrorHandler.ts
@@ -1,5 +1,5 @@
 import { getReasonPhrase, StatusCodes } from "http-status-codes";
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import logger from "../logger";
 
 export default function genericErrorHandler(

--- a/services/server/src/common/errors/InternalServerError.ts
+++ b/services/server/src/common/errors/InternalServerError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class InternalServerError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/NotFoundError.ts
+++ b/services/server/src/common/errors/NotFoundError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class NotFoundError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/PayloadTooLargeError.ts
+++ b/services/server/src/common/errors/PayloadTooLargeError.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class PayloadTooLargeError implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/errors/TooManyRequests.ts
+++ b/services/server/src/common/errors/TooManyRequests.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { IResponseError } from "../interfaces";
+import type { IResponseError } from "../interfaces";
 
 export class TooManyRequests implements IResponseError {
   statusCode: number;

--- a/services/server/src/common/interfaces.ts
+++ b/services/server/src/common/interfaces.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import type { Router } from "express";
 
 export interface IController {
   registerRoutes(): Router;

--- a/services/server/src/common/logger.ts
+++ b/services/server/src/common/logger.ts
@@ -1,9 +1,10 @@
-import { createLogger, transports, format, Logger } from "winston";
+import type { Logger } from "winston";
+import { createLogger, transports, format } from "winston";
 import chalk from "chalk";
+import type { ILibSourcifyLogger } from "@ethereum-sourcify/lib-sourcify";
 import {
   setLibSourcifyLogger,
   setLibSourcifyLoggerLevel,
-  ILibSourcifyLogger,
 } from "@ethereum-sourcify/lib-sourcify";
 import { asyncLocalStorage } from "./async-context";
 import {

--- a/services/server/src/server/apiv1/controllers.common.ts
+++ b/services/server/src/server/apiv1/controllers.common.ts
@@ -1,10 +1,10 @@
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { getAddress } from "ethers";
 import { BadRequestError, InternalServerError } from "../../common/errors";
 import logger from "../../common/logger";
 import { isContractAlreadyPerfect } from "./verification/verification.common";
-import { Services } from "../services/services";
-import {
+import type { Services } from "../services/services";
+import type {
   ImmutableReferences,
   StringMap,
   Transformation,
@@ -12,7 +12,7 @@ import {
   Verification,
   VerificationStatus,
 } from "@ethereum-sourcify/lib-sourcify";
-import { Match } from "../types";
+import type { Match } from "../types";
 
 export function checksumAddresses(
   req: Request,

--- a/services/server/src/server/apiv1/deprecated.routes.ts
+++ b/services/server/src/server/apiv1/deprecated.routes.ts
@@ -1,4 +1,5 @@
-import express, { Response, Request, NextFunction } from "express";
+import type { Response, Request, NextFunction } from "express";
+import type express from "express";
 import { deprecatedRoutesVerifyStateless } from "./verification/verify/stateless/verify.stateless.routes";
 import { deprecatedRoutesVerifySession } from "./verification/verify/session/verify.session.routes";
 import { deprecatedRoutesSessionState } from "./verification/session-state/session-state.routes";

--- a/services/server/src/server/apiv1/repository/repository.handlers.ts
+++ b/services/server/src/server/apiv1/repository/repository.handlers.ts
@@ -1,6 +1,6 @@
-import { Response, Request, NextFunction } from "express";
+import type { Response, Request, NextFunction } from "express";
 import { StatusCodes } from "http-status-codes";
-import {
+import type {
   ContractData,
   FilesInfo,
   V1MatchLevel,
@@ -10,13 +10,13 @@ import {
 } from "../../types";
 import { NotFoundError } from "../../../common/errors";
 import logger from "../../../common/logger";
-import { Services } from "../../services/services";
-import {
-  detectAndResolveProxy,
+import type { Services } from "../../services/services";
+import type {
   Implementation,
   ProxyDetectionResult,
 } from "../../services/utils/proxy-contract-util";
-import { ChainRepository } from "../../../sourcify-chain-repository";
+import { detectAndResolveProxy } from "../../services/utils/proxy-contract-util";
+import type { ChainRepository } from "../../../sourcify-chain-repository";
 import { getAddress } from "ethers";
 import path from "path";
 

--- a/services/server/src/server/apiv1/routes.ts
+++ b/services/server/src/server/apiv1/routes.ts
@@ -1,4 +1,5 @@
-import { Router, Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { Router } from "express";
 import testArtifactsRoutes from "./testartifacts/testartifacts.routes";
 import repositoryRoutes from "./repository/repository.routes";
 import sessionStateRoutes from "./verification/session-state/session-state.routes";

--- a/services/server/src/server/apiv1/testartifacts/testartifacts.handlers.ts
+++ b/services/server/src/server/apiv1/testartifacts/testartifacts.handlers.ts
@@ -1,4 +1,4 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import { StatusCodes } from "http-status-codes";
 
 /**

--- a/services/server/src/server/apiv1/validation.ts
+++ b/services/server/src/server/apiv1/validation.ts
@@ -1,6 +1,6 @@
 import { getAddress, isAddress } from "ethers";
 import { BadRequestError } from "../../common/errors";
-import { ChainRepository } from "../../sourcify-chain-repository";
+import type { ChainRepository } from "../../sourcify-chain-repository";
 import type { OpenApiValidatorOpts } from "express-openapi-validator/dist/framework/types";
 
 export function makeV1ValidatorFormats(

--- a/services/server/src/server/apiv1/verification/etherscan/session/etherscan.session.handlers.ts
+++ b/services/server/src/server/apiv1/verification/etherscan/session/etherscan.session.handlers.ts
@@ -1,11 +1,11 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import {
   checkContractsInSession,
   getSessionJSON,
   saveFilesToSession,
   verifyContractsInSession,
 } from "../../verification.common";
-import {
+import type {
   ISolidityCompiler,
   IVyperCompiler,
   PathContent,
@@ -16,8 +16,8 @@ import {
   fetchFromEtherscan,
 } from "../../../../services/utils/etherscan-util";
 import logger from "../../../../../common/logger";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
-import { Services } from "../../../../services/services";
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type { Services } from "../../../../services/services";
 
 export const stringToBase64 = (str: string): string =>
   Buffer.from(str, "utf8").toString("base64");

--- a/services/server/src/server/apiv1/verification/etherscan/stateless/etherscan.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/etherscan/stateless/etherscan.stateless.handlers.ts
@@ -1,15 +1,15 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import {
   fetchFromEtherscan,
   getCompilationFromEtherscanResult,
 } from "../../../../services/utils/etherscan-util";
 import logger from "../../../../../common/logger";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
-import {
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type {
   ISolidityCompiler,
   IVyperCompiler,
 } from "@ethereum-sourcify/lib-sourcify";
-import { Services } from "../../../../services/services";
+import type { Services } from "../../../../services/services";
 import { getApiV1ResponseFromVerification } from "../../../controllers.common";
 
 export async function verifyFromEtherscan(req: Request, res: Response) {

--- a/services/server/src/server/apiv1/verification/private/stateless/customReplaceMethods.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/customReplaceMethods.ts
@@ -1,9 +1,9 @@
-import { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
+import type { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
 import {
   bytesFromString,
   getDatabaseColumnsFromVerification,
 } from "../../../../services/utils/database-util";
-import { SourcifyDatabaseService } from "../../../../services/storageServices/SourcifyDatabaseService";
+import type { SourcifyDatabaseService } from "../../../../services/storageServices/SourcifyDatabaseService";
 import { BadRequestError } from "../../../../../common/errors";
 
 export type CustomReplaceMethod = (

--- a/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/private/stateless/private.stateless.handlers.ts
@@ -1,17 +1,20 @@
-import { Response } from "express";
-import { LegacyVerifyRequest, extractFiles } from "../../verification.common";
-import {
+import type { Response } from "express";
+import type { LegacyVerifyRequest } from "../../verification.common";
+import { extractFiles } from "../../verification.common";
+import type {
   ISolidityCompiler,
   SolidityMetadataContract,
-  createMetadataContractsFromFiles,
-  Verification,
   SolidityJsonInput,
-  SolidityCompilation,
   AbstractCompilation,
   CompilationTarget,
   SourcifyChain,
   VyperJsonInput,
   IVyperCompiler,
+} from "@ethereum-sourcify/lib-sourcify";
+import {
+  createMetadataContractsFromFiles,
+  Verification,
+  SolidityCompilation,
   VyperCompilation,
   splitFullyQualifiedName,
 } from "@ethereum-sourcify/lib-sourcify";
@@ -21,14 +24,15 @@ import {
   InternalServerError,
 } from "../../../../../common/errors";
 import { StatusCodes } from "http-status-codes";
-import { Services } from "../../../../services/services";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type { Services } from "../../../../services/services";
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
 import logger from "../../../../../common/logger";
 import { getApiV1ResponseFromVerification } from "../../../controllers.common";
-import { SourcifyDatabaseService } from "../../../../services/storageServices/SourcifyDatabaseService";
+import type { SourcifyDatabaseService } from "../../../../services/storageServices/SourcifyDatabaseService";
 import SourcifyChainMock from "../../../../services/utils/SourcifyChainMock";
 import { getCreatorTx } from "../../../../services/utils/contract-creation-util";
-import { CustomReplaceMethod, REPLACE_METHODS } from "./customReplaceMethods";
+import type { CustomReplaceMethod } from "./customReplaceMethods";
+import { REPLACE_METHODS } from "./customReplaceMethods";
 
 export async function verifyDeprecated(
   req: LegacyVerifyRequest,

--- a/services/server/src/server/apiv1/verification/session-state/session-state.handlers.ts
+++ b/services/server/src/server/apiv1/verification/session-state/session-state.handlers.ts
@@ -1,4 +1,4 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import {
   FILE_ENCODING,
   addRemoteFile,
@@ -8,11 +8,13 @@ import {
   saveFilesToSession,
   verifyContractsInSession,
 } from "../verification.common";
-import {
+import type {
   ISolidityCompiler,
   IVyperCompiler,
   PathBuffer,
   PathContent,
+} from "@ethereum-sourcify/lib-sourcify";
+import {
   performFetch,
   SolidityMetadataContract,
 } from "@ethereum-sourcify/lib-sourcify";
@@ -24,8 +26,8 @@ import {
   decode as bytecodeDecode,
 } from "@ethereum-sourcify/bytecode-utils";
 import logger from "../../../../common/logger";
-import { Services } from "../../../services/services";
-import { ChainRepository } from "../../../../sourcify-chain-repository";
+import type { Services } from "../../../services/services";
+import type { ChainRepository } from "../../../../sourcify-chain-repository";
 
 export async function getSessionDataEndpoint(req: Request, res: Response) {
   res.send(getSessionJSON(req.session));

--- a/services/server/src/server/apiv1/verification/solc-json/session/solc-json.session.handlers.ts
+++ b/services/server/src/server/apiv1/verification/solc-json/session/solc-json.session.handlers.ts
@@ -1,4 +1,4 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import {
   FILE_ENCODING,
   checkContractsInSession,
@@ -6,12 +6,12 @@ import {
   getSessionJSON,
   saveFilesToSession,
 } from "../../verification.common";
-import {
+import type {
   ISolidityCompiler,
   PathContent,
 } from "@ethereum-sourcify/lib-sourcify";
 import { BadRequestError } from "../../../../../common/errors";
-import { Services } from "../../../../services/services";
+import type { Services } from "../../../../services/services";
 export async function addInputSolcJsonEndpoint(req: Request, res: Response) {
   const inputFiles = extractFiles(req, true);
   if (!inputFiles) throw new BadRequestError("No files found");

--- a/services/server/src/server/apiv1/verification/solc-json/stateless/solc-json.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/solc-json/stateless/solc-json.stateless.handlers.ts
@@ -1,13 +1,13 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import { extractFiles } from "../../verification.common";
-import {
+import type {
   ISolidityCompiler,
-  SolidityCompilation,
   SolidityJsonInput,
 } from "@ethereum-sourcify/lib-sourcify";
+import { SolidityCompilation } from "@ethereum-sourcify/lib-sourcify";
 import { BadRequestError } from "../../../../../common/errors";
-import { Services } from "../../../../services/services";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type { Services } from "../../../../services/services";
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
 import { getApiV1ResponseFromVerification } from "../../../controllers.common";
 import logger from "../../../../../common/logger";
 import { getContractPathFromSources } from "../../../../services/utils/parsing-util";

--- a/services/server/src/server/apiv1/verification/verification.common.ts
+++ b/services/server/src/server/apiv1/verification/verification.common.ts
@@ -1,14 +1,16 @@
-import { Request } from "express";
+import type { Request } from "express";
 import { BadRequestError, PayloadTooLargeError } from "../../../common/errors";
-import {
+import type {
   InvalidSources,
   MissingSources,
   PathContent,
   IVyperCompiler,
-  SolidityMetadataContract,
-  VyperCompilation,
   CompilationTarget,
   Verification,
+} from "@ethereum-sourcify/lib-sourcify";
+import {
+  SolidityMetadataContract,
+  VyperCompilation,
   VerificationError,
   useAllSourcesAndReturnCompilation,
   SolidityCompilation,
@@ -16,21 +18,21 @@ import {
   splitFiles,
   rearrangeSources,
 } from "@ethereum-sourcify/lib-sourcify";
-import { Session } from "express-session";
-import { JsonFragmentType } from "ethers";
-import QueryString from "qs";
-import { VerificationService } from "../../services/VerificationService";
-import {
+import type { Session } from "express-session";
+import type { JsonFragmentType } from "ethers";
+import type QueryString from "qs";
+import type { VerificationService } from "../../services/VerificationService";
+import type {
   ContractMeta,
   ContractWrapper,
   ContractWrapperData,
 } from "../../common";
-import { ISolidityCompiler } from "@ethereum-sourcify/lib-sourcify";
-import { StorageService } from "../../services/StorageService";
+import type { ISolidityCompiler } from "@ethereum-sourcify/lib-sourcify";
+import type { StorageService } from "../../services/StorageService";
 import logger from "../../../common/logger";
 import { createHash } from "crypto";
-import { ChainRepository } from "../../../sourcify-chain-repository";
-import { Match } from "../../types";
+import type { ChainRepository } from "../../../sourcify-chain-repository";
+import type { Match } from "../../types";
 import { keccak256 } from "ethers";
 import { getMatchStatus } from "../controllers.common";
 

--- a/services/server/src/server/apiv1/verification/verify/session/verify.session.handlers.ts
+++ b/services/server/src/server/apiv1/verification/verify/session/verify.session.handlers.ts
@@ -1,18 +1,18 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
+import type { SendableContract } from "../../verification.common";
 import {
-  SendableContract,
   getSessionJSON,
   verifyContractsInSession,
 } from "../../verification.common";
-import {
-  isEmpty,
+import type {
   ISolidityCompiler,
   IVyperCompiler,
 } from "@ethereum-sourcify/lib-sourcify";
+import { isEmpty } from "@ethereum-sourcify/lib-sourcify";
 import { BadRequestError } from "../../../../../common/errors";
 import logger from "../../../../../common/logger";
-import { Services } from "../../../../services/services";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type { Services } from "../../../../services/services";
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
 
 export async function verifyContractsInSessionEndpoint(
   req: Request,

--- a/services/server/src/server/apiv1/verification/verify/stateless/verify.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/verify/stateless/verify.stateless.handlers.ts
@@ -1,8 +1,11 @@
-import { Response } from "express";
-import { LegacyVerifyRequest, extractFiles } from "../../verification.common";
-import {
+import type { Response } from "express";
+import type { LegacyVerifyRequest } from "../../verification.common";
+import { extractFiles } from "../../verification.common";
+import type {
   ISolidityCompiler,
   SolidityMetadataContract,
+} from "@ethereum-sourcify/lib-sourcify";
+import {
   createMetadataContractsFromFiles,
   VerificationError,
   Verification,
@@ -10,8 +13,8 @@ import {
 } from "@ethereum-sourcify/lib-sourcify";
 import { BadRequestError, NotFoundError } from "../../../../../common/errors";
 import { StatusCodes } from "http-status-codes";
-import { Services } from "../../../../services/services";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type { Services } from "../../../../services/services";
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
 import logger from "../../../../../common/logger";
 import { getApiV1ResponseFromVerification } from "../../../controllers.common";
 

--- a/services/server/src/server/apiv1/verification/vyper/stateless/vyper.stateless.handlers.ts
+++ b/services/server/src/server/apiv1/verification/vyper/stateless/vyper.stateless.handlers.ts
@@ -1,15 +1,15 @@
-import { Response, Request } from "express";
+import type { Response, Request } from "express";
 import { extractFiles } from "../../verification.common";
-import {
+import type {
   IVyperCompiler,
   StringMap,
   VyperSettings,
-  VyperCompilation,
   VyperJsonInput,
 } from "@ethereum-sourcify/lib-sourcify";
+import { VyperCompilation } from "@ethereum-sourcify/lib-sourcify";
 import { NotFoundError, BadRequestError } from "../../../../../common/errors";
-import { Services } from "../../../../services/services";
-import { ChainRepository } from "../../../../../sourcify-chain-repository";
+import type { Services } from "../../../../services/services";
+import type { ChainRepository } from "../../../../../sourcify-chain-repository";
 import logger from "../../../../../common/logger";
 import { getApiV1ResponseFromVerification } from "../../../controllers.common";
 

--- a/services/server/src/server/apiv2/errors.ts
+++ b/services/server/src/server/apiv2/errors.ts
@@ -8,14 +8,14 @@ import { v4 as uuidv4 } from "uuid";
 import type { Request, Response, NextFunction } from "express";
 import { error as openApiValidatorErrors } from "express-openapi-validator";
 import logger from "../../common/logger";
-import {
-  getErrorMessageFromCode,
+import type {
   SourcifyLibErrorCode,
   SourcifyLibErrorParameters,
 } from "@ethereum-sourcify/lib-sourcify";
+import { getErrorMessageFromCode } from "@ethereum-sourcify/lib-sourcify";
 import { TooManyRequests } from "../../common/errors/TooManyRequests";
 import { BadGatewayError } from "../../common/errors/BadGatewayError";
-import { JobErrorData } from "../services/utils/database-util";
+import type { JobErrorData } from "../services/utils/database-util";
 
 export type ErrorCode =
   | VerificationErrorCode

--- a/services/server/src/server/apiv2/jobs/jobs.handler.ts
+++ b/services/server/src/server/apiv2/jobs/jobs.handler.ts
@@ -1,8 +1,8 @@
 import { StatusCodes } from "http-status-codes";
-import { Services } from "../../services/services";
+import type { Services } from "../../services/services";
 import logger from "../../../common/logger";
-import { Request } from "express";
-import { TypedResponse, VerificationJob } from "../../types";
+import type { Request } from "express";
+import type { TypedResponse, VerificationJob } from "../../types";
 import { JobNotFoundError } from "../errors";
 
 interface GetJobRequest extends Request {

--- a/services/server/src/server/apiv2/lookup/lookup.handlers.ts
+++ b/services/server/src/server/apiv2/lookup/lookup.handlers.ts
@@ -1,21 +1,19 @@
 import { StatusCodes } from "http-status-codes";
-import { Services } from "../../services/services";
+import type { Services } from "../../services/services";
 import logger from "../../../common/logger";
-import { Request } from "express";
-import {
+import type { Request } from "express";
+import type {
   ProxyResolution,
   TypedResponse,
   VerifiedContract,
   VerifiedContractMinimal,
 } from "../../types";
 import { getAddress } from "ethers";
-import {
-  detectAndResolveProxy,
-  Implementation,
-} from "../../services/utils/proxy-contract-util";
-import { ChainRepository } from "../../../sourcify-chain-repository";
+import type { Implementation } from "../../services/utils/proxy-contract-util";
+import { detectAndResolveProxy } from "../../services/utils/proxy-contract-util";
+import type { ChainRepository } from "../../../sourcify-chain-repository";
 import { v4 as uuidv4 } from "uuid";
-import { Field } from "../../services/utils/database-util";
+import type { Field } from "../../services/utils/database-util";
 
 interface ListContractsRequest extends Request {
   params: {

--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -1,5 +1,5 @@
-import { Request, Response, NextFunction } from "express";
-import { ChainRepository } from "../../sourcify-chain-repository";
+import type { Request, Response, NextFunction } from "express";
+import type { ChainRepository } from "../../sourcify-chain-repository";
 import logger from "../../common/logger";
 import {
   AlreadyVerifiedError,
@@ -11,7 +11,7 @@ import {
 import { getAddress } from "ethers";
 import { FIELDS_TO_STORED_PROPERTIES } from "../services/utils/database-util";
 import { reduceAccessorStringToProperty } from "../services/utils/util";
-import { Services } from "../services/services";
+import type { Services } from "../services/services";
 import type {
   Metadata,
   SolidityJsonInput,

--- a/services/server/src/server/apiv2/routes.ts
+++ b/services/server/src/server/apiv2/routes.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import lookupRoutes from "./lookup/lookup.routes";
 import jobsRoutes from "./jobs/jobs.routes";
 import verificationRoutes from "./verification/verification.routes";
-import { Services } from "../services/services";
+import type { Services } from "../services/services";
 import { RWStorageIdentifiers } from "../services/storageServices/identifiers";
 import { RouteNotFoundError } from "./errors";
 

--- a/services/server/src/server/apiv2/verification/verification.handlers.ts
+++ b/services/server/src/server/apiv2/verification/verification.handlers.ts
@@ -5,13 +5,13 @@ import type {
   Metadata,
 } from "@ethereum-sourcify/lib-sourcify";
 import { splitFullyQualifiedName } from "@ethereum-sourcify/lib-sourcify";
-import { TypedResponse } from "../../types";
+import type { TypedResponse } from "../../types";
 import logger from "../../../common/logger";
-import { Request } from "express";
-import { Services } from "../../services/services";
+import type { Request } from "express";
+import type { Services } from "../../services/services";
 import { StatusCodes } from "http-status-codes";
 import { fetchFromEtherscan } from "../../services/utils/etherscan-util";
-import { ChainRepository } from "../../../sourcify-chain-repository";
+import type { ChainRepository } from "../../../sourcify-chain-repository";
 
 interface VerifyFromJsonInputRequest extends Request {
   params: {

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -18,9 +18,10 @@ import genFunc from "connect-pg-simple";
 // local imports
 import logger from "../common/logger";
 import { sourcifyChainsMap } from "../sourcify-chains";
-import { LibSourcifyConfig, Server } from "./server";
+import type { LibSourcifyConfig } from "./server";
+import { Server } from "./server";
 import { SolcLocal } from "./services/compiler/local/SolcLocal";
-import session from "express-session";
+import type session from "express-session";
 import { VyperLocal } from "./services/compiler/local/VyperLocal";
 
 export const getEtherscanApiKeyForEachChain = (): Record<string, string> =>

--- a/services/server/src/server/common.ts
+++ b/services/server/src/server/common.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   InvalidSources,
   CompilationLanguage,
   Metadata,

--- a/services/server/src/server/routes.ts
+++ b/services/server/src/server/routes.ts
@@ -1,6 +1,7 @@
-import { Router, Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { Router } from "express";
 import logger, { setLogLevel } from "../common/logger";
-import { ChainRepository } from "../sourcify-chain-repository";
+import type { ChainRepository } from "../sourcify-chain-repository";
 import apiV2Routes from "./apiv2/routes";
 import apiV1Routes from "./apiv1/routes";
 import { readFileSync } from "fs";

--- a/services/server/src/server/server.ts
+++ b/services/server/src/server/server.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import express, { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
+import express from "express";
 import cors from "cors";
 import * as OpenApiValidator from "express-openapi-validator";
 import yamljs from "yamljs";
@@ -17,21 +18,23 @@ import genericErrorHandler from "../common/errors/GenericErrorHandler";
 import { initDeprecatedRoutes } from "./apiv1/deprecated.routes";
 import getSessionMiddleware from "./session";
 import { Services } from "./services/services";
-import { StorageServiceOptions } from "./services/StorageService";
-import { VerificationServiceOptions } from "./services/VerificationService";
-import {
-  getLibSourcifyLoggerLevel,
+import type { StorageServiceOptions } from "./services/StorageService";
+import type { VerificationServiceOptions } from "./services/VerificationService";
+import type {
   ISolidityCompiler,
   IVyperCompiler,
-  SolidityMetadataContract,
-  SourcifyChain,
   SourcifyChainMap,
 } from "@ethereum-sourcify/lib-sourcify";
+import {
+  getLibSourcifyLoggerLevel,
+  SolidityMetadataContract,
+  SourcifyChain,
+} from "@ethereum-sourcify/lib-sourcify";
 import { ChainRepository } from "../sourcify-chain-repository";
-import { SessionOptions } from "express-session";
+import type { SessionOptions } from "express-session";
 import { makeV1ValidatorFormats } from "./apiv1/validation";
 import { errorHandler as v2ErrorHandler } from "./apiv2/errors";
-import http from "http";
+import type http from "http";
 import { RWStorageIdentifiers } from "./services/storageServices/identifiers";
 
 declare module "express-serve-static-core" {

--- a/services/server/src/server/services/StorageService.ts
+++ b/services/server/src/server/services/StorageService.ts
@@ -1,16 +1,12 @@
-import { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
-import {
-  RepositoryV1Service,
-  RepositoryV1ServiceOptions,
-} from "./storageServices/RepositoryV1Service";
-import {
-  RepositoryV2Service,
-  RepositoryV2ServiceOptions,
-} from "./storageServices/RepositoryV2Service";
+import type { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
+import type { RepositoryV1ServiceOptions } from "./storageServices/RepositoryV1Service";
+import { RepositoryV1Service } from "./storageServices/RepositoryV1Service";
+import type { RepositoryV2ServiceOptions } from "./storageServices/RepositoryV2Service";
+import { RepositoryV2Service } from "./storageServices/RepositoryV2Service";
 import { SourcifyDatabaseService } from "./storageServices/SourcifyDatabaseService";
 import { AllianceDatabaseService } from "./storageServices/AllianceDatabaseService";
 import logger from "../../common/logger";
-import {
+import type {
   ContractData,
   FileObject,
   FilesInfo,
@@ -28,25 +24,23 @@ import {
   VerificationJobId,
   SimilarityCandidate,
 } from "../types";
+import type { StorageIdentifiers } from "./storageServices/identifiers";
 import {
   RWStorageIdentifiers,
-  StorageIdentifiers,
   WStorageIdentifiers,
 } from "./storageServices/identifiers";
 import { ConflictError } from "../../common/errors/ConflictError";
 import { isBetterVerification } from "./utils/util";
-import {
-  S3RepositoryService,
-  S3RepositoryServiceOptions,
-} from "./storageServices/S3RepositoryService";
-import { DatabaseOptions } from "./utils/Database";
-import { Field } from "./utils/database-util";
-import { VerifyErrorExport } from "./workers/workerTypes";
-import {
+import type { S3RepositoryServiceOptions } from "./storageServices/S3RepositoryService";
+import { S3RepositoryService } from "./storageServices/S3RepositoryService";
+import type { DatabaseOptions } from "./utils/Database";
+import type { Field } from "./utils/database-util";
+import type { VerifyErrorExport } from "./workers/workerTypes";
+import type {
   EtherscanVerifyApiIdentifiers,
-  EtherscanVerifyApiService,
   EtherscanVerifyApiServiceOptions,
 } from "./storageServices/EtherscanVerifyApiService";
+import { EtherscanVerifyApiService } from "./storageServices/EtherscanVerifyApiService";
 
 export interface WStorageService {
   IDENTIFIER: StorageIdentifiers;

--- a/services/server/src/server/services/VerificationService.ts
+++ b/services/server/src/server/services/VerificationService.ts
@@ -1,10 +1,9 @@
-import {
+import type {
   SourcifyChain,
   ISolidityCompiler,
   SolidityJsonInput,
   VyperJsonInput,
   PathBuffer,
-  Verification,
   SolidityCompilation,
   VyperCompilation,
   SourcifyChainMap,
@@ -14,6 +13,7 @@ import {
   Metadata,
   EtherscanResult,
 } from "@ethereum-sourcify/lib-sourcify";
+import { Verification } from "@ethereum-sourcify/lib-sourcify";
 import { getCreatorTx } from "./utils/contract-creation-util";
 import { ContractIsAlreadyBeingVerifiedError } from "../../common/errors/ContractIsAlreadyBeingVerifiedError";
 import logger from "../../common/logger";
@@ -22,18 +22,20 @@ import {
   getSolcExecutable,
   getSolcJs,
 } from "@ethereum-sourcify/compilers";
-import { VerificationJobId } from "../types";
-import { StorageService } from "./StorageService";
+import type { VerificationJobId } from "../types";
+import type { StorageService } from "./StorageService";
 import Piscina from "piscina";
 import path from "path";
 import { filename as verificationWorkerFilename } from "./workers/verificationWorker";
 import { v4 as uuidv4 } from "uuid";
 import { ConflictError } from "../../common/errors/ConflictError";
 import os from "os";
-import {
-  VerifyError,
+import type {
   VerifyErrorExport,
   VerifyFromEtherscanInput,
+} from "./workers/workerTypes";
+import {
+  VerifyError,
   type VerifyFromJsonInput,
   type VerifyFromMetadataInput,
   type VerifyOutput,

--- a/services/server/src/server/services/compiler/local/SolcLocal.ts
+++ b/services/server/src/server/services/compiler/local/SolcLocal.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SolidityOutput,
   ISolidityCompiler,
   SolidityJsonInput,

--- a/services/server/src/server/services/compiler/local/VyperLocal.ts
+++ b/services/server/src/server/services/compiler/local/VyperLocal.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IVyperCompiler,
   VyperJsonInput,
   VyperOutput,

--- a/services/server/src/server/services/services.ts
+++ b/services/server/src/server/services/services.ts
@@ -1,8 +1,7 @@
-import { StorageService, StorageServiceOptions } from "./StorageService";
-import {
-  VerificationService,
-  VerificationServiceOptions,
-} from "./VerificationService";
+import type { StorageServiceOptions } from "./StorageService";
+import { StorageService } from "./StorageService";
+import type { VerificationServiceOptions } from "./VerificationService";
+import { VerificationService } from "./VerificationService";
 
 export class Services {
   public verification: VerificationService;

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -1,8 +1,10 @@
-import { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
+import type { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
 import * as DatabaseUtil from "../utils/database-util";
-import { bytesFromString, Tables } from "../utils/database-util";
-import { Database, DatabaseOptions } from "../utils/Database";
-import { PoolClient, QueryResult } from "pg";
+import type { Tables } from "../utils/database-util";
+import { bytesFromString } from "../utils/database-util";
+import type { DatabaseOptions } from "../utils/Database";
+import { Database } from "../utils/Database";
+import type { PoolClient, QueryResult } from "pg";
 
 export default abstract class AbstractDatabaseService {
   public database: Database;

--- a/services/server/src/server/services/storageServices/AllianceDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AllianceDatabaseService.ts
@@ -1,7 +1,7 @@
 import logger from "../../../common/logger";
 import AbstractDatabaseService from "./AbstractDatabaseService";
-import { WStorageService } from "../StorageService";
-import { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
+import type { WStorageService } from "../StorageService";
+import type { VerificationExport } from "@ethereum-sourcify/lib-sourcify";
 import { WStorageIdentifiers } from "./identifiers";
 
 export class AllianceDatabaseService

--- a/services/server/src/server/services/storageServices/EtherscanVerifyApiService.ts
+++ b/services/server/src/server/services/storageServices/EtherscanVerifyApiService.ts
@@ -1,14 +1,14 @@
-import {
+import type {
   CompilationLanguage,
   VerificationExport,
   VyperSettings,
 } from "@ethereum-sourcify/lib-sourcify";
 import logger from "../../../common/logger";
-import { WStorageService } from "../StorageService";
+import type { WStorageService } from "../StorageService";
 import { WStorageIdentifiers } from "./identifiers";
-import { Database } from "../utils/Database";
-import { SourcifyDatabaseService } from "./SourcifyDatabaseService";
-import { ExternalVerification } from "../utils/database-util";
+import type { Database } from "../utils/Database";
+import type { SourcifyDatabaseService } from "./SourcifyDatabaseService";
+import type { ExternalVerification } from "../utils/database-util";
 
 export type EtherscanVerifyApiIdentifiers =
   | WStorageIdentifiers.EtherscanVerify

--- a/services/server/src/server/services/storageServices/RepositoryV1Service.ts
+++ b/services/server/src/server/services/storageServices/RepositoryV1Service.ts
@@ -1,12 +1,12 @@
 import dirTree from "directory-tree";
 import Path from "path";
 import fs from "fs";
-import {
+import type {
   VerificationStatus,
   StringMap,
   VerificationExport,
 } from "@ethereum-sourcify/lib-sourcify";
-import {
+import type {
   ContractData,
   FileObject,
   FilesInfo,
@@ -19,7 +19,7 @@ import {
 import path from "path";
 import logger from "../../../common/logger";
 import { getAddress } from "ethers";
-import { RWStorageService } from "../StorageService";
+import type { RWStorageService } from "../StorageService";
 import { RWStorageIdentifiers } from "./identifiers";
 import { exists, readFile } from "../utils/util";
 import { getMatchStatus } from "../../apiv1/controllers.common";

--- a/services/server/src/server/services/storageServices/RepositoryV2Service.ts
+++ b/services/server/src/server/services/storageServices/RepositoryV2Service.ts
@@ -7,15 +7,19 @@
 
 import Path from "path";
 import fs from "fs";
-import {
+import type {
   VerificationStatus,
   StringMap,
   VerificationExport,
 } from "@ethereum-sourcify/lib-sourcify";
-import { V1MatchLevelWithoutAny, MatchQuality, PathConfig } from "../../types";
+import type {
+  V1MatchLevelWithoutAny,
+  MatchQuality,
+  PathConfig,
+} from "../../types";
 import logger from "../../../common/logger";
 import { getAddress, id as keccak256 } from "ethers";
-import { WStorageService } from "../StorageService";
+import type { WStorageService } from "../StorageService";
 import { WStorageIdentifiers } from "./identifiers";
 import { exists, readFile } from "../utils/util";
 import { getMatchStatus } from "../../apiv1/controllers.common";

--- a/services/server/src/server/services/storageServices/S3RepositoryService.ts
+++ b/services/server/src/server/services/storageServices/S3RepositoryService.ts
@@ -1,5 +1,5 @@
 import { RepositoryV2Service } from "./RepositoryV2Service";
-import { WStorageService } from "../StorageService";
+import type { WStorageService } from "../StorageService";
 import { WStorageIdentifiers } from "./identifiers";
 import logger from "../../../common/logger";
 import {
@@ -8,7 +8,7 @@ import {
   ListObjectsV2Command,
   DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
-import { PathConfig } from "../../types";
+import type { PathConfig } from "../../types";
 import Path from "path";
 
 export interface S3RepositoryServiceOptions {

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -1,25 +1,27 @@
-import {
+import type {
   VerificationStatus,
   StringMap,
   VerificationExport,
-  splitFullyQualifiedName,
   ISolidityCompiler,
   IVyperCompiler,
   PreRunCompilation,
 } from "@ethereum-sourcify/lib-sourcify";
+import { splitFullyQualifiedName } from "@ethereum-sourcify/lib-sourcify";
 import logger from "../../../common/logger";
 import AbstractDatabaseService from "./AbstractDatabaseService";
-import { RWStorageService } from "../StorageService";
-import {
-  bytesFromString,
+import type { RWStorageService } from "../StorageService";
+import type {
   Field,
-  FIELDS_TO_STORED_PROPERTIES,
   GetSourcifyMatchByChainAddressWithPropertiesResult,
   StoredProperties,
   Tables,
-  createPreRunCompilationFromStoredCandidate,
 } from "../utils/database-util";
 import {
+  bytesFromString,
+  FIELDS_TO_STORED_PROPERTIES,
+  createPreRunCompilationFromStoredCandidate,
+} from "../utils/database-util";
+import type {
   ContractData,
   FileObject,
   FilesInfo,
@@ -49,13 +51,11 @@ import { extractSignaturesFromAbi } from "../utils/signature-util";
 import { BadRequestError } from "../../../common/errors";
 import { RWStorageIdentifiers } from "./identifiers";
 import semver from "semver";
-import { DatabaseOptions } from "../utils/Database";
-import {
-  getVerificationErrorMessage,
-  VerificationErrorCode,
-} from "../../apiv2/errors";
-import { VerifyErrorExport } from "../workers/workerTypes";
-import { PoolClient } from "pg";
+import type { DatabaseOptions } from "../utils/Database";
+import type { VerificationErrorCode } from "../../apiv2/errors";
+import { getVerificationErrorMessage } from "../../apiv2/errors";
+import type { VerifyErrorExport } from "../workers/workerTypes";
+import type { PoolClient } from "pg";
 
 const MAX_RETURNED_CONTRACTS_BY_GETCONTRACTS = 200;
 

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -1,7 +1,7 @@
-import { Pool, PoolClient, QueryResult } from "pg";
-import { Bytes, BytesKeccak } from "../../types";
-import {
-  bytesFromString,
+import type { PoolClient, QueryResult } from "pg";
+import { Pool } from "pg";
+import type { Bytes, BytesKeccak } from "../../types";
+import type {
   GetSourcifyMatchByChainAddressResult,
   GetSourcifyMatchByChainAddressWithPropertiesResult,
   GetSourcifyMatchesByChainResult,
@@ -9,17 +9,20 @@ import {
   GetVerifiedContractByChainAndAddressResult,
   GetVerificationJobsByChainAndAddressResult,
   SourceInformation,
-  STORED_PROPERTIES_TO_SELECTORS,
   StoredProperties,
   Tables,
   GetSourcifyMatchesAllChainsResult,
   ExternalVerification,
   CodePrefixMatchResult,
 } from "./database-util";
+import {
+  bytesFromString,
+  STORED_PROPERTIES_TO_SELECTORS,
+} from "./database-util";
 import { createHash } from "crypto";
 import { AuthTypes, Connector } from "@google-cloud/cloud-sql-connector";
 import logger from "../../../common/logger";
-import { EtherscanVerifyApiIdentifiers } from "../storageServices/EtherscanVerifyApiService";
+import type { EtherscanVerifyApiIdentifiers } from "../storageServices/EtherscanVerifyApiService";
 
 export interface DatabaseOptions {
   googleCloudSql?: {

--- a/services/server/src/server/services/utils/SourcifyChainMock.ts
+++ b/services/server/src/server/services/utils/SourcifyChainMock.ts
@@ -1,10 +1,8 @@
 import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
-import { TransactionReceipt, TransactionResponse } from "ethers";
-import {
-  bytesFromString,
-  GetSourcifyMatchByChainAddressWithPropertiesResult,
-} from "./database-util";
-import { Database } from "./Database";
+import type { TransactionReceipt, TransactionResponse } from "ethers";
+import type { GetSourcifyMatchByChainAddressWithPropertiesResult } from "./database-util";
+import { bytesFromString } from "./database-util";
+import type { Database } from "./Database";
 import logger from "../../../common/logger";
 
 export type SourcifyChainMockContractDeployment = Required<

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -1,4 +1,4 @@
-import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import { StatusCodes } from "http-status-codes";
 import logger from "../../../common/logger";
 

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ImmutableReferences,
   Metadata,
   VerificationStatus,
@@ -18,10 +18,12 @@ import {
   SourcifyLibErrorData,
   ISolidityCompiler,
   IVyperCompiler,
+} from "@ethereum-sourcify/lib-sourcify";
+import {
   PreRunCompilation,
   splitFullyQualifiedName,
 } from "@ethereum-sourcify/lib-sourcify";
-import {
+import type {
   VerifiedContract as VerifiedContractApiObject,
   Bytes,
   BytesSha,
@@ -31,9 +33,10 @@ import {
   SignatureRepresentations,
   SimilarityCandidate,
 } from "../../types";
-import { keccak256, JsonFragment } from "ethers";
+import type { JsonFragment } from "ethers";
+import { keccak256 } from "ethers";
 import { SignatureType } from "./signature-util";
-import { EtherscanVerifyApiIdentifiers } from "../storageServices/EtherscanVerifyApiService";
+import type { EtherscanVerifyApiIdentifiers } from "../storageServices/EtherscanVerifyApiService";
 
 export type JobErrorData = Omit<SourcifyLibErrorData, "chainId" | "address">;
 

--- a/services/server/src/server/services/utils/etherscan-util.ts
+++ b/services/server/src/server/services/utils/etherscan-util.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ISolidityCompiler,
   IVyperCompiler,
   SourcifyChain,

--- a/services/server/src/server/services/utils/parsing-util.ts
+++ b/services/server/src/server/services/utils/parsing-util.ts
@@ -1,5 +1,5 @@
 import SolidityParser from "@solidity-parser/parser";
-import { Sources } from "@ethereum-sourcify/lib-sourcify";
+import type { Sources } from "@ethereum-sourcify/lib-sourcify";
 import logger from "../../../common/logger";
 
 /**

--- a/services/server/src/server/services/utils/proxy-contract-util.ts
+++ b/services/server/src/server/services/utils/proxy-contract-util.ts
@@ -1,5 +1,5 @@
 import { whatsabi } from "@shazow/whatsabi";
-import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import { AbiCoder } from "ethers";
 
 export type ProxyType =

--- a/services/server/src/server/services/utils/signature-util.ts
+++ b/services/server/src/server/services/utils/signature-util.ts
@@ -1,4 +1,5 @@
-import { id as keccak256str, Fragment, JsonFragment } from "ethers";
+import type { JsonFragment } from "ethers";
+import { id as keccak256str, Fragment } from "ethers";
 
 export enum SignatureType {
   Function = "function",

--- a/services/server/src/server/services/utils/util.ts
+++ b/services/server/src/server/services/utils/util.ts
@@ -1,13 +1,13 @@
 import Path from "path";
 import fs from "fs";
-import {
+import type {
   V1MatchLevelWithoutAny,
   MatchQuality,
   MatchLevel,
   Match,
 } from "../../types";
 import { getAddress } from "ethers";
-import {
+import type {
   VerificationStatus,
   VerificationExport,
 } from "@ethereum-sourcify/lib-sourcify";

--- a/services/server/src/server/services/workers/verificationWorker.ts
+++ b/services/server/src/server/services/workers/verificationWorker.ts
@@ -1,17 +1,18 @@
 import Piscina from "piscina";
-import {
+import type {
   SolidityJsonInput,
   VyperJsonInput,
+  SourcifyChainInstance,
+  SourcifyChainMap,
+} from "@ethereum-sourcify/lib-sourcify";
+import {
   SolidityCompilation,
   VyperCompilation,
   Verification,
   SourcifyLibError,
   SourcifyChain,
-  SourcifyChainInstance,
-  SourcifyChainMap,
   SolidityMetadataContract,
   useAllSourcesAndReturnCompilation,
-  PreRunCompilation,
 } from "@ethereum-sourcify/lib-sourcify";
 import { resolve } from "path";
 import { ChainRepository } from "../../../sourcify-chain-repository";
@@ -32,7 +33,6 @@ import logger, { setLogLevel } from "../../../common/logger";
 import { getCompilationFromEtherscanResult } from "../utils/etherscan-util";
 import { asyncLocalStorage } from "../../../common/async-context";
 import SourcifyChainMock from "../utils/SourcifyChainMock";
-import type { SimilarityCandidate } from "../../types";
 import { createPreRunCompilationFromStoredCandidate } from "../utils/database-util";
 
 export const filename = resolve(__filename);

--- a/services/server/src/server/services/workers/workerTypes.ts
+++ b/services/server/src/server/services/workers/workerTypes.ts
@@ -7,7 +7,7 @@ import type {
   EtherscanResult,
 } from "@ethereum-sourcify/lib-sourcify";
 import { type MatchingErrorResponse } from "../../apiv2/errors";
-import { JobErrorData } from "../utils/database-util";
+import type { JobErrorData } from "../utils/database-util";
 import type { SimilarityCandidate } from "../../types";
 
 export interface VerificationWorkerInput {

--- a/services/server/src/server/session.ts
+++ b/services/server/src/server/session.ts
@@ -1,6 +1,6 @@
 import session from "express-session";
 import logger from "../common/logger";
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 export default function getSessionMiddleware(
   sessionOptions: session.SessionOptions,

--- a/services/server/src/server/types.ts
+++ b/services/server/src/server/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CompiledContractCborAuxdata,
   Devdoc,
   ImmutableReferences,
@@ -17,12 +17,15 @@ import {
   VyperOutputSource,
   SolidityOutputSource,
 } from "@ethereum-sourcify/lib-sourcify";
-import { Response } from "express";
-import { JsonFragment } from "ethers";
-import { ProxyDetectionResult } from "./services/utils/proxy-contract-util";
-import { GenericErrorResponse, MatchingErrorResponse } from "./apiv2/errors";
-import { SignatureType } from "./services/utils/signature-util";
-import { GetSourcifyMatchByChainAddressWithPropertiesResult } from "./services/utils/database-util";
+import type { Response } from "express";
+import type { JsonFragment } from "ethers";
+import type { ProxyDetectionResult } from "./services/utils/proxy-contract-util";
+import type {
+  GenericErrorResponse,
+  MatchingErrorResponse,
+} from "./apiv2/errors";
+import type { SignatureType } from "./services/utils/signature-util";
+import type { GetSourcifyMatchByChainAddressWithPropertiesResult } from "./services/utils/database-util";
 
 // Types used internally by the server.
 

--- a/services/server/src/sourcify-chain-repository.ts
+++ b/services/server/src/sourcify-chain-repository.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SourcifyChain,
   SourcifyChainMap,
 } from "@ethereum-sourcify/lib-sourcify";

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -1,5 +1,4 @@
-import {
-  SourcifyChain,
+import type {
   SourcifyChainMap,
   Chain,
   APIKeyRPC,
@@ -8,6 +7,7 @@ import {
   SourcifyChainExtension,
   SourcifyRpc,
 } from "@ethereum-sourcify/lib-sourcify";
+import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import chainsRaw from "./chains.json";
 import rawSourcifyChainExtentions from "./sourcify-chains-default.json";
 import logger from "./common/logger";

--- a/services/server/test/chains/etherscan-instances.spec.ts
+++ b/services/server/test/chains/etherscan-instances.spec.ts
@@ -6,7 +6,7 @@ import { hookIntoVerificationWorkerRun } from "../helpers/helpers";
 import chai, { request } from "chai";
 import { ServerFixture } from "../helpers/ServerFixture";
 import { ChainRepository } from "../../src/sourcify-chain-repository";
-import { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
+import type { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
 import { assertJobVerification } from "../helpers/assertions";
 import { toMatchLevel } from "../../src/server/services/utils/util";
 import sinon from "sinon";

--- a/services/server/test/helpers/LocalChainFixture.ts
+++ b/services/server/test/helpers/LocalChainFixture.ts
@@ -1,18 +1,20 @@
 import path from "path";
 import fs from "fs";
+import type { DeploymentInfo } from "./helpers";
 import {
   deployFromAbiAndBytecodeForCreatorTxHash,
-  DeploymentInfo,
   readFilesFromDirectory,
 } from "./helpers";
-import { JsonRpcProvider, JsonRpcSigner, Network } from "ethers";
+import type { JsonRpcSigner } from "ethers";
+import { JsonRpcProvider, Network } from "ethers";
 import { LOCAL_CHAINS } from "../../src/sourcify-chains";
 import nock from "nock";
 import storageContractArtifact from "../testcontracts/Storage/Storage.json";
 import storageContractMetadata from "../testcontracts/Storage/metadata.json";
 import storageContractMetadataModified from "../testcontracts/Storage/metadataModified.json";
 import storageJsonInput from "../testcontracts/Storage/StorageJsonInput.json";
-import { ChildProcess, spawn } from "child_process";
+import type { ChildProcess } from "child_process";
+import { spawn } from "child_process";
 import treeKill from "tree-kill";
 import { SolidityMetadataContract } from "@ethereum-sourcify/lib-sourcify";
 import type { Metadata } from "@ethereum-sourcify/lib-sourcify";

--- a/services/server/test/helpers/ServerFixture.ts
+++ b/services/server/test/helpers/ServerFixture.ts
@@ -1,21 +1,20 @@
 import rimraf from "rimraf";
 import { resetDatabase } from "../helpers/helpers";
-import { Server, ServerOptions } from "../../src/server/server";
+import type { ServerOptions } from "../../src/server/server";
+import { Server } from "../../src/server/server";
 import config from "config";
 import { sourcifyChainsMap } from "../../src/sourcify-chains";
-import {
-  RWStorageIdentifiers,
-  StorageIdentifiers,
-} from "../../src/server/services/storageServices/identifiers";
+import type { StorageIdentifiers } from "../../src/server/services/storageServices/identifiers";
+import { RWStorageIdentifiers } from "../../src/server/services/storageServices/identifiers";
 import { Pool } from "pg";
-import { SourcifyDatabaseService } from "../../src/server/services/storageServices/SourcifyDatabaseService";
+import type { SourcifyDatabaseService } from "../../src/server/services/storageServices/SourcifyDatabaseService";
 import genFunc from "connect-pg-simple";
 import expressSession from "express-session";
 import { SolcLocal } from "../../src/server/services/compiler/local/SolcLocal";
 import { VyperLocal } from "../../src/server/services/compiler/local/VyperLocal";
 import path from "path";
 import { testS3Bucket, testS3Path } from "./S3ClientMock";
-import { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
 
 export type ServerFixtureOptions = {
   port: number;

--- a/services/server/test/helpers/assertions.ts
+++ b/services/server/test/helpers/assertions.ts
@@ -6,15 +6,15 @@ import fs from "fs";
 import { getAddress, id } from "ethers";
 import type { Response } from "superagent";
 import type { Done } from "mocha";
-import { Pool } from "pg";
-import {
+import type { Pool } from "pg";
+import type {
   Transformation,
   TransformationValues,
   VerificationStatus,
 } from "@ethereum-sourcify/lib-sourcify";
-import { ServerFixture } from "./ServerFixture";
+import type { ServerFixture } from "./ServerFixture";
 import { getMatchStatus } from "../../src/server/apiv1/controllers.common";
-import { MatchLevel } from "../../src/server/types";
+import type { MatchLevel } from "../../src/server/types";
 import { toVerificationStatus } from "../../src/server/services/utils/util";
 import chaiHttp from "chai-http";
 

--- a/services/server/test/helpers/common-tests.ts
+++ b/services/server/test/helpers/common-tests.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
-import { ServerFixture } from "./ServerFixture";
+import type { ServerFixture } from "./ServerFixture";
 import chaiHttp from "chai-http";
-import { hookIntoVerificationWorkerRun } from "./helpers";
+import type { hookIntoVerificationWorkerRun } from "./helpers";
 
 chai.use(chaiHttp);
 

--- a/services/server/test/helpers/etherscanResponseMocks.ts
+++ b/services/server/test/helpers/etherscanResponseMocks.ts
@@ -1,5 +1,5 @@
 import nock from "nock";
-import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 
 export const mockEtherscanApi = (
   sourcifyChain: SourcifyChain,

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -1,24 +1,22 @@
 import config from "config";
-import {
-  ContractFactory,
-  Wallet,
+import type {
   JsonRpcSigner,
   JsonFragment,
   JsonRpcProvider,
   BytesLike,
-  Contract,
 } from "ethers";
+import { ContractFactory, Wallet, Contract } from "ethers";
 import { assertVerificationSession, assertVerification } from "./assertions";
 import chai, { expect } from "chai";
 import chaiHttp from "chai-http";
 import path from "path";
 import { promises as fs, readFileSync } from "fs";
-import { ServerFixture } from "./ServerFixture";
+import type { ServerFixture } from "./ServerFixture";
 import type { Done } from "mocha";
-import { LocalChainFixture } from "./LocalChainFixture";
-import { Pool } from "pg";
+import type { LocalChainFixture } from "./LocalChainFixture";
+import type { Pool } from "pg";
 import sinon from "sinon";
-import { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
+import type { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
 
 chai.use(chaiHttp);
 

--- a/services/server/test/integration/apiv1/verification-handlers/etherscan.spec.ts
+++ b/services/server/test/integration/apiv1/verification-handlers/etherscan.spec.ts
@@ -29,7 +29,7 @@ import {
   VYPER_SINGLE_CONTRACT_RESPONSE,
   VYPER_STANDARD_JSON_CONTRACT_RESPONSE,
 } from "../../../helpers/etherscanResponseMocks";
-import { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
+import type { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
 
 chai.use(chaiHttp);
 

--- a/services/server/test/integration/apiv1/verification-handlers/vyper.stateless.spec.ts
+++ b/services/server/test/integration/apiv1/verification-handlers/vyper.stateless.spec.ts
@@ -13,11 +13,9 @@ import {
 } from "../../../helpers/assertions";
 import chaiHttp from "chai-http";
 import { StatusCodes } from "http-status-codes";
-import { VerifyVyperRequest } from "../../../../src/server/apiv1/verification/vyper/stateless/vyper.stateless.handlers";
-import {
-  AuxdataTransformation,
-  VyperSettings,
-} from "@ethereum-sourcify/lib-sourcify";
+import type { VerifyVyperRequest } from "../../../../src/server/apiv1/verification/vyper/stateless/vyper.stateless.handlers";
+import type { VyperSettings } from "@ethereum-sourcify/lib-sourcify";
+import { AuxdataTransformation } from "@ethereum-sourcify/lib-sourcify";
 import contractArtifact from "../../../sources/vyper/testcontract/artifact.json";
 
 chai.use(chaiHttp);

--- a/services/server/test/integration/apiv2/jobs.spec.ts
+++ b/services/server/test/integration/apiv2/jobs.spec.ts
@@ -1,15 +1,13 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
 import { ServerFixture } from "../../helpers/ServerFixture";
-import { VerificationJob } from "../../../src/server/types";
+import type { VerificationJob } from "../../../src/server/types";
 import { v4 as uuidv4 } from "uuid";
 import { LocalChainFixture } from "../../helpers/LocalChainFixture";
-import {
-  getVerificationErrorMessage,
-  MatchingErrorResponse,
-} from "../../../src/server/apiv2/errors";
+import type { MatchingErrorResponse } from "../../../src/server/apiv2/errors";
+import { getVerificationErrorMessage } from "../../../src/server/apiv2/errors";
 import { verifyContract } from "../../helpers/helpers";
-import { JobErrorData } from "../../../src/server/services/utils/database-util";
+import type { JobErrorData } from "../../../src/server/services/utils/database-util";
 
 chai.use(chaiHttp);
 

--- a/services/server/test/integration/apiv2/lookup/all-chains.spec.ts
+++ b/services/server/test/integration/apiv2/lookup/all-chains.spec.ts
@@ -4,10 +4,8 @@ import { deployAndVerifyContract } from "../../../helpers/helpers";
 import { LocalChainFixture } from "../../../helpers/LocalChainFixture";
 import { ServerFixture } from "../../../helpers/ServerFixture";
 import { getAddress } from "ethers";
-import {
-  SourcifyChain,
-  SourcifyChainMap,
-} from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
+import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 
 chai.use(chaiHttp);
 

--- a/services/server/test/integration/apiv2/lookup/contract-details.spec.ts
+++ b/services/server/test/integration/apiv2/lookup/contract-details.spec.ts
@@ -1,8 +1,8 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
+import type { DeploymentInfo } from "../../../helpers/helpers";
 import {
   deployFromAbiAndBytecode,
-  DeploymentInfo,
   verifyContract,
 } from "../../../helpers/helpers";
 import { LocalChainFixture } from "../../../helpers/LocalChainFixture";
@@ -14,7 +14,7 @@ import { getAddress } from "ethers";
 import Sinon from "sinon";
 import * as proxyContractUtil from "../../../../src/server/services/utils/proxy-contract-util";
 import { extractSignaturesFromAbi } from "../../../../src/server/services/utils/signature-util";
-import { SignatureRepresentations } from "../../../../src/server/types";
+import type { SignatureRepresentations } from "../../../../src/server/types";
 
 chai.use(chaiHttp);
 

--- a/services/server/test/integration/apiv2/verification/compiler-versions/verify.compiler-versions.spec.ts
+++ b/services/server/test/integration/apiv2/verification/compiler-versions/verify.compiler-versions.spec.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
-import { SolidityJsonInput } from "@ethereum-sourcify/compilers-types";
+import type { SolidityJsonInput } from "@ethereum-sourcify/compilers-types";
 import {
   deployFromAbiAndBytecodeForCreatorTxHash,
   hookIntoVerificationWorkerRun,

--- a/services/server/test/integration/apiv2/verification/verify.etherscan.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.etherscan.spec.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../helpers/etherscanResponseMocks";
 import { sourcifyChainsMap } from "../../../../src/sourcify-chains";
 import testContracts from "../../../helpers/etherscanInstanceContracts.json";
-import { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
+import type { VerificationStatus } from "@ethereum-sourcify/lib-sourcify";
 import { toMatchLevel } from "../../../../src/server/services/utils/util";
 import {
   testAlreadyBeingVerified,

--- a/services/server/test/integration/apiv2/verification/verify.similarity.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.similarity.spec.ts
@@ -7,7 +7,7 @@ import {
   deployFromAbiAndBytecodeForCreatorTxHash,
   hookIntoVerificationWorkerRun,
 } from "../../../helpers/helpers";
-import { SourcifyDatabaseService } from "../../../../src/server/services/storageServices/SourcifyDatabaseService";
+import type { SourcifyDatabaseService } from "../../../../src/server/services/storageServices/SourcifyDatabaseService";
 import { MockVerificationExport } from "../../../helpers/mocks";
 import { assertJobVerification } from "../../../helpers/assertions";
 import {

--- a/services/server/test/integration/database.spec.ts
+++ b/services/server/test/integration/database.spec.ts
@@ -8,7 +8,7 @@ import type { MetadataSourceMap } from "@ethereum-sourcify/lib-sourcify";
 import { Database } from "../../src/server/services/utils/Database";
 import { bytesFromString } from "../../src/server/services/utils/database-util";
 import crypto from "crypto";
-import { Bytes } from "../../src/server/types";
+import type { Bytes } from "../../src/server/types";
 import sinon from "sinon";
 import { assertVerification } from "../helpers/assertions";
 import path from "path";

--- a/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
+++ b/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
@@ -6,7 +6,7 @@ import { MockVerificationExport } from "../../helpers/mocks";
 import { resetDatabase } from "../../helpers/helpers";
 import sinon from "sinon";
 import * as signatureUtil from "../../../src/server/services/utils/signature-util";
-import { QueryResult } from "pg";
+import type { QueryResult } from "pg";
 import {
   bytesFromString,
   type Tables,

--- a/services/server/test/unit/VerificationService.spec.ts
+++ b/services/server/test/unit/VerificationService.spec.ts
@@ -9,7 +9,7 @@ import rimraf from "rimraf";
 import { StorageService } from "../../src/server/services/StorageService";
 import { RWStorageIdentifiers } from "../../src/server/services/storageServices/identifiers";
 import sinon from "sinon";
-import { EtherscanResult } from "@ethereum-sourcify/lib-sourcify";
+import type { EtherscanResult } from "@ethereum-sourcify/lib-sourcify";
 
 describe("VerificationService", function () {
   const sandbox = sinon.createSandbox();

--- a/services/server/test/unit/apiv2/middlewares.spec.ts
+++ b/services/server/test/unit/apiv2/middlewares.spec.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { validateCompilerVersion } from "../../../src/server/apiv2/middlewares";

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../src/server/services/utils/contract-creation-util";
 import { sourcifyChainsMap } from "../../../src/sourcify-chains";
 import { ChainRepository } from "../../../src/sourcify-chain-repository";
-import { FetchContractCreationTxMethod } from "@ethereum-sourcify/lib-sourcify";
+import type { FetchContractCreationTxMethod } from "@ethereum-sourcify/lib-sourcify";
 import sinon from "sinon";
 import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import { findContractCreationTxByBinarySearch } from "../../../src/server/services/utils/contract-creation-util";

--- a/services/server/test/unit/utils/signature-util.spec.ts
+++ b/services/server/test/unit/utils/signature-util.spec.ts
@@ -1,6 +1,7 @@
 import chai from "chai";
 import { extractSignaturesFromAbi } from "../../../src/server/services/utils/signature-util";
-import { JsonFragment, id as keccak256str } from "ethers";
+import type { JsonFragment } from "ethers";
+import { id as keccak256str } from "ethers";
 
 describe("signature-util", function () {
   describe("extractSignaturesFromAbi", function () {

--- a/services/server/test/unit/verificationWorker.spec.ts
+++ b/services/server/test/unit/verificationWorker.spec.ts
@@ -15,19 +15,19 @@ import {
   type SourcifyChainInstance,
   type SolidityJsonInput,
   type SoliditySettings,
-  OutputError,
 } from "@ethereum-sourcify/lib-sourcify";
 import { getAddress } from "ethers";
-import { VerifyOutput } from "../../src/server/services/workers/workerTypes";
-import {
-  deployFromAbiAndBytecodeForCreatorTxHash,
-  DeploymentInfo,
-} from "../helpers/helpers";
-import { JobErrorData } from "../../src/server/services/utils/database-util";
+import type { VerifyOutput } from "../../src/server/services/workers/workerTypes";
+import type { DeploymentInfo } from "../helpers/helpers";
+import { deployFromAbiAndBytecodeForCreatorTxHash } from "../helpers/helpers";
+import type { JobErrorData } from "../../src/server/services/utils/database-util";
 import { SolcLocal } from "../../src/server/services/compiler/local/SolcLocal";
-import type { SolidityOutput } from "@ethereum-sourcify/lib-sourcify";
+import type {
+  SolidityOutput,
+  OutputError,
+} from "@ethereum-sourcify/lib-sourcify";
 import type { SimilarityCandidate } from "../../src/server/types";
-import { VerificationErrorCode } from "../../src/server/apiv2/errors";
+import type { VerificationErrorCode } from "../../src/server/apiv2/errors";
 
 chai.use(chaiHttp);
 


### PR DESCRIPTION
Came to my mind during the review of #2481. It's just adding a rule but a great improvement for the runtime code since we can enforce that any import for typing is pruned from the javascript output.