### PR TITLE
Add deprecation warning field and Warning HTTP header to legacy v1 API responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ workspace/
 
 # Sourcify release script temporary file
 .release_package_data.tmp
+.claude/

--- a/services/server/src/server/apiv1/controllers.common.ts
+++ b/services/server/src/server/apiv1/controllers.common.ts
@@ -14,6 +14,16 @@ import type {
 } from "@ethereum-sourcify/lib-sourcify";
 import type { Match } from "../types";
 
+export const CHECK_ENDPOINTS_DEPRECATION_WARNING =
+  "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. " +
+  "Use GET /v2/contract/{chain}/{address} for each address+chain combination instead. " +
+  "Full API docs: https://sourcify.dev/server/api-docs/swagger.json";
+
+export const VERIFY_ENDPOINTS_DEPRECATION_WARNING =
+  "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. " +
+  "Use POST /v2/verify instead. " +
+  "Full API docs: https://sourcify.dev/server/api-docs/swagger.json";
+
 export function checksumAddresses(
   req: Request,
   res: Response,
@@ -108,6 +118,7 @@ export interface ApiV1Response extends Omit<
   txIndex?: number;
   deployer?: string;
   status: VerificationStatus;
+  warning?: string;
 }
 
 export function getMatchStatus(
@@ -161,6 +172,7 @@ export function getApiV1ResponseFromVerification(
     deployer: verification.deploymentInfo.deployer,
     contractName: verification.compilation.compilationTarget.name,
     status,
+    warning: VERIFY_ENDPOINTS_DEPRECATION_WARNING,
   };
 }
 
@@ -173,5 +185,6 @@ export function getApiV1ResponseFromMatch(match: Match): ApiV1Response {
     contractName: match.contractName,
     storageTimestamp: match.storageTimestamp,
     status,
+    warning: VERIFY_ENDPOINTS_DEPRECATION_WARNING,
   };
 }

--- a/services/server/src/server/apiv1/repository/check-all-by-addresses.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/check-all-by-addresses.stateless.paths.yaml
@@ -43,6 +43,12 @@ paths:
                   properties:
                     address:
                       type: string
+                    status:
+                      type: string
+                      description: Set to "false" when the contract is not found on any of the requested chains.
+                    warning:
+                      type: string
+                      description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
                     chainIds:
                       type: array
                       items:
@@ -67,6 +73,9 @@ paths:
                                   type: string
                           proxyResolutionError:
                             type: string
+                          warning:
+                            type: string
+                            description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
               examples:
                 multiple results:
                   value:
@@ -126,12 +135,15 @@ paths:
                       chainIds:
                         - chainId: "43114"
                           status: "perfect"
+                          warning: "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. Use GET /v2/contract/{chain}/{address} for each address+chain combination instead. Full API docs: https://sourcify.dev/server/api-docs/swagger.json"
                 not found:
                   value:
                     - address: "0x1f9cA631AE0C4890F99b38634C969b7E4f8719F0"
                       status: "false"
+                      warning: "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. Use GET /v2/contract/{chain}/{address} for each address+chain combination instead. Full API docs: https://sourcify.dev/server/api-docs/swagger.json"
                     - address: "0x8D2548A5f641b00Cf0f5B693d4A72D8c0aE24d31"
                       status: "false"
+                      warning: "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. Use GET /v2/contract/{chain}/{address} for each address+chain combination instead. Full API docs: https://sourcify.dev/server/api-docs/swagger.json"
                 proxy resolution error:
                   value:
                     - address: "0xEb30853fc616Bbb8f1444451A3c202cbcd08Fb47"

--- a/services/server/src/server/apiv1/repository/check-by-addresses.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/repository/check-by-addresses.stateless.paths.yaml
@@ -45,3 +45,7 @@ paths:
                       items:
                         type: string
                       example: ["43114", "137"]
+                    warning:
+                      type: string
+                      description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
+                      example: "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. Use GET /v2/contract/{chain}/{address} for each address+chain combination instead. Full API docs: https://sourcify.dev/server/api-docs/swagger.json"

--- a/services/server/src/server/apiv1/repository/repository.handlers.ts
+++ b/services/server/src/server/apiv1/repository/repository.handlers.ts
@@ -9,6 +9,7 @@ import type {
   Match,
 } from "../../types";
 import { NotFoundError } from "../../../common/errors";
