### PR TITLE
Replace toBeHex with toQuantity for block number conversion in SourcifyChain

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -6,7 +6,7 @@ import {
   TransactionReceipt,
   TransactionResponse,
   getAddress,
-  toBeHex,
+  toQuantity,
 } from 'ethers';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
 import type {
@@ -511,7 +511,7 @@ export class SourcifyChain {
     const provider = rpc.provider;
 
     const traces = await this.callProviderWithTimeout(
-      provider.send('trace_block', [toBeHex(blockNumber)]),
+      provider.send('trace_block', [toQuantity(blockNumber)]),
       rpc.maskedUrl,
     );
 
@@ -624,7 +624,7 @@ export class SourcifyChain {
 
     const traces = await this.callProviderWithTimeout(
       provider.send('debug_traceBlockByNumber', [
-        toBeHex(blockNumber),
+        toQuantity(blockNumber),
         { tracer: 'callTracer' },
       ]),
       rpc.maskedUrl,


### PR DESCRIPTION
RPCs are returning: "invalid argument 0: hex number with leading zero digits".
Currently monitor produces a lot of errors in the logs on staging due to this.

toQuantity is the correct method for providing numbers to rpcs because it does not produce leading 0s.