### PR TITLE
Add Datadog Synthetic tests workflow

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -1,0 +1,38 @@
+# This workflow will trigger Datadog Synthetic tests within your Datadog organisation
+# For more information on running Synthetic tests within your GitHub workflows see: https://docs.datadoghq.com/synthetics/cicd_integrations/github_actions/
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# To get started:
+
+# 1. Add your Datadog API (DD_API_KEY) and Application Key (DD_APP_KEY) as secrets to your GitHub repository. For more information, see: https://docs.datadoghq.com/account_management/api-app-keys/.
+# 2. Start using the action within your workflow
+
+name: Run Datadog Synthetic tests
+
+on:
+  push:
+    branches: [ "staging" ]
+  pull_request:
+    branches: [ "staging" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Run Synthetic tests within your GitHub workflow.
+    # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
+    - name: Run Datadog Synthetic tests
+      uses: DataDog/synthetics-ci-github-action@87b505388a22005bb8013481e3f73a367b9a53eb # v1.4.0
+      with:
+        api_key: ${{secrets.DD_API_KEY}}
+        app_key: ${{secrets.DD_APP_KEY}}
+        test_search_query: 'tag:e2e-tests' #Modify this tag to suit your tagging strategy
+
+


### PR DESCRIPTION
This workflow triggers Datadog Synthetic tests on push and pull request events to the staging branch.

<!-- If you are opening a chain support request PR please follow the template below. Otherwise you can write your own PR description -->

# Add New Chain <chainId>

Thanks for your pull request to add a new support in Sourcify.

If you haven't done so, please follow the instructions on [how to request chain support](https://docs.sourcify.dev/docs/chain-support/) in docs.

Please check the following items before submitting your pull request for a speedy review.

## Checklist

- [x] The branch is named as `add-chain-<chainId>`.
- [x] I haven't modified the `chains.json` file directly.
- [x] In `sourcify-chains.json` file
  - [x] I've set `supported: true`.
  - [x] I haven't added an `rpc` field but the one in [chains.json](../../src/chains.json) is used (if not, please explain why).
- [x] I've added a test in [chain-tests.js](../../test/chains/chains-test.js) file.
- [x] `test-new-chain` test in Circle CI is passing.
