### PR TITLE
fix(lib-sourcify): normalize old Vyper beta versions from Etherscan

### DIFF
--- a/packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts
+++ b/packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts
@@ -27,6 +27,11 @@ interface VyperVersionCache {
 let vyperVersionCache: VyperVersionCache | null = null;
 const CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour default
 
+// Etherscan encodes early Vyper betas as e.g. "0.1.0b17" while the GitHub release
+// tag (and the Hardhat mirror) uses "0.1.0-beta.17". Normalize before lookup.
+const normalizeVyperVersion = (v: string): string =>
+  v.replace(/^(\d+\.\d+\.\d+)b(\d+)$/, '$1-beta.$2');
+
 export const getVyperCompilerVersion = async (
   compilerString: string,
   cacheDurationMs: number = CACHE_DURATION_MS,
@@ -64,8 +69,9 @@ export const getVyperCompilerVersion = async (
 
   if (!vyperVersionCache) return undefined;
   const versionNumber = compilerString.split(':')[1];
+  const normalizedVersion = normalizeVyperVersion(versionNumber);
   let found = vyperVersionCache.versions.find(
-    (v) => v.tag === versionNumber,
+    (v) => v.tag === versionNumber || v.tag === normalizedVersion,
   )?.compiler_version;
   if (!found) {
     // If not found, try a one-time refresh to capture newly added versions
@@ -86,7 +92,7 @@ export const getVyperCompilerVersion = async (
         lastFetch: Date.now(),
       };
       found = vyperVersionCache.versions.find(
-        (v) => v.tag === versionNumber,
+        (v) => v.tag === versionNumber || v.tag === normalizedVersion,
       )?.compiler_version;
     } catch (error) {
       logWarn('Failed to refresh Vyper versions for missing tag', {

--- a/packages/lib-sourcify/test/utils/etherscan-util.spec.ts
+++ b/packages/lib-sourcify/test/utils/etherscan-util.spec.ts
@@ -15,6 +15,7 @@ import { solc, vyperCompiler } from '../utils';
 // and ensure consistency across lib-sourcify and server tests.
 import {
   INVALID_API_KEY_RESPONSE,
+  MALFORMED_VYPER_VERSION_RESPONSE,
   MULTIPLE_CONTRACT_RESPONSE,
   RATE_LIMIT_REACHED_RESPONSE,
   SINGLE_CONTRACT_RESPONSE,
@@ -451,6 +452,97 @@ describe('etherscan util (lib)', function () {
       expect(compilation.compilationTarget).to.deep.equal(
         expectedCompilation.compilationTarget,
       );
+    });
+  });
+
+  describe('getVyperCompilerVersion', () => {
+    it('should resolve "vyper:0.1.0b17" to the GitHub tag format', async () => {
+      nock('https://vyper-releases-mirror.hardhat.org')
+        .get('/list.json')
+        .times(2)
+        .reply(200, [
+          {
+            tag_name: 'v0.1.0-beta.17',
+            assets: [{ name: 'vyper.0.1.0-beta.17+commit.0671b7b.darwin' }],
+          },
+        ]);
+
+      const result = await EtherscanUtils.getVyperCompilerVersion(
+        'vyper:0.1.0b17',
+        0,
+      );
+      expect(result).to.equal('0.1.0-beta.17+commit.0671b7b');
+    });
+
+    it('should resolve "vyper:0.1.0b16" to the GitHub tag format', async () => {
+      nock('https://vyper-releases-mirror.hardhat.org')
+        .get('/list.json')
+        .times(2)
+        .reply(200, [
+          {
+            tag_name: 'v0.1.0-beta.16',
+            assets: [{ name: 'vyper.0.1.0-beta.16+commit.5e4a94a.darwin' }],
+          },
+        ]);
+
+      const result = await EtherscanUtils.getVyperCompilerVersion(
+        'vyper:0.1.0b16',
+        0,
+      );
+      expect(result).to.equal('0.1.0-beta.16+commit.5e4a94a');
+    });
+
+    it('should still resolve a well-formed "vyper:0.3.10"', async () => {
+      nock('https://vyper-releases-mirror.hardhat.org')
+        .get('/list.json')
+        .times(2)
+        .reply(200, [
+          {
+            tag_name: 'v0.3.10',
+            assets: [{ name: 'vyper.0.3.10+commit.91361694.darwin' }],
+          },
+        ]);
+
+      const result = await EtherscanUtils.getVyperCompilerVersion(
+        'vyper:0.3.10',
+        0,
+      );
+      expect(result).to.equal('0.3.10+commit.91361694');
+    });
+
+    it('should return undefined for a version not in the mirror', async () => {
+      nock('https://vyper-releases-mirror.hardhat.org')
+        .get('/list.json')
+        .times(2)
+        .reply(200, [
+          {
+            tag_name: 'v0.1.0-beta.17',
+            assets: [{ name: 'vyper.0.1.0-beta.17+commit.0671b7b.darwin' }],
+          },
+        ]);
+
+      const result = await EtherscanUtils.getVyperCompilerVersion(
+        'vyper:0.1.0b4',
+        0,
+      );
+      expect(result).to.be.undefined;
+    });
+
+    it('should resolve a malformed Vyper version via processVyperResultFromEtherscan', async () => {
+      nock('https://vyper-releases-mirror.hardhat.org')
+        .get('/list.json')
+        .times(2)
+        .reply(200, [
+          {
+            tag_name: 'v0.1.0-beta.17',
+            assets: [{ name: 'vyper.0.1.0-beta.17+commit.0671b7b.darwin' }],
+          },
+        ]);
+
+      const result = await EtherscanUtils.processVyperResultFromEtherscan(
+        MALFORMED_VYPER_VERSION_RESPONSE.result[0] as any,
+      );
+      expect(result.compilerVersion).to.equal('0.1.0-beta.17+commit.0671b7b');
     });
   });
 });

--- a/services/server/test/helpers/etherscanResponseMocks.ts
+++ b/services/server/test/helpers/etherscanResponseMocks.ts
@@ -288,3 +288,28 @@ export const VYPER_STANDARD_JSON_CONTRACT_RESPONSE = {
     },
   ],
 };
+
+// Same shape as VYPER_SINGLE_CONTRACT_RESPONSE but with the old Etherscan beta format
+// "vyper:0.1.0b17" instead of the normalized GitHub tag "0.1.0-beta.17".
+export const MALFORMED_VYPER_VERSION_RESPONSE = {
+  status: "1",
+  message: "OK",
+  result: [
+    {
+      SourceCode:
+        "# @version 0.1.0b17\r\n# A minimal Vyper contract for testing version normalization\r\n\r\nowner: address\r\n\r\n@deploy\r\ndef __init__():\r\n    self.owner = msg.sender",
+      ABI: "[]",
+      ContractName: "SimpleOwner",
+      CompilerVersion: "vyper:0.1.0b17",
+      OptimizationUsed: "0",
+      Runs: "0",
+      ConstructorArguments: "",
+      EVMVersion: "Default",
+      Library: "",
+      LicenseType: "MIT",
+      Proxy: "0",
+      Implementation: "",
+      SwarmSource: "",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes 157 failed Vyper Etherscan imports caused by a format mismatch in `getVyperCompilerVersion` (`packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts`).

Etherscan encodes early Vyper beta releases as `vyper:0.1.0b16` / `vyper:0.1.0b17`, but the GitHub release tags (and the Hardhat Vyper releases mirror) use `v0.1.0-beta.16` / `v0.1.0-beta.17`. The strict equality lookup therefore always failed, even though binaries exist for these versions.

**Fix:** normalize the version string before lookup — `0.1.0bN` → `0.1.0-beta.N` — applied to both the initial find and the one-time-refresh retry path.

This is the Vyper equivalent of the Solidity version-resolution issue #2716 fixed in #2732.

## Context

Out of 4,011 failed Vyper Etherscan imports:

| | Count |
|---|---|
| **Fixed by this PR** (format mismatch, `0.1.0b16` + `0.1.0b17`) | **157** |
| Not fixable (no binaries ever published for `0.1.0b4`–`0.1.0b15`, `0.2.13`, `0.3.5`) | 3,854 |

## Changes

- `packages/lib-sourcify/src/utils/etherscan/etherscan-util.ts` — add `normalizeVyperVersion` helper; update both `find` calls in `getVyperCompilerVersion`
- `packages/lib-sourcify/test/utils/etherscan-util.spec.ts` — new `describe('getVyperCompilerVersion')` block with 5 test cases
- `services/server/test/helpers/etherscanResponseMocks.ts` — add `MALFORMED_VYPER_VERSION_RESPONSE` fixture

## Test plan

- [ ] `cd packages/lib-sourcify && npm test` — all 28 etherscan-util tests pass, including 5 new cases
- [ ] New tests cover: resolving `b16`, resolving `b17`, regression for well-formed `0.3.10`, `undefined` returned for genuinely missing version (`b4`), and end-to-end via `processVyperResultFromEtherscan`