### PR TITLE
Tempo-Moderato-42431

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -2444,25 +2444,36 @@
       "etherscanApi": true
     }
   },
-  "42431": {
-    "sourcifyName": "Tempo Moderato Testnet",
-    "supported": true,
-    "rpc": [
-      "https://rpc.moderato.tempo.xyz"
-    ],
-    "nativeCurrency": {
-      "name": "USD",
-      "symbol": "USD",
-      "decimals": 6
+  {
+  "name": "Tempo Moderato Testnet",
+  "chain": "TEMPO",
+  "icon": "tempo",
+  "rpc": [
+    "https://rpc.moderato.tempo.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "USD",
+    "symbol": "USD",
+    "decimals": 6
+  },
+  "infoURL": "https://tempo.xyz",
+  "shortName": "moderato",
+  "chainId": 42431,
+  "networkId": 42431,
+  "network": "testnet",
+  "slip44": 1,
+  "ens": {},
+  "explorers": [
+    {
+      "name": "Tempo Explorer",
+      "url": "https://explore.tempo.xyz",
+      "standard": "EIP3091"
     },
-    "chainId": 42431,
-    "networkId": 42431,
-    "explorers": [
-      {
-        "name": "Tempo Explorer",
-        "url": "https://explore.tempo.xyz",
-        "standard": "EIP3091"
-      }
-    ]
-  }
+    {
+      "name": "Tempo Scout",
+      "url": "https://scout.tempo.xyz",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
​Hi Sourcify team,​I'm adding the Tempo Moderato Testnet to the supported chains.
​Chain ID: 42431
​RPC: https://rpc.moderato.tempo.xyz/
​Native Currency: USD (6 decimals)
​Explorer: https://explore.tempo.xyz/
​The network is live and I have already performed successful contract deployments on it.