### PR TITLE
Add ethpandaops archive node rpc

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -32,6 +32,20 @@
         ]
       },
       {
+        "type": "FetchRequest",
+        "url": "https://archive.mainnet.ethpandaops.io",
+        "headers": [
+          {
+            "headerName": "CF-Access-Client-Id",
+            "headerEnvName": "CF_ACCESS_CLIENT_ID"
+          },
+          {
+            "headerName": "CF-Access-Client-Secret",
+            "headerEnvName": "CF_ACCESS_CLIENT_SECRET"
+          }
+        ]
+      },
+      {
         "type": "APIKeyRPC",
         "url": "https://eth-mainnet.g.alchemy.com/v2/{API_KEY}",
         "apiKeyEnvName": "ALCHEMY_API_KEY"


### PR DESCRIPTION
rpc.mainnet.ethpandaops.io addresses randomly one of their nodes, which is a standard full node in most cases. Full nodes don't provide tx receipts when we verify old contracts, such that a lot of requests went to Alchemy and Quicknode lately. This adds archive.mainnet.ethpandaops.io as an additional rpc to specifically request the ethpandaops archive nodes. It's added additionally to the standard rpc endpoint, because the archive endpoint is backed by less nodes and might suffer more likely from instabilities.