### PR TITLE
Add and run lint commands to compilers-types package

### DIFF
--- a/packages/compilers-types/package.json
+++ b/packages/compilers-types/package.json
@@ -9,7 +9,13 @@
     "build": "run-p build:*",
     "build:main": "tsc -p tsconfig.json",
     "build:module": "tsc -p tsconfig.module.json",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "fix": "run-s fix:*",
+    "fix:prettier": "prettier \"./**/*.ts\" --write",
+    "fix:lint": "eslint . --ext .ts --fix",
+    "check": "run-s check:*",
+    "check:eslint": "eslint . --ext .ts",
+    "check:prettier": "prettier \"./**/*.ts\" --check"
   },
   "files": [
     "build/main",

--- a/packages/compilers-types/src/CompilationTypes.ts
+++ b/packages/compilers-types/src/CompilationTypes.ts
@@ -86,8 +86,10 @@ export interface MetadataOutput {
 
 // Metadata JSON's "settings" does have extra "compilationTarget" and its "libraries" field is in a different format
 // ( libraries["MyContract.sol:Mycontract"]:"0xab..cd" vs libraries["MyContract.sol"]["MyContract"]:"0xab..cd")
-export interface MetadataCompilerSettings
-  extends Omit<SoliditySettings, "libraries" | "outputSelection"> {
+export interface MetadataCompilerSettings extends Omit<
+  SoliditySettings,
+  "libraries" | "outputSelection"
+> {
   compilationTarget: {
     [sourceName: string]: string;
   };

--- a/packages/compilers-types/src/SolidityTypes.ts
+++ b/packages/compilers-types/src/SolidityTypes.ts
@@ -1,5 +1,5 @@
-import { JsonFragment } from "ethers";
-import { Devdoc, Userdoc, LinkReferences } from "./CompilationTypes";
+import type { JsonFragment } from "ethers";
+import type { Devdoc, Userdoc, LinkReferences } from "./CompilationTypes";
 
 interface File {
   keccak256?: string;

--- a/packages/compilers-types/src/VyperTypes.ts
+++ b/packages/compilers-types/src/VyperTypes.ts
@@ -1,6 +1,6 @@
-import { JsonFragment } from "ethers";
-import { Devdoc } from "./CompilationTypes";
-import { Userdoc } from "./CompilationTypes";
+import type { JsonFragment } from "ethers";
+import type { Devdoc } from "./CompilationTypes";
+import type { Userdoc } from "./CompilationTypes";
 
 export interface VyperSettings {
   /** EVM version to compile for */


### PR DESCRIPTION
I noticed my IDE shows lint errors inside compilers-types packages. This fixes and enforces linting.