### PR TITLE
Replace contract creation fetching via Etherscan with Blockscout for Arbitrum Nova

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -1467,11 +1467,9 @@
     "sourcifyName": "Arbitrum Nova",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "etherscanApi": true
-    },
-    "etherscanApi": {
-      "supported": true,
-      "apiKeyEnvName": "ETHERSCAN_API_KEY_ARBITRUM_NOVA"
+      "blockscoutApi": {
+        "url": "https://arbitrum-nova.blockscout.com/"
+      }
     },
     "rpc": [
       "https://nova.arbitrum.io/rpc",

--- a/services/server/test/helpers/etherscanInstanceContracts.json
+++ b/services/server/test/helpers/etherscanInstanceContracts.json
@@ -376,23 +376,6 @@
       "expectedStatus": "perfect"
     }
   ],
-  "42170": [
-    {
-      "address": "0x0571d3aF023Ea8eD2323758B80Dd0C8DAe2C94f4",
-      "type": "single",
-      "expectedStatus": "partial"
-    },
-    {
-      "address": "0xa7016847E0285f15bf4449a2a260b379eB517100",
-      "type": "multiple",
-      "expectedStatus": "partial"
-    },
-    {
-      "address": "0xD779479d792Ab8E94f61d6b2682a877B2868A8AD",
-      "type": "standard-json",
-      "expectedStatus": "perfect"
-    }
-  ],
   "560048": [
     {
       "address": "0x39cC8eB3F950CA5655937CFB2b01849547057E2c",


### PR DESCRIPTION
I received an e-mail from Etherscan that nova.arbiscan.io will be deprecated on Jan 31.