### PR TITLE
Improve log levels

### DIFF
--- a/packages/compilers/src/lib/solidityCompiler.ts
+++ b/packages/compilers/src/lib/solidityCompiler.ts
@@ -71,7 +71,7 @@ export async function useSolidityCompiler(
   }
   let startCompilation: number;
   if (solcPath && !forceEmscripten) {
-    logInfo('Compiling with solc binary', { version, solcPath });
+    logDebug('Compiling with solc binary', { version, solcPath });
     startCompilation = Date.now();
     try {
       compiled = await asyncExec(
@@ -86,7 +86,7 @@ export async function useSolidityCompiler(
       throw error;
     }
   } else {
-    logInfo('Compiling with solc-js', { version });
+    logDebug('Compiling with solc-js', { version });
     const solJson = await getSolcJs(solJsonRepoPath, version);
     startCompilation = Date.now();
     if (solJson) {
@@ -115,7 +115,7 @@ export async function useSolidityCompiler(
   }
 
   const endCompilation = Date.now();
-  logInfo('Local compiler - Compilation done', {
+  logDebug('Local compiler - Compilation done', {
     compiler: 'solidity',
     timeInMs: endCompilation - startCompilation,
   });

--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -19,7 +19,7 @@ import type {
   VyperOutput,
   VyperOutputContract,
 } from '@ethereum-sourcify/compilers-types';
-import { logInfo, logSilly, logWarn } from '../logger';
+import { logDebug, logInfo, logSilly, logWarn } from '../logger';
 
 function cleanCompilerVersion(version: string): string {
   // Remove non-numerical characters from the beginning of the version string
@@ -69,7 +69,7 @@ export abstract class AbstractCompilation {
     const version = this.compilerVersion;
 
     const compilationStartTime = Date.now();
-    logInfo('Compiling contract', {
+    logDebug('Compiling contract', {
       version,
       contract: this.compilationTarget.name,
       path: this.compilationTarget.path,

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -8,7 +8,7 @@ import {
   getAddress,
   toQuantity,
 } from 'ethers';
-import { logDebug, logError, logInfo, logWarn } from '../logger';
+import { logDebug, logInfo, logWarn } from '../logger';
 import type {
   CallFrame,
   FetchContractCreationTxMethods,
@@ -217,7 +217,7 @@ export class SourcifyChain {
           continue;
         }
 
-        logError('RPC operation threw error', {
+        logInfo('RPC operation threw error', {
           operation: operationName,
           error,
           maskedUrl: rpc.maskedUrl,
@@ -228,7 +228,7 @@ export class SourcifyChain {
       }
     }
 
-    logError('All RPCs failed or are blocked', {
+    logInfo('All RPCs failed or are blocked', {
       operation: operationName,
       chainId: this.chainId,
     });
@@ -275,7 +275,7 @@ export class SourcifyChain {
         return { tryNext: true };
       }
 
-      logInfo('Fetching tx', {
+      logDebug('Fetching tx', {
         creatorTxHash,
         maskedProviderUrl: rpc.maskedUrl,
       });
@@ -409,7 +409,7 @@ export class SourcifyChain {
           if (e instanceof RpcFailure) {
             throw e;
           }
-          logWarn('Failed to fetch from parity traces', {
+          logInfo('Failed to fetch from parity traces', {
             maskedProviderUrl: rpc.maskedUrl,
             chainId: this.chainId,
             error: e.message,
@@ -432,7 +432,7 @@ export class SourcifyChain {
           if (e instanceof RpcFailure) {
             throw e;
           }
-          logWarn('Failed to fetch from geth traces', {
+          logInfo('Failed to fetch from geth traces', {
             maskedProviderUrl: rpc.maskedUrl,
             chainId: this.chainId,
             error: e.message,
@@ -464,7 +464,7 @@ export class SourcifyChain {
     );
 
     if (traces instanceof Array && traces.length > 0) {
-      logInfo('Fetched tx traces for creation tx hash', {
+      logDebug('Fetched tx traces for creation tx hash', {
         creatorTxHash,
         maskedProviderUrl: rpc.maskedUrl,
         chainId: this.chainId,
@@ -516,7 +516,7 @@ export class SourcifyChain {
     );
 
     if (traces instanceof Array && traces.length > 0) {
-      logInfo('Fetched tx traces for block number', {
+      logDebug('Fetched tx traces for block number', {
         blockNumber,
         maskedProviderUrl: rpc.maskedUrl,
         chainId: this.chainId,
@@ -574,7 +574,7 @@ export class SourcifyChain {
     );
 
     if (traces?.calls instanceof Array && traces.calls.length > 0) {
-      logInfo('Fetched tx traces for creation tx hash', {
+      logDebug('Fetched tx traces for creation tx hash', {
         creatorTxHash,
         maskedProviderUrl: rpc.maskedUrl,
         chainId: this.chainId,
@@ -631,7 +631,7 @@ export class SourcifyChain {
     );
 
     if (traces instanceof Array && traces.length > 0) {
-      logInfo('Fetched tx traces for block number', {
+      logDebug('Fetched tx traces for block number', {
         blockNumber,
         maskedProviderUrl: rpc.maskedUrl,
         chainId: this.chainId,
@@ -860,6 +860,13 @@ export class SourcifyChain {
       );
     }
 
+    logInfo('Fetched creation bytecode', {
+      address,
+      transactionHash,
+      bytecodeLength: creationBytecode.length,
+      bytecodeStart: creationBytecode.slice(0, 32),
+      chainId: this.chainId,
+    });
     return {
       creationBytecode,
       txReceipt,


### PR DESCRIPTION
A few changes to make the gcp logs less verbose:

- Reduce log level in SourcifyChain for cases where errors can be expected
- Reduce log levels in solidityCompiler and AbstractCompilation to only log once for each compilation of a verification
- Fixed the EtherscanVerifyApiService to not log twice on submission error
- Added a log in SourcifyChain when creation bytecode is fetched to match runtime code fetching

(following https://github.com/argotorg/sourcify/pull/2585#discussion_r2691113257)