### PR TITLE
chore(docker): update monitor and 4byte production images to trixie-slim

### DIFF
--- a/services/4byte/Dockerfile
+++ b/services/4byte/Dockerfile
@@ -15,7 +15,7 @@ RUN npx lerna run build --scope sourcify-4byte
 ######################
 ## Production image ##
 ######################
-FROM node:22.22.0-bookworm-slim as production
+FROM node:22.22.0-trixie-slim as production
 
 RUN mkdir -p /home/app/services/4byte
 

--- a/services/monitor/Dockerfile
+++ b/services/monitor/Dockerfile
@@ -11,7 +11,7 @@ RUN npx lerna run build --scope sourcify-monitor
 ######################
 ## Production image ##
 ######################
-FROM node:22.22.0-bookworm-slim as production
+FROM node:22.22.0-trixie-slim as production
 
 RUN mkdir -p /home/app/services/monitor
 


### PR DESCRIPTION
## Summary

- Commit `1ce735d9` on staging updated the server's production Docker image from `bookworm-slim` to `trixie-slim` because the Fe compiler requires GLIBC >= 2.39.
- This PR updates the remaining production images (monitor, 4byte) from `bookworm-slim` to `trixie-slim` for consistency across the monorepo.
- Builder stages are unchanged (still using `bookworm`).

## Test plan

- [ ] Verify monitor Docker image builds successfully with `trixie-slim`
- [ ] Verify 4byte Docker image builds successfully with `trixie-slim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)