### PR TITLE
fix(lib-sourcify): don't misdiagnose extra_file_input_bug for pre-0.4.7 contracts

### DIFF
--- a/packages/compilers/CLAUDE.md
+++ b/packages/compilers/CLAUDE.md
@@ -1,0 +1,22 @@
+## Solc Compiler Internals
+
+### soljson vs native binary
+
+Sourcify uses two compiler paths:
+
+- **Native binary** — invoked via `solc --standard-json`. Available from v0.4.10 (Linux), v0.3.6 (macOS), v0.4.1 (Windows).
+- **soljson** — Emscripten-compiled JavaScript build. Used for all versions below the native binary thresholds. Downloaded from `binaries.soliditylang.org/bin/`.
+
+### solc npm wrapper — C function fallback chain
+
+For old soljsons that predate Standard JSON, the `solc` npm package (`wrapper.js`) translates Standard JSON input/output to the old format. It detects available C functions and uses the highest-priority one available:
+
+| Priority | C function | Introduced | Input format |
+|---|---|---|---|
+| 1 | `solidity_compile` | v0.5.0 | Standard JSON (new libsolc API, replaces all older functions) |
+| 2 | `compileStandard` | v0.4.11 | Standard JSON |
+| 3 | `compileJSONCallback` | v0.2.1 | `{"sources":{"f.sol":"..."}}` + import callback |
+| 4 | `compileJSONMulti` | v0.1.6 | `{"sources":{"f.sol":"..."}}` |
+| 5 | `compileJSON` | v0.1.0 | Raw source string (single file only) |
+
+Note: for v0.1.6–v0.2.0 soljsons, the wrapper lands on `compileJSONMulti` even though `compileJSON` also exists.

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -324,7 +324,13 @@ export class Verification {
       AuxdataStyle.SOLIDITY,
     );
     // Metadata hashes match but bytecodes don't match.
+    // Guard: both auxdata must be defined (i.e. CBOR metadata actually exists in both bytecodes).
+    // Pre-0.4.7 contracts have no CBOR metadata, so splitAuxdata returns undefined for index [1].
+    // Without this guard, undefined === undefined would incorrectly trigger the bug diagnosis.
+    // See: https://github.com/argotorg/sourcify/issues/2729
     if (
+      deployedAuxdata !== undefined &&
+      recompiledAuxdata !== undefined &&
       deployedAuxdata === recompiledAuxdata &&
       (this.compilation.jsonInput.settings as SoliditySettings).optimizer
         ?.enabled

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -25,6 +25,7 @@ import { VyperCompilation } from '../../src/Compilation/VyperCompilation';
 import chaiAsPromised from 'chai-as-promised';
 import { findSolcPlatform } from '@ethereum-sourcify/compilers';
 import { SolidityCompilation, SourcifyChain } from '../../src';
+import { SolidityBugType } from '../../src/Verification/VerificationTypes';
 import Sinon from 'sinon';
 import { YulCompilation } from '../../src/Compilation/YulCompilation';
 import type { SolidityJsonInput } from '@ethereum-sourcify/compilers-types';
@@ -603,6 +604,46 @@ describe('Verification Class Tests', () => {
           creationMatch: null,
         },
       });
+    });
+
+    it('should NOT diagnose extra_file_input_bug when bytecodes have no CBOR metadata (pre-0.4.7)', async () => {
+      // Pre-0.4.7 contracts have no CBOR metadata. splitAuxdata returns a single-element array
+      // for such bytecodes, so the auxdata at index [1] is undefined.
+      // undefined === undefined must NOT trigger the extra_file_input_bug diagnosis.
+      // See: https://github.com/argotorg/sourcify/issues/2729
+      const contractFolderPath = path.join(
+        __dirname,
+        '..',
+        'sources',
+        'Storage',
+      );
+      const compilation = await getCompilationFromMetadata(contractFolderPath);
+
+      // Enable optimizer to match the condition that previously caused the misdiagnosis
+      (compilation.jsonInput.settings as any).optimizer = {
+        enabled: true,
+        runs: 200,
+      };
+
+      const verification = new Verification(
+        compilation,
+        sourcifyChainHardhat,
+        '0x0000000000000000000000000000000000000001', // dummy address, not deployed
+      );
+
+      // Stub onchainRuntimeBytecode and compilation.runtimeBytecode with bytecodes
+      // that have no CBOR metadata (short synthetic bytecodes that differ from each other)
+      Sinon.stub(verification, 'onchainRuntimeBytecode' as any).get(
+        () => '0x6060604052',
+      );
+      Sinon.stub(verification.compilation, 'runtimeBytecode' as any).get(
+        () => '0x6060604060',
+      );
+
+      const result = verification.handleSolidityExtraFileInputBug();
+      expect(result).to.equal(SolidityBugType.NONE);
+
+      Sinon.restore();
     });
 
     it('should fail when bytecode could not be fetched', async () => {


### PR DESCRIPTION
## Summary

- `handleSolidityExtraFileInputBug()` was incorrectly returning `EXTRA_FILE_INPUT_BUG` for pre-0.4.7 Solidity contracts (e.g. v0.1.7) whenever bytecodes didn't match and the optimizer was enabled
- Root cause: pre-0.4.7 contracts have no CBOR metadata, so `splitAuxdata()` returns a single-element array — the auxdata at index `[1]` is `undefined` for both onchain and recompiled bytecodes. Since `undefined === undefined` is `true`, the check falsely triggered
- Fix: guard that both auxdata values must be defined (i.e. CBOR metadata actually exists in both bytecodes) before diagnosing the extra file input bug
- Added some documentation in compilers CLAUDE.md about the findings during the investigation. I don't know the best place to put this.

Fixes #2729

> **Note:** This fixes the misdiagnosis. The deeper issue (Standard JSON producing different bytecode than the old `compileJSON()` API for very old compiler versions) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)