### PR TITLE
Clean up PulseChain RPC URLs in chains.json

### DIFF
--- a/services/server/src/chains.json
+++ b/services/server/src/chains.json
@@ -6607,11 +6607,9 @@
     "infoURL": "https://pulsechain.com/",
     "rpc": [
       "https://rpc.pulsechain.com",
-      "wss://rpc.pulsechain.com",
       "https://pulsechain-rpc.publicnode.com",
       "wss://pulsechain-rpc.publicnode.com",
-      "https://rpc-pulsechain.g4mm4.io",
-      "wss://rpc-pulsechain.g4mm4.io"
+      "https://rpc-pulsechain.g4mm4.io"
     ],
     "icon": "pulsechain",
     "slip44": 60,


### PR DESCRIPTION
Removed no longer available WebSocket RPC URLs.


