### PR TITLE
fix(ci): increase build job resource class to xlarge to fix OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ aliases:
   - &build-base
     docker:
       - image: cimg/base:2024.07
-    resource_class: large
+    resource_class: xlarge
     parameters:
       run-build:
         type: boolean
@@ -174,7 +174,7 @@ aliases:
       - run: echo 0
   - &build-base-arm64
     <<: *build-base
-    resource_class: arm.large # override resource class
+    resource_class: arm.xlarge # override resource class
 
 jobs:
   build-push-monitor-amd64:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -69,7 +69,7 @@ aliases:
   - &build-base
     docker:
       - image: cimg/base:2024.07
-    resource_class: large
+    resource_class: xlarge
     parameters:
       run-build:
         type: boolean
@@ -99,7 +99,7 @@ aliases:
       - run: echo 0
   - &build-base-arm64
     <<: *build-base
-    resource_class: arm.large # override resource class
+    resource_class: arm.xlarge # override resource class
   - &monitor-e2e-base
     steps:
       - run:


### PR DESCRIPTION
## Summary
- Docker build jobs were OOM-killed (exit 137) due to insufficient memory
- Upgrade `resource_class` from `large` (8 GB RAM) to `xlarge` (16 GB RAM) for all Docker build jobs in both `config.yml` and `continue_config.yml`
- Applies to both amd64 (`large` → `xlarge`) and arm64 (`arm.large` → `arm.xlarge`) builds

## Test plan
- [ ] Verify build jobs complete without OOM errors on next CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)