### PR TITLE
Update PulseChain's fetchContractCreationTxUsing blockscout API link

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -204,8 +204,8 @@
     "sourcifyName": "PulseChain Mainnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://scan.pulsechain.com/"
+      "blockscoutApi": {
+        "url": "https://api.scan.pulsechain.com/"
       }
     }
   },


### PR DESCRIPTION
The current `fetchContractCreationTxUsing` for PulseChain  is not working anymore, also it is using the Blockscout scraping method instead of the API method.

This PR adds a working `blockscoutApi` configuration for PulseChain mainnet