### PR TITLE
Add contractApiUrl to externalVerifcations returned properties

### DIFF
--- a/services/server/src/server/services/storageServices/EtherscanVerifyApiService.ts
+++ b/services/server/src/server/services/storageServices/EtherscanVerifyApiService.ts
@@ -324,18 +324,27 @@ export const buildJobExternalVerificationsObject = (
     }
 
     let statusUrl;
+    let contractApiUrl;
     if (
       verifierData.verificationId &&
       // We need to handle the special case for a blockscout already verified contract
       verifierData.verificationId !== VERIFIER_ALREADY_VERIFIED
     ) {
       try {
-        const apiBaseUrl = verifierService?.getApiUrl(
+        const statusApiBaseUrl = verifierService?.getApiUrl(
           "checkverifystatus",
           parseInt(chainId),
         );
-        if (apiBaseUrl) {
-          statusUrl = `${apiBaseUrl}&guid=${encodeURIComponent(verifierData.verificationId)}`;
+        if (statusApiBaseUrl) {
+          statusUrl = `${statusApiBaseUrl}&guid=${encodeURIComponent(verifierData.verificationId)}`;
+        }
+
+        const contractApiBaseUrl = verifierService?.getApiUrl(
+          "getabi",
+          parseInt(chainId),
+        );
+        if (contractApiBaseUrl) {
+          contractApiUrl = `${contractApiBaseUrl}&address=${address}`;
         }
       } catch (error) {
         // Cannot generate url
@@ -362,6 +371,7 @@ export const buildJobExternalVerificationsObject = (
       error: verifierData.error,
       statusUrl,
       explorerUrl,
+      contractApiUrl,
     };
 
     switch (verifier) {

--- a/services/server/src/server/types.ts
+++ b/services/server/src/server/types.ts
@@ -131,6 +131,7 @@ export type VerificationJobId = string;
 export type ApiExternalVerification = ExternalVerification & {
   statusUrl?: string;
   explorerUrl?: string;
+  contractApiUrl?: string;
 };
 
 export interface ApiExternalVerifications {

--- a/services/server/test/integration/apiv2/jobs.spec.ts
+++ b/services/server/test/integration/apiv2/jobs.spec.ts
@@ -130,6 +130,9 @@ describe("GET /v2/verify/:verificationId", function () {
           explorerUrl:
             "https://etherscan.io/address/" +
             chainFixture.defaultContractAddress,
+          contractApiUrl:
+            "https://api.etherscan.io/api?module=contract&action=getabi&chainid=31337&address=" +
+            chainFixture.defaultContractAddress,
         },
         blockscout: {
           verificationId: "VERIFIER_ALREADY_VERIFIED",


### PR DESCRIPTION
In order to display the contract verification status in the UI, we need to call an Etherscan endpoint to retrieve information about the contract, checking its existence.

With this PR we add `contractApiUrl` as an additional property of the externalVerifications object, together with statusUrl (to check the status of the verification) and `explorerUrl` (link to the explorer contract's page): this new property contains a link to the `getabi` endpoint, that the user can call to check the existence of the contract on the explorer.