### PR TITLE
Remove Meter API fetching from contract creation utilities

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
@@ -32,9 +32,6 @@ export interface FetchContractCreationTxMethods {
   blocksScanApi?: {
     url: string;
   };
-  meterApi?: {
-    url: string;
-  };
   telosApi?: {
     url: string;
   };

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -13,7 +13,6 @@ const ETHERSCAN_API =
 const BLOCKSSCAN_SUFFIX = "api/accounts/${ADDRESS}";
 const BLOCKSCOUT_API_SUFFIX = "/api/v2/addresses/${ADDRESS}";
 const TELOS_SUFFIX = "v1/contract/${ADDRESS}";
-const METER_SUFFIX = "api/accounts/${ADDRESS}";
 const AVALANCHE_SUBNET_SUFFIX =
   "contracts/${ADDRESS}/transactions:getDeployment";
 const NEXUS_SUFFIX = "v1/${RUNTIME}/accounts/${ADDRESS}";
@@ -129,17 +128,6 @@ function getBlocksScanApiContractCreatorFetcher(
     apiURL + BLOCKSSCAN_SUFFIX,
     (response: any) => {
       if (response.fromTxn) return response.fromTxn as string;
-    },
-  );
-}
-
-function getMeterApiContractCreatorFetcher(
-  apiURL: string,
-): ContractCreationFetcher {
-  return getApiContractCreationFetcher(
-    apiURL + METER_SUFFIX,
-    (response: any) => {
-      return response.account.creationTxHash as string;
     },
   );
 }
@@ -337,15 +325,6 @@ export const getCreatorTx = async (
   if (sourcifyChain.fetchContractCreationTxUsing?.blocksScanApi) {
     const fetcher = getBlocksScanApiContractCreatorFetcher(
       sourcifyChain.fetchContractCreationTxUsing?.blocksScanApi.url,
-    );
-    const result = await getCreatorTxUsingFetcher(fetcher, contractAddress);
-    if (result) {
-      return result;
-    }
-  }
-  if (sourcifyChain.fetchContractCreationTxUsing?.meterApi) {
-    const fetcher = getMeterApiContractCreatorFetcher(
-      sourcifyChain.fetchContractCreationTxUsing?.meterApi.url,
     );
     const result = await getCreatorTxUsingFetcher(fetcher, contractAddress);
     if (result) {

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -293,21 +293,11 @@
   },
   "82": {
     "sourcifyName": "Meter Mainnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "meterApi": {
-        "url": "https://api.meter.io:8000/"
-      }
-    }
+    "supported": true
   },
   "83": {
     "sourcifyName": "Meter Testnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "meterApi": {
-        "url": "https://api.meter.io:4000/"
-      }
-    }
+    "supported": true
   },
   "97": {
     "sourcifyName": "Binance Smart Chain Testnet",

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -51,26 +51,6 @@ describe("contract creation util", function () {
   //     );
   // });
 
-  it("should run getCreatorTx with chainId 83", async function () {
-    const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
-      .sourcifyChainsArray;
-    const sourcifyChain = sourcifyChainsArray.find(
-      (sourcifyChain) => sourcifyChain.chainId === 83,
-    );
-    if (!sourcifyChain) {
-      chai.assert.fail("No chain for chainId 83 configured");
-    }
-    const creatorTx = await getCreatorTx(
-      sourcifyChain,
-      "0x89e772941d94Ef4BDA1e4f68E79B4bc5F6096389",
-    );
-    chai
-      .expect(creatorTx)
-      .equals(
-        "0x8cc7b0fb66eaf7b32bac7b7938aedfcec6d49f9fe607b8008a5541e72d264069",
-      );
-  });
-
   it("should run getCreatorTx with chainId 335", async function () {
     const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
       .sourcifyChainsArray;


### PR DESCRIPTION
The Meter API has been constantly failing for a while in the CI. This counts not only for now, but it has also been unreliable in the past. When looking at the Meter project on GitHub and X it looks relatively dead. I don't think we should support a custom creation method like this.