### PR TITLE
feat: add Flow EVM Mainnet (747) and Testnet (545)

### DIFF
--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -2526,5 +2526,29 @@
         "url": "https://saigon-explorer.roninchain.com"
       }
     }
+  },
+  "747": {
+    "sourcifyName": "Flow EVM Mainnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://evm.flow.com/"
+      }
+    },
+    "rpc": [
+      "https://mainnet.evm.nodes.onflow.org"
+    ]
+  },
+  "545": {
+    "sourcifyName": "Flow EVM Testnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://testnet.evm.flow.com/"
+      }
+    },
+    "rpc": [
+      "https://testnet.evm.nodes.onflow.org"
+    ]
   }
 }


### PR DESCRIPTION
## Add Flow EVM chain support

Adds support for **Flow EVM Mainnet** (Chain ID: 747) and **Flow EVM Testnet** (Chain ID: 545).

### Chain Details

| | Mainnet | Testnet |
|---|---|---|
| **Chain ID** | 747 | 545 |
| **RPC** | https://mainnet.evm.nodes.onflow.org | https://testnet.evm.nodes.onflow.org |
| **Explorer** | https://evm.flow.com | https://testnet.evm.flow.com |
| **Currency** | FLOW | FLOW |

### Notes

- Both chains are standard EVM-compatible, running on the [Flow blockchain](https://developers.flow.com/evm/about)
- Both chains are registered in [ethereum-lists/chains](https://chainid.network/chain/747/)
- [CreateX](https://github.com/pcaversaccio/createx) is deployed on both chains (`0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`)
- [Multicall3](https://github.com/mds1/multicall3) is deployed on both chains (`0xcA11bde05977b3631167028862bE2a173976CA11`)
- Both explorers run [Blockscout](https://www.blockscout.com/), configured via `blockscoutApi` for `fetchContractCreationTxUsing`