### PR TITLE
feat: support custom Etherscan-compatible API URLs

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -51,6 +51,7 @@ export class SourcifyChain {
   readonly etherscanApi?: {
     supported: boolean;
     apiKeyEnvName?: string;
+    url?: string;
   };
 
   private static rpcTimeout: number = 10 * 1000;

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
@@ -9,6 +9,7 @@ export type SourcifyChainExtension = {
   etherscanApi?: {
     supported: boolean;
     apiKeyEnvName?: string;
+    url?: string; // Custom base URL for Etherscan-compatible APIs (e.g. "https://block-explorer-api.testnet.battlechain.com")
   };
   fetchContractCreationTxUsing?: FetchContractCreationTxMethods;
   rpc?: Array<string | BaseRPC | APIKeyRPC | FetchRequestRPC>;

--- a/packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts
+++ b/packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts
@@ -161,8 +161,11 @@ export const fetchFromEtherscan = async (
   chainId: number | string,
   address: string,
   apiKey: string,
+  customBaseUrl?: string,
 ): Promise<EtherscanResult> => {
-  const url = `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getsourcecode&address=${address}&apikey=`;
+  const url = customBaseUrl
+    ? `${customBaseUrl}/api?module=contract&action=getsourcecode&address=${address}&apikey=`
+    : `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getsourcecode&address=${address}&apikey=`;
   const secretUrl = url + apiKey;
   const maskedUrl = url + (apiKey ? apiKey.slice(0, 6) + '...' : '');
 

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -85,16 +85,20 @@ function getBlockscoutScrapeContractCreatorFetcher(
 function getEtherscanApiContractCreatorFetcher(
   apiKey: string,
   chainId: number,
+  customBaseUrl?: string,
 ): ContractCreationFetcher {
+  const baseUrl = customBaseUrl
+    ? `${customBaseUrl}/api?module=contract&action=getcontractcreation&contractaddresses=\${ADDRESS}&apikey=`
+    : ETHERSCAN_API.replace("${CHAIN_ID}", chainId.toString());
   return getApiContractCreationFetcher(
-    ETHERSCAN_API.replace("${CHAIN_ID}", chainId.toString()) + apiKey,
+    baseUrl + apiKey,
     (response: any) => {
       if (response?.message === "NOTOK")
         throw new Error(`Etherscan API error: ${response?.result}`);
       if (response?.result?.[0]?.txHash)
         return response?.result?.[0]?.txHash as string;
     },
-    ETHERSCAN_API.replace("${CHAIN_ID}", chainId.toString()),
+    baseUrl,
   );
 }
 
@@ -355,6 +359,7 @@ export const getCreatorTx = async (
     const fetcher = getEtherscanApiContractCreatorFetcher(
       apiKey,
       sourcifyChain.chainId,
+      sourcifyChain.etherscanApi?.url,
     );
     const result = await getCreatorTxUsingFetcher(fetcher, contractAddress);
     if (result) {

--- a/services/server/src/server/services/utils/etherscan-util.ts
+++ b/services/server/src/server/services/utils/etherscan-util.ts
@@ -86,6 +86,7 @@ export const fetchFromEtherscanOrThrowError = async (
       sourcifyChain.chainId,
       address,
       apiKey,
+      sourcifyChain.etherscanApi?.url,
     );
   } catch (err) {
     return mapLibError(err, throwV2Errors);


### PR DESCRIPTION
## Summary

Adds an optional `url` field to the `etherscanApi` chain configuration, enabling chains with their own Etherscan-compatible block explorers to use a custom base URL instead of the hardcoded `https://api.etherscan.io/v2/api`.

Kept separate from #2709 (remote chain config refactor) as that PR is already very large.

## Changes

- **`SourcifyChainTypes.ts`** and **`SourcifyChain.ts`** (`packages/lib-sourcify`): Add `url?: string` to `etherscanApi`
- **`etherscan-util.ts`** (`packages/lib-sourcify`): `fetchFromEtherscan` accepts optional `customBaseUrl`. When provided, uses `${customBaseUrl}/api?module=contract&action=getsourcecode&...` instead of the default Etherscan v2 URL
- **`etherscan-util.ts`** (server): Passes `sourcifyChain.etherscanApi?.url` through to lib-sourcify
- **`contract-creation-util.ts`** (server): `getEtherscanApiContractCreatorFetcher` accepts optional `customBaseUrl`. When provided, uses `${customBaseUrl}/api?module=contract&action=getcontractcreation&...` instead of the hardcoded `ETHERSCAN_API` constant

## Example usage (BattleChain Testnet)

Chain definition (`extra-chains.json`):
```json
{
  "name": "BattleChain Testnet",
  "chain": "ETH",
  "rpc": ["https://testnet.battlechain.com"],
  "faucets": [],
  "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
  "infoURL": "https://battlechain.com",
  "shortName": "battlechain-testnet",
  "chainId": 627,
  "networkId": 627,
  "slip44": 1,
  "explorers": [
    { "name": "BattleChain Explorer", "url": "https://explorer.testnet.battlechain.com", "standard": "EIP3091" }
  ]
}
```

Sourcify extension (`sourcify-chains-default.json`):
```json
"627": {
  "sourcifyName": "BattleChain Testnet",
  "supported": true,
  "etherscanApi": {
    "supported": true,
    "url": "https://block-explorer-api.testnet.battlechain.com"
  },
  "fetchContractCreationTxUsing": {
    "etherscanApi": true
  },
  "rpc": ["https://testnet.battlechain.com"]
}
```

With `url` set, both the Etherscan source import (`getsourcecode`) and the contract creation tx lookup (`getcontractcreation`) will hit `https://block-explorer-api.testnet.battlechain.com/api?...` instead of `api.etherscan.io`.

## Test plan

- [x] `npx lerna run build` passes
- [x] `packages/lib-sourcify` tests pass (158 passing)
- [x] `services/server` unit tests pass (69 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)