+import { CHECK_ENDPOINTS_DEPRECATION_WARNING } from "../controllers.common";
 import logger from "../../../common/logger";
 import type { Services } from "../../services/services";
 import type {
@@ -199,6 +200,7 @@ export async function checkAllByChainAndAddressEndpoint(
             chainId,
             status: found[0].runtimeMatch,
             ...proxyStatus,
+            warning: CHECK_ENDPOINTS_DEPRECATION_WARNING,
           });
         }
       } catch (error) {
@@ -215,6 +217,7 @@ export async function checkAllByChainAndAddressEndpoint(
       map.set(address, {
         address: address,
         status: "false",
+        warning: CHECK_ENDPOINTS_DEPRECATION_WARNING,
       });
     }
   }
@@ -268,7 +271,12 @@ export async function checkByChainAndAddressesEnpoint(
         );
         if (found.length != 0) {
           if (!map.has(address)) {
-            map.set(address, { address, status: "perfect", chainIds: [] });
+            map.set(address, {
+              address,
+              status: "perfect",
+              chainIds: [],
+              warning: CHECK_ENDPOINTS_DEPRECATION_WARNING,
+            });
           }
 
           map.get(address).chainIds.push(chainId);
@@ -281,6 +289,7 @@ export async function checkByChainAndAddressesEnpoint(
       map.set(address, {
         address: address,
         status: "false",
+        warning: CHECK_ENDPOINTS_DEPRECATION_WARNING,
       });
     }
   }

--- a/services/server/src/server/apiv1/routes.ts
+++ b/services/server/src/server/apiv1/routes.ts
@@ -27,6 +27,10 @@ router.use(
   ],
   (req: Request, res: Response, next: NextFunction) => {
     res.setHeader("Deprecation", "true");
+    res.setHeader(
+      "Warning",
+      '299 - "Deprecated: use v2 API. See https://sourcify.dev/server/api-docs/swagger.json"',
+    );
     next();
   },
 );

--- a/services/server/src/server/apiv1/verification/etherscan/stateless/etherscan.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/verification/etherscan/stateless/etherscan.stateless.paths.yaml
@@ -66,6 +66,9 @@ paths:
                           type: string
                         libraryMap:
                           type: object
+                        warning:
+                          type: string
+                          description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
               examples:
                 Perfect Match:
                   value:

--- a/services/server/src/server/apiv1/verification/solc-json/stateless/solc-json.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/verification/solc-json/stateless/solc-json.stateless.paths.yaml
@@ -106,6 +106,9 @@ paths:
                           type: string
                         libraryMap:
                           type: object
+                        warning:
+                          type: string
+                          description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
               examples:
                 Perfect Match:
                   value:

--- a/services/server/src/server/apiv1/verification/verify/stateless/verify.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/verification/verify/stateless/verify.stateless.paths.yaml
@@ -95,6 +95,9 @@ paths:
                           type: string
                         libraryMap:
                           type: object
+                        warning:
+                          type: string
+                          description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
               examples:
                 Perfect Match:
                   value:
@@ -105,6 +108,7 @@ paths:
                         libraryMap:
                           lib1: "0x3f681646d4a755815f9cb19e1acc8565a0c2ac"
                           lib2: "0x4f681646d4a755815f9cb19e1acc8565a0c2ac"
+                        warning: "DEPRECATED: This endpoint will be removed. Do not build new integrations against it. Use POST /v2/verify instead. Full API docs: https://sourcify.dev/server/api-docs/swagger.json"
                 Partial Match:
                   value:
                     result:

--- a/services/server/src/server/apiv1/verification/vyper/stateless/vyper.stateless.paths.yaml
+++ b/services/server/src/server/apiv1/verification/vyper/stateless/vyper.stateless.paths.yaml
@@ -73,6 +73,9 @@ paths:
                           type: string
                         message:
                           type: string
+                        warning:
+                          type: string
+                          description: Deprecation warning. This endpoint will be removed. Use the v2 API instead.
               examples:
                 Perfect Match:
                   value:

--- a/services/server/test/helpers/assertions.ts
+++ b/services/server/test/helpers/assertions.ts
@@ -13,7 +13,10 @@ import type {
   VerificationStatus,
 } from "@ethereum-sourcify/lib-sourcify";
 import type { ServerFixture } from "./ServerFixture";
