### PR TITLE
Fix chain explorer configurations for contract creation fetching

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -753,7 +753,7 @@
     "sourcifyName": "Aurora Testnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
+      "blockscoutApi": {
         "url": "https://explorer.testnet.aurora.dev/"
       }
     }
@@ -855,21 +855,11 @@
   },
   "9000": {
     "sourcifyName": "Evmos Testnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://testnet.evmos.explorers.guru/"
-      }
-    }
+    "supported": false
   },
   "9001": {
     "sourcifyName": "Evmos Mainnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://evm.evmos.org/"
-      }
-    }
+    "supported": false
   },
   "62621": {
     "sourcifyName": "MultiVAC Mainnet",
@@ -1011,12 +1001,7 @@
   },
   "7700": {
     "sourcifyName": "Canto Mainnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://tuber.build/"
-      }
-    }
+    "supported": true
   },
   "7701": {
     "sourcifyName": "Canto Testnet",
@@ -1050,7 +1035,7 @@
     "supported": true,
     "fetchContractCreationTxUsing": {
       "blockscoutApi": {
-        "url": "https://blockscout.chiadochain.net/"
+        "url": "https://gnosis-chiado.blockscout.com/"
       }
     }
   },
@@ -1093,8 +1078,8 @@
     "sourcifyName": "ZetaChain: Mainnet",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://zetachain.blockscout.com/"
+      "blockscoutApi": {
+        "url": "https://zetascan.com/"
       }
     }
   },
@@ -1386,12 +1371,7 @@
   },
   "2222": {
     "sourcifyName": "Kava EVM",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://explorer.kava.io/"
-      }
-    }
+    "supported": true
   },
   "32769": {
     "sourcifyName": "Zilliqa EVM",
@@ -1456,12 +1436,7 @@
   },
   "250": {
     "sourcifyName": "FTM Fantom Opera Mainnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "routescanApi": {
-        "type": "mainnet"
-      }
-    }
+    "supported": false
   },
   "42170": {
     "sourcifyName": "Arbitrum Nova",
@@ -1781,7 +1756,7 @@
     "sourcifyName": "Mode",
     "supported": true,
     "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
+      "blockscoutApi": {
         "url": "https://explorer.mode.network/"
       },
       "routescanApi": {
@@ -2197,11 +2172,6 @@
   "1516": {
     "sourcifyName": "Story Odyssey",
     "supported": false,
-    "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://odyssey.storyscan.xyz/"
-      }
-    },
     "rpc": ["https://rpc.odyssey.storyrpc.io"]
   },
   "26100": {

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -581,21 +581,21 @@ describe("Test Supported Chains", function () {
     "shared/",
   );
 
-  // Evmos Testnet
-  verifyContract(
-    "0x07Eb2490cEfc74bAEb4B13c2dB9119CA0c38959B",
-    "9000",
-    "Evmos Testnet",
-    "shared/",
-  );
+  // // Evmos Testnet
+  // verifyContract(
+  //   "0x07Eb2490cEfc74bAEb4B13c2dB9119CA0c38959B",
+  //   "9000",
+  //   "Evmos Testnet",
+  //   "shared/",
+  // );
 
-  // Evmos Mainnet
-  verifyContract(
-    "0x1d897A65A4fa98BBdfc2e94ad2357cE051Bf4a21",
-    "9001",
-    "Evmos Mainnet",
-    "shared/",
-  );
+  // // Evmos Mainnet
+  // verifyContract(
+  //   "0x1d897A65A4fa98BBdfc2e94ad2357cE051Bf4a21",
+  //   "9001",
+  //   "Evmos Mainnet",
+  //   "shared/",
+  // );
 
   // MultiVAC Mainnet
   verifyContract(
@@ -1229,13 +1229,13 @@ describe("Test Supported Chains", function () {
     "shared/",
   );
 
-  // FTM Fantom Opera Mainnet
-  verifyContract(
-    "0xc47856bEBCcc2BBB23E7a5E1Ba8bB4Fffa5C5476",
-    "250",
-    "Fantom Opera",
-    "shared/",
-  );
+  // // FTM Fantom Opera Mainnet
+  // verifyContract(
+  //   "0xc47856bEBCcc2BBB23E7a5E1Ba8bB4Fffa5C5476",
+  //   "250",
+  //   "Fantom Opera",
+  //   "shared/",
+  // );
 
   verifyContract(
     "0x4956f15efdc3dc16645e90cc356eafa65ffc65ec",


### PR DESCRIPTION
## Summary
- Upgrade `blockscoutScrape` to `blockscoutApi` for chains with working APIs (7000, 34443, 1313161555)
- Fix Gnosis Chiado (10200) URL to use working `gnosis-chiado.blockscout.com`
- Remove broken `fetchContractCreationTxUsing` configs for unreachable explorers (1516, 7700, 2222)
- Disable support for chains with non-functional explorers (250, 9000, 9001)

## Changes by Chain

| Chain ID | Name | Change |
|----------|------|--------|
| 7000 | ZetaChain | `blockscoutScrape` → `blockscoutApi` (zetascan.com) |
| 34443 | Mode | `blockscoutScrape` → `blockscoutApi` |
| 1313161555 | Aurora Testnet | `blockscoutScrape` → `blockscoutApi` |
| 10200 | Gnosis Chiado | Fixed URL to `gnosis-chiado.blockscout.com` |
| 1516 | Story Odyssey | Removed broken config |
| 7700 | Canto | Removed broken config |
| 2222 | Kava EVM | Removed broken config |
| 250 | Fantom Opera | Set `supported: false` |
| 9000 | Evmos Testnet | Set `supported: false` |
| 9001 | Evmos Mainnet | Set `supported: false` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)