### PR TITLE
Fix OOM error in CircleCI

### DIFF
--- a/services/server/src/server/services/StorageService.ts
+++ b/services/server/src/server/services/StorageService.ts
@@ -352,13 +352,26 @@ export class StorageService {
 
   public async close() {
     logger.info("Gracefully closing storage services");
+
+    // Close all services except SourcifyDatabase first because
+    // it is used by other services and should be closed last
+    // to avoid errors during the closing process
+    const sourcifyDatabase =
+      this.rwServices[RWStorageIdentifiers.SourcifyDatabase];
     const closingPromises: Promise<void>[] = [];
-    for (const service of Object.values(this.wServices)) {
+    for (const service of [
+      ...Object.values(this.rwServices).filter((s) => s !== sourcifyDatabase),
+      ...Object.values(this.wServices),
+    ]) {
       if (service.close) {
         closingPromises.push(service.close());
       }
     }
     await Promise.all(closingPromises);
+
+    if (sourcifyDatabase?.close) {
+      await sourcifyDatabase.close();
+    }
   }
 
   async storeVerification(

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -19,6 +19,10 @@ export default abstract class AbstractDatabaseService {
     return await this.database.initDatabasePool(this.IDENTIFIER);
   }
 
+  async close() {
+    await this.database.close();
+  }
+
   validateVerificationBeforeStoring(verification: VerificationExport): boolean {
     if (
       verification.status.runtimeMatch === null ||

--- a/services/server/src/server/services/storageServices/S3RepositoryService.ts
+++ b/services/server/src/server/services/storageServices/S3RepositoryService.ts
@@ -37,6 +37,11 @@ export class S3RepositoryService
     });
   }
 
+  async close() {
+    this.s3.destroy();
+    logger.info(`${this.IDENTIFIER} closed`);
+  }
+
   async deletePartialIfExists(chainId: string, address: string) {
     const prefix = Path.join("contracts", "partial_match", chainId, address);
 

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -88,6 +88,13 @@ export class Database {
     return this._pool != undefined;
   }
 
+  async close(): Promise<void> {
+    if (this._pool) {
+      await this._pool.end();
+      this._pool = undefined;
+    }
+  }
+
   async initDatabasePool(identifier: string): Promise<boolean> {
     // if the database is already initialized
     if (this._pool != undefined) {

--- a/services/server/test/helpers/helpers.ts
+++ b/services/server/test/helpers/helpers.ts
@@ -4,7 +4,9 @@ import type {
   JsonRpcProvider,
   BytesLike,
 } from "ethers";
-import { ContractFactory, Wallet, Contract } from "ethers";
+import { ContractFactory, Wallet, Contract, getAddress } from "ethers";
+import type { SourcifyDatabaseService } from "../../src/server/services/storageServices/SourcifyDatabaseService";
+import { MockVerificationExport } from "./mocks";
 import { assertVerification } from "./assertions";
 import chai, { expect } from "chai";
 import chaiHttp from "chai-http";
@@ -360,4 +362,34 @@ export function hookIntoVerificationWorkerRun(
   };
 
   return makeWorkersWait;
+}
+
+/**
+ * Insert a mock verified contract directly into the database.
+ * Each contract gets unique bytecodes and address derived from the index
+ * to satisfy the DB unique constraints, avoiding expensive on-chain
+ * deployments and full verification round-trips.
+ */
+export async function insertMockVerification(
+  databaseService: SourcifyDatabaseService,
+  index: number,
+  partial: boolean,
+  chainId: number = 31337,
+): Promise<string> {
+  const hexIndex = index.toString(16).padStart(4, "0");
+  const mock = structuredClone(MockVerificationExport);
+  mock.address = getAddress(`0x${hexIndex}${"0".repeat(40 - hexIndex.length)}`);
+  mock.chainId = chainId;
+  mock.onchainRuntimeBytecode = `0x${"aa".repeat(32)}${hexIndex}`;
+  mock.onchainCreationBytecode = `0x${"bb".repeat(32)}${hexIndex}`;
+  mock.compilation.runtimeBytecode = `0x${"cc".repeat(32)}${hexIndex}`;
+  mock.compilation.creationBytecode = `0x${"dd".repeat(32)}${hexIndex}`;
+  mock.compilation.runtimeBytecodeCborAuxdata = {};
+  mock.compilation.creationBytecodeCborAuxdata = {};
+  mock.deploymentInfo.txHash = `0x${"ee".repeat(31)}${hexIndex}`;
+  mock.status = partial
+    ? { runtimeMatch: "partial", creationMatch: "partial" }
+    : { runtimeMatch: "perfect", creationMatch: "perfect" };
+  await databaseService.storeVerification(mock);
+  return mock.address;
 }

--- a/services/server/test/integration/apiv1/repository-handlers/files.spec.ts
+++ b/services/server/test/integration/apiv1/repository-handlers/files.spec.ts
@@ -2,9 +2,9 @@ import chai from "chai";
 import config from "config";
 import chaiHttp from "chai-http";
 import {
-  deployAndVerifyContract,
   deployFromAbiAndBytecode,
   deployFromAbiAndBytecodeForCreatorTxHash,
+  insertMockVerification,
   waitSecs,
 } from "../../../helpers/helpers";
 import { LocalChainFixture } from "../../../helpers/LocalChainFixture";
@@ -14,6 +14,7 @@ import fs from "fs";
 import { RWStorageIdentifiers } from "../../../../src/server/services/storageServices/identifiers";
 import { id as keccak256 } from "ethers";
 import contractVyperArtifact from "../../../sources/vyper/testcontract/artifact.json";
+import type { SourcifyDatabaseService } from "../../../../src/server/services/storageServices/SourcifyDatabaseService";
 
 chai.use(chaiHttp);
 
@@ -591,23 +592,30 @@ describe("Verify repository endpoints", function () {
     },
   );
 
-  describe(`Pagination in /files/contracts/{full|any|partial}/${chainFixture.chainId}`, async function () {
+  describe(`Pagination in /files/contracts/{full|any|partial}/${chainFixture.chainId}`, function () {
     const endpointMatchTypes = ["full", "any", "partial"];
     for (const endpointMatchType of endpointMatchTypes) {
       it(`should handle pagination in /files/contracts/${endpointMatchType}/${chainFixture.chainId}`, async function () {
+        const databaseService = serverFixtureWithDatabase.server.services
+          .storage.rwServices[
+          RWStorageIdentifiers.SourcifyDatabase
+        ] as SourcifyDatabaseService;
+
         const contractAddresses: string[] = [];
 
-        // Deploy 5 contracts
+        // Insert 5 mock contracts directly into the database
         for (let i = 0; i < 5; i++) {
-          // Deploy partial matching contract if endpoint is partial or choose randomly if endpointMachtype is any. 'any' endpoint results should be consistent regardless.
-          const shouldDeployPartial =
+          // Use unique index per endpointMatchType to avoid conflicts across iterations
+          const globalIndex =
+            endpointMatchTypes.indexOf(endpointMatchType) * 10 + i;
+          const shouldBePartial =
             endpointMatchType === "partial" ||
-            (endpointMatchType === "any" && Math.random() > 0.5);
+            (endpointMatchType === "any" && i % 2 === 0);
 
-          const address = await deployAndVerifyContract(
-            chainFixture,
-            serverFixtureWithDatabase,
-            shouldDeployPartial,
+          const address = await insertMockVerification(
+            databaseService,
+            globalIndex,
+            shouldBePartial,
           );
           contractAddresses.push(address);
         }

--- a/services/server/test/unit/VerificationService.spec.ts
+++ b/services/server/test/unit/VerificationService.spec.ts
@@ -15,6 +15,7 @@ import { MockVerificationExport } from "../helpers/mocks";
 
 describe("VerificationService", function () {
   const sandbox = sinon.createSandbox();
+  let verificationService: VerificationService;
 
   beforeEach(function () {
     // Clear any previously nocked interceptors
@@ -22,10 +23,14 @@ describe("VerificationService", function () {
     rimraf.sync(path.join(testS3Path, testS3Bucket));
   });
 
-  afterEach(function () {
+  afterEach(async function () {
     // Ensure that all nock interceptors have been used
     nock.isDone();
     sandbox.restore();
+    // Destroy the Piscina worker pool to free memory
+    if (verificationService) {
+      await verificationService.close();
+    }
   });
 
   after(() => {
@@ -100,7 +105,7 @@ describe("VerificationService", function () {
         });
     }
 
-    const verificationService = new VerificationService(
+    verificationService = new VerificationService(
       {
         initCompilers: true,
         sourcifyChainMap: {},
@@ -140,7 +145,7 @@ describe("VerificationService", function () {
     const verificationId = "test-verification-id";
     const mockStorageService = createMockStorageService(verificationId);
 
-    const verificationService = new VerificationService(
+    verificationService = new VerificationService(
       {
         initCompilers: false,
         sourcifyChainMap: {},
@@ -201,7 +206,7 @@ describe("VerificationService", function () {
     const verificationId = "test-verification-id-s3";
     const mockStorageService = createMockStorageService(verificationId);
 
-    const verificationService = new VerificationService(
+    verificationService = new VerificationService(
       {
         initCompilers: false,
         sourcifyChainMap: {},
@@ -257,7 +262,7 @@ describe("VerificationService", function () {
     const verificationId = "test-verification-id-s3-fail";
     const mockStorageService = createMockStorageService(verificationId);
 
-    const verificationService = new VerificationService(
+    verificationService = new VerificationService(
       {
         initCompilers: false,
         sourcifyChainMap: {},


### PR DESCRIPTION
This PR fixes the out of memory error in CI server-test runs. It addresses three separate problems:

1. **Clean `VerificationService` after each test in its tests.** This is the real core of the problem. Each unit test creates a new VerificationService() which spins up a Piscina worker pool (minThreads=2), but never calls close(). After all 4 tests, 8 zombie worker threads remain alive for the rest of the suite, accumulating hundreds of MBs and eventually OOM-killing the CI container (exit 137). The fix calls verificationService.close() in afterEach to destroy the pool and free the threads.
2. **Gracefully close storage services with proper shutdown order.**  We've always missed gracefully closing the database storage services. I also make sure to close the Sourcify database storage service as last since other services are writing to it.
3. **Mock contracts insertion in should handle pagination.** In `file.spec.ts` we deploy and verify 15 contracts just to test pagination, I replaced it with inserting into database mocked contracts

See [how the latest CircleCI](https://app.circleci.com/pipelines/github/argotorg/sourcify/10925/workflows/bc98252d-4a76-4567-9e9b-a67d042991fe/jobs/63973/resources) run has a very low impact on memory.