-import { getMatchStatus } from "../../src/server/apiv1/controllers.common";
+import {
+  getMatchStatus,
+  VERIFY_ENDPOINTS_DEPRECATION_WARNING,
+} from "../../src/server/apiv1/controllers.common";
 import type { MatchLevel } from "../../src/server/types";
 import { toVerificationStatus } from "../../src/server/services/utils/util";
 import chaiHttp from "chai-http";
@@ -60,6 +63,7 @@ export const assertVerification = async (
       .to.equal(expectedAddress.toLowerCase());
     chai.expect(result.chainId).to.equal(expectedChain);
     chai.expect(result.status).to.equal(expectedStatus);
+    chai.expect(result.warning).to.equal(VERIFY_ENDPOINTS_DEPRECATION_WARNING);
 
     await assertContractSaved(
       serverFixture?.sourcifyDatabase ?? null,

--- a/services/server/test/integration/apiv1/repository-handlers/check-by-addresses.spec.ts
+++ b/services/server/test/integration/apiv1/repository-handlers/check-by-addresses.spec.ts
@@ -1,4 +1,7 @@
 import { assertValidationError } from "../../../helpers/assertions";
+import {
+  CHECK_ENDPOINTS_DEPRECATION_WARNING,
+} from "../../../../src/server/apiv1/controllers.common";
 import chai from "chai";
 import chaiHttp from "chai-http";
 import { StatusCodes } from "http-status-codes";
@@ -35,6 +38,7 @@ const assertLookup = (
   const result = resultArray[0];
   chai.expect(result.status).to.equal(expectedStatus);
   chai.expect(result.address).to.equal(expectedAddress);
+  chai.expect(result.warning).to.equal(CHECK_ENDPOINTS_DEPRECATION_WARNING);
   if (done) done();
 };
 
@@ -61,7 +65,15 @@ const assertLookupAll = (
   chai.expect(resultArray).to.have.a.lengthOf(1);
   const result = resultArray[0];
   chai.expect(result.address).to.equal(expectedAddress);
-  chai.expect(result.chainIds).to.deep.equal(expectedChainIds);
+  // Assert warning in each chainId entry
+  result.chainIds.forEach(({ warning }: { warning: string }) => {
+    chai.expect(warning).to.equal(CHECK_ENDPOINTS_DEPRECATION_WARNING);
+  });
+  // Compare chainId entries without the warning field
+  const chainIdsWithoutWarning = result.chainIds.map(
+    ({ warning: _w, ...rest }: Record<string, unknown>) => rest,
+  );
+  chai.expect(chainIdsWithoutWarning).to.deep.equal(expectedChainIds);
   if (done) done();
 };
 

--- a/services/server/test/integration/apiv1/repository-handlers/check-by-addresses.spec.ts
+++ b/services/server/test/integration/apiv1/repository-handlers/check-by-addresses.spec.ts
@@ -1,7 +1,5 @@
 import { assertValidationError } from "../../../helpers/assertions";
-import {
-  CHECK_ENDPOINTS_DEPRECATION_WARNING,
-} from "../../../../src/server/apiv1/controllers.common";
+import { CHECK_ENDPOINTS_DEPRECATION_WARNING } from "../../../../src/server/apiv1/controllers.common";
 import chai from "chai";
 import chaiHttp from "chai-http";
 import { StatusCodes } from "http-status-codes";


### PR DESCRIPTION
Closes #2624

## Summary

- Adds a `"warning"` field to JSON response bodies of all legacy v1 API endpoints, so AI agents and developers inspecting payloads are immediately prompted to switch to the v2 API
- Adds the RFC 7234 `Warning: 299` HTTP header alongside the existing `Deprecation: true` header across all v1 routes
- Updates OpenAPI schemas to document the new `warning` field in response schemas and examples
- Updates tests to assert the `warning` field is present and correct

## Details

**New `warning` field in JSON responses:**
- `/check-all-by-addresses` — added to each `chainIds[*]` entry and to top-level "not found" address objects (`status: "false"`)
- `/check-by-addresses` — added to each top-level address object (found and not found)
- `/verify`, `/verify/etherscan`, `/verify/solc-json`, `/verify/vyper` — added to each `result[*]` item

Warning messages are endpoint-specific and name the v2 replacement directly:
- Check endpoints: `"... Use GET /v2/contract/{chain}/{address} for each address+chain combination instead."`
- Verify endpoints: `"... Use POST /v2/verify instead."`

**OpenAPI schema fix:** The `check-all-by-addresses` schema now correctly documents the top-level `status` field as only being present (with value `"false"`) when the contract is not found on any of the requested chains. Verified against the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)