### PR TITLE
Change JOIN to LEFT JOIN for compiled_contracts_signatures in query

### DIFF
--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -235,7 +235,7 @@ ${
   properties.includes("event_signatures") ||
   properties.includes("error_signatures")
     ? `
-        JOIN ${this.schema}.compiled_contracts_signatures ON compiled_contracts_signatures.compilation_id = compiled_contracts.id
+        LEFT JOIN ${this.schema}.compiled_contracts_signatures ON compiled_contracts_signatures.compilation_id = compiled_contracts.id
         LEFT JOIN ${this.schema}.signatures ON signatures.signature_hash_32 = compiled_contracts_signatures.signature_hash_32
       `
     : ""


### PR DESCRIPTION
This PR fixes this case: https://github.com/argotorg/sourcify/issues/2483 (contract not returning in lookup api with ?fields=all)

The contract in the example in 2483 has only a constructor and a fallback method, so there are no signatures stored. we should use `LEFT JOIN` to handle such cases, otherwise the query will return 0 rows