### PR TITLE
Fix ci schema validation

### DIFF
--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -152,7 +152,7 @@ jobs:
             # Initialize git submodules
             git submodule update --init
             # Apply migrations using npm script
-            npm run migrate:up
+            DBMATE_SCHEMA_FILE=ci-dump.sql npm run migrate:up
             # Force dump in case problems were ignored
             DBMATE_SCHEMA_FILE=ci-dump.sql npx dbmate dump
 


### PR DESCRIPTION
I found why the CI didn't failed in #2619 because of the missing changes to `sourcify-database.sql`. We were overwriting the dump file which we wanted to check against.