### PR TITLE
fix: gate Vyper outputSelection fields by compiler version

### DIFF
--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -40,7 +40,7 @@ export function returnFixedVyperVersion(compilerVersion: string): string {
 // compilerVersionCompatibleWithSemver strips the rc/b suffix, so all 0.4.0
 // variants look the same to semver — we must inspect the raw version for that
 // specific boundary.
-function supportsCreationBytecodeSourceMap(
+export function supportsCreationBytecodeSourceMap(
   compilerVersion: string,
   compatibleVersion: string,
 ): boolean {

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -5,7 +5,7 @@ import {
   decode,
   splitAuxdata,
 } from '@ethereum-sourcify/bytecode-utils';
-import semver, { gte } from 'semver';
+import semver, { gte, gt, lt } from 'semver';
 import type {
   VyperJsonInput,
   VyperOutput,
@@ -34,6 +34,23 @@ export function returnFixedVyperVersion(compilerVersion: string): string {
       throw new CompilationError({ code: 'invalid_compiler_version' });
     }
   }
+}
+
+// evm.bytecode.sourceMap is supported from 0.4.0rc4 onwards.
+// compilerVersionCompatibleWithSemver strips the rc/b suffix, so all 0.4.0
+// variants look the same to semver — we must inspect the raw version for that
+// specific boundary.
+function supportsCreationBytecodeSourceMap(
+  compilerVersion: string,
+  compatibleVersion: string,
+): boolean {
+  if (gt(compatibleVersion, '0.4.0')) return true;
+  if (lt(compatibleVersion, '0.4.0')) return false;
+  // Exactly 0.4.0 — inspect the original version string
+  if (/0\.4\.0b\d+/.test(compilerVersion)) return false;
+  const rcMatch = compilerVersion.match(/0\.4\.0rc(\d+)/);
+  if (rcMatch) return parseInt(rcMatch[1]) >= 4;
+  return true; // stable 0.4.0
 }
 
 export function returnAuxdataStyle(
@@ -108,9 +125,6 @@ export class VyperCompilation extends AbstractCompilation {
       'ast',
       'interface',
       'ir',
-      'layout',
-      'userdoc',
-      'devdoc',
       'evm.bytecode.object',
       'evm.bytecode.opcodes',
       'evm.deployedBytecode.object',
@@ -119,8 +133,24 @@ export class VyperCompilation extends AbstractCompilation {
       'evm.methodIdentifiers',
     ];
 
-    // evm.bytecode.sourceMap output selection is only supported since Vyper 0.4.0
-    if (gte(this.compilerVersionCompatibleWithSemver, '0.4.0')) {
+    // userdoc and devdoc are only supported from 0.2.0 onwards
+    if (gte(this.compilerVersionCompatibleWithSemver, '0.2.0')) {
+      outputs.push('userdoc');
+      outputs.push('devdoc');
+    }
+
+    // layout is only supported from 0.4.1 onwards (including betas and rcs)
+    if (gte(this.compilerVersionCompatibleWithSemver, '0.4.1')) {
+      outputs.push('layout');
+    }
+
+    // evm.bytecode.sourceMap is only supported from 0.4.0rc4 onwards
+    if (
+      supportsCreationBytecodeSourceMap(
+        this.compilerVersion,
+        this.compilerVersionCompatibleWithSemver,
+      )
+    ) {
       outputs.push('evm.bytecode.sourceMap');
     }
 

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -1,9 +1,12 @@
 import { describe, it } from 'mocha';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import fs from 'fs';
 import { VyperCompilation } from '../../src/Compilation/VyperCompilation';
 import { vyperCompiler } from '../utils';
+
+chai.use(chaiAsPromised);
 
 describe('VyperCompilation', () => {
   it('should compile a simple Vyper contract', async () => {
@@ -687,5 +690,79 @@ describe('VyperCompilation', () => {
     );
 
     expect(compilation.compilerVersion).to.equal('0.3.10+commit.91361694');
+  });
+});
+
+// Helper to build a VyperCompilation with a mock compiler (no actual compilation needed)
+function makeCompilation(version: string) {
+  const mockCompiler = {
+    compile: async () => ({ contracts: {} as any }),
+  };
+  return new VyperCompilation(
+    mockCompiler as any,
+    version,
+    {
+      language: 'Vyper',
+      sources: { 'test.vy': { content: '' } },
+      settings: { outputSelection: { '*': [] } },
+    },
+    { name: 'test', path: 'test.vy' },
+  );
+}
+
+function outputsFor(version: string): string[] {
+  const compilation = makeCompilation(version);
+  return compilation.jsonInput.settings!.outputSelection![
+    'test.vy'
+  ] as string[];
+}
+
+describe('VyperCompilation outputSelection version gating', () => {
+  it('0.1.x: excludes userdoc, devdoc, layout, evm.bytecode.sourceMap', () => {
+    const outputs = outputsFor('0.1.0b16+commit.5e4a94a');
+    expect(outputs).to.not.include('userdoc');
+    expect(outputs).to.not.include('devdoc');
+    expect(outputs).to.not.include('layout');
+    expect(outputs).to.not.include('evm.bytecode.sourceMap');
+  });
+
+  it('0.2.x: includes userdoc and devdoc, excludes layout, evm.bytecode.sourceMap', () => {
+    const outputs = outputsFor('0.2.0+commit.a7f14fe');
+    expect(outputs).to.include('userdoc');
+    expect(outputs).to.include('devdoc');
+    expect(outputs).to.not.include('layout');
+    expect(outputs).to.not.include('evm.bytecode.sourceMap');
+  });
+
+  it('0.4.0rc3: excludes layout and evm.bytecode.sourceMap', () => {
+    const outputs = outputsFor('0.4.0rc3+commit.f2136550');
+    expect(outputs).to.include('userdoc');
+    expect(outputs).to.include('devdoc');
+    expect(outputs).to.not.include('layout');
+    expect(outputs).to.not.include('evm.bytecode.sourceMap');
+  });
+
+  it('0.4.0rc4: includes evm.bytecode.sourceMap, excludes layout', () => {
+    const outputs = outputsFor('0.4.0rc4+commit.d0d581d');
+    expect(outputs).to.include('userdoc');
+    expect(outputs).to.include('devdoc');
+    expect(outputs).to.not.include('layout');
+    expect(outputs).to.include('evm.bytecode.sourceMap');
+  });
+
+  it('0.4.0 stable: includes evm.bytecode.sourceMap, excludes layout', () => {
+    const outputs = outputsFor('0.4.0+commit.e9db8d9f');
+    expect(outputs).to.include('userdoc');
+    expect(outputs).to.include('devdoc');
+    expect(outputs).to.not.include('layout');
+    expect(outputs).to.include('evm.bytecode.sourceMap');
+  });
+
+  it('0.4.1+: includes userdoc, devdoc, layout, evm.bytecode.sourceMap', () => {
+    const outputs = outputsFor('0.4.1+commit.8a93dd27');
+    expect(outputs).to.include('userdoc');
+    expect(outputs).to.include('devdoc');
+    expect(outputs).to.include('layout');
+    expect(outputs).to.include('evm.bytecode.sourceMap');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2757 — old Vyper versions (e.g. `0.1.0b16`) were rejecting verification with `compiler_error: Invalid outputSelection - 'userdoc'` because `initVyperJsonInput` unconditionally added output fields that didn't exist in those compiler versions.

## Investigation

We built a script (`scripts/test-vyper-versions.ts`) that iterates every release from the Vyper Hardhat mirror (`https://vyper-releases-mirror.hardhat.org/list.json`), instantiates `VyperCompilation` for each version, calls `compile()`, and records success or the full compiler error. Running it against all 60 available versions revealed the exact version boundaries for each unsupported output field:

| Output field | Supported from |
|---|---|
| `userdoc` / `devdoc` | `0.2.0` |
| `evm.bytecode.sourceMap` | `0.4.0rc4` |
| `layout` | `0.4.1` (including betas/rcs) |

The `evm.bytecode.sourceMap` boundary required special handling: `returnFixedVyperVersion` strips `rc`/`b` suffixes, so all `0.4.0` variants map to the same semver `0.4.0`. A dedicated `supportsCreationBytecodeSourceMap()` function inspects the raw compiler version string to distinguish rc3 from rc4.

## Changes

- **`VyperCompilation.initVyperJsonInput`**: gates `userdoc`/`devdoc` behind `>=0.2.0`, `layout` behind `>=0.4.1`, and `evm.bytecode.sourceMap` behind `>=0.4.0rc4`
- **`supportsCreationBytecodeSourceMap`**: new exported helper that handles the `0.4.0` rc boundary
- **`VyperCompilation.spec.ts`**: unit tests covering all version boundaries without downloading any compiler binary; also adds missing `chai-as-promised` registration

## Test plan

- [ ] Run `cd packages/lib-sourcify && npm test` — new unit tests pass
- [ ] Retry verification of `0x2146b07c9c9fC7B4bFc31D29ef59E2a179F881b6` on Ethereum Mainnet (chain 1) with compiler `vyper:0.1.0b16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)