### PR TITLE
ci: add kuzdoganbot routine workflow

### DIFF
--- a/.github/workflows/kuzdoganbot.yml
+++ b/.github/workflows/kuzdoganbot.yml
@@ -1,0 +1,20 @@
+name: kuzdoganbot routine
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fire:
+    if: >
+      github.event.comment.user.login == 'kuzdogan' &&
+      startsWith(github.event.comment.body, '/kuzdoganbot')
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/_fire-routine.yml
+    with:
+      trigger_prefix: /kuzdoganbot
+      routine_url: https://api.anthropic.com/v1/claude_code/routines/trig_01G8ZiE6uu9reRQrx39dduvg/fire
+    secrets:
+      anthropic_token: ${{ secrets.ANTHROPIC_TOKEN_KAAN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/kuzdoganbot.yml` — a routine trigger workflow for `@kuzdogan`, mirroring the `marcocastignoli-bot` workflow from #2768
- Triggers when `kuzdogan` posts a comment starting with `/kuzdoganbot`
- Uses the reusable `_fire-routine.yml` workflow (already on staging)
- Fires routine `trig_01G8ZiE6uu9reRQrx39dduvg` using the `ANTHROPIC_TOKEN_KAAN` secret

## Prerequisites

Make sure the `ANTHROPIC_TOKEN_KAAN` secret is set in the repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)