### PR TITLE
Add Tempo Mainnet (chain ID 4217)

### DIFF
--- a/services/server/src/extra-chains.json
+++ b/services/server/src/extra-chains.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "Tempo Mainnet",
+    "chain": "USD",
+    "rpc": ["https://tempo-mainnet.drpc.org"],
+    "faucets": [],
+    "nativeCurrency": { "name": "Tempo USD", "symbol": "USD", "decimals": 18 },
+    "infoURL": "https://tempo.xyz/",
+    "shortName": "tempo",
+    "chainId": 4217,
+    "networkId": 4217,
+    "icon": "tempo",
+    "explorers": [
+      {
+        "name": "explorer-tempo",
+        "url": "https://explorer.tempo.xyz/",
+        "standard": "EIP3091"
+      }
+    ]
+  },
+  {
     "name": "Tempo Moderato Testnet",
     "title": "Tempo Testnet (Moderato)",
     "chain": "USD",

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -2260,6 +2260,16 @@
       }
     }
   },
+  "4217": {
+    "sourcifyName": "Tempo Mainnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://explorer.tempo.xyz/"
+      }
+    },
+    "rpc": ["https://tempo-mainnet.drpc.org"]
+  },
   "42429": {
     "sourcifyName": "Tempo Testnet (Andantino)",
     "supported": true,


### PR DESCRIPTION
# Add New Chain 4217

## Checklist

- [x] The branch is named as `add-chain-<chainId>`.
- [x] I haven't modified the `chains.json` file directly.
- [x] Chain is not yet in `chains.json` so it has been added to `extra-chains.json`.
- [x] In `sourcify-chains-default.json` file
  - [x] I've set `supported: true`.
  - [x] Added `rpc` field with the public dRPC endpoint.
  - [x] Added `fetchContractCreationTxUsing` with the Blockscout explorer.
- [x] CreateX is deployed at the standard address (`0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`) on Tempo Mainnet.

## Chain Details

- **Chain ID**: 4217
- **Name**: Tempo Mainnet
- **RPC**: https://tempo-mainnet.drpc.org
- **Explorer**: https://explorer.tempo.xyz/ (Blockscout)
- **Currency**: USD (18 decimals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)