### PR TITLE
feat(server): optional remote chain registry to augment sourcify-chains

### DIFF
--- a/services/server/.env.dev
+++ b/services/server/.env.dev
@@ -48,6 +48,17 @@ NODE_LOG_LEVEL=
 # Configuration for the Piscina worker pool
 # How long one worker can be idle before it is shutdown in seconds. If not set, uses 30 s as default.
 WORKER_IDLE_TIMEOUT=
+
+# Optional remote chain registry. When set, the server fetches additional
+# chains at boot and merges them with the bundled sourcify-chains-default.json.
+# Static chains/extensions always take precedence over remote entries.
+# Payload format is chainlist.org-style: a JSON object keyed by chainId where
+# each entry has { chainId, rpc[], name?, hidden?, ... } and may optionally
+# include a `sourcifyExtension` field with full sourcify-chains-default.json
+# semantics (etherscanApi, fetchContractCreationTxUsing, typed RPCs, etc.).
+CHAIN_REGISTRY_URL=
+# Optional bearer token sent as `Authorization: Bearer <token>` to the registry
+CHAIN_REGISTRY_AUTH_TOKEN=
 # How many verifications one worker can handle concurrently. If not set, uses 5 as default.
 CONCURRENT_VERIFICATIONS_PER_WORKER=
 

--- a/services/server/src/chain-registry.ts
+++ b/services/server/src/chain-registry.ts
@@ -1,0 +1,237 @@
+import type {
+  Chain,
+  SourcifyChainExtension,
+  APIKeyRPC,
+  BaseRPC,
+  FetchRequestRPC,
+} from "@ethereum-sourcify/lib-sourcify";
+import logger from "./common/logger";
+
+// Extended FetchRequestRPC variant used by sourcify-chains-default.json,
+// where header values can be sourced from environment variables. Mirrors the
+// type defined in sourcify-chains.ts so a remote registry can serve the same
+// shape as the local sourcify-chains-default.json.
+type FetchRequestRPCWithHeaderEnvName = Omit<FetchRequestRPC, "headers"> & {
+  headers?: Array<{
+    headerName: string;
+    headerValue?: string;
+    headerEnvName?: string;
+  }>;
+};
+
+// Sourcify-extension variant accepted from a remote registry. Same as
+// SourcifyChainExtension but with the extended FetchRequestRPC variant.
+export type RemoteSourcifyExtension = Omit<SourcifyChainExtension, "rpc"> & {
+  rpc?: Array<string | BaseRPC | APIKeyRPC | FetchRequestRPCWithHeaderEnvName>;
+};
+
+// One entry in the remote chain registry response. Compatible with
+// chainlist.org's chains.json: only `chainId` is required; `rpc` is recommended
+// but optional. An optional `hidden` flag mirrors the chainlist convention for
+// chains that should not be advertised. An optional `sourcifyExtension` lets
+// the registry serve full sourcify-chains-default.json semantics (api keys,
+// Etherscan support, fetchContractCreationTxUsing, etc.) when needed.
+export interface RemoteChainEntry {
+  chainId: number;
+  name?: string;
+  title?: string;
+  shortName?: string;
+  network?: string;
+  networkId?: number;
+  infoURL?: string;
+  faucets?: string[];
+  nativeCurrency?: {
+    name: string;
+    symbol: string;
+    decimals: number;
+  };
+  rpc?: string[];
+  hidden?: boolean;
+  // Optional. The remote registry may omit `sourcifyName` / `supported`; we
+  // fill in defaults from the entry when they are missing.
+  sourcifyExtension?: Partial<RemoteSourcifyExtension>;
+}
+
+// The remote payload is an object keyed by chain id (string) -> entry, matching
+// chainlist.org's representation of chains.json.
+export type RemoteChainRegistryResponse = Record<string, RemoteChainEntry>;
+
+export interface ChainRegistryOptions {
+  url: string;
+  authToken?: string;
+  timeoutMs?: number;
+}
+
+export interface ChainRegistryResult {
+  // Entries to merge into the chains.json layer (Chain metadata).
+  chainsJsonAdditions: Chain[];
+  // Entries to merge into the sourcifyChainsExtensions layer.
+  extensionAdditions: Record<string, RemoteSourcifyExtension>;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const isHttpUrl = (value: string): boolean =>
+  value.startsWith("http://") || value.startsWith("https://");
+
+const isRemoteChainEntry = (value: unknown): value is RemoteChainEntry => {
+  if (!isObject(value)) return false;
+  if (typeof value.chainId !== "number") return false;
+  if (value.rpc !== undefined && !isStringArray(value.rpc)) return false;
+  if (value.hidden !== undefined && typeof value.hidden !== "boolean")
+    return false;
+  if (value.name !== undefined && typeof value.name !== "string") return false;
+  return true;
+};
+
+const parseResponse = (raw: unknown): RemoteChainRegistryResponse => {
+  if (!isObject(raw)) {
+    throw new Error("Remote chain registry response is not a JSON object");
+  }
+  const out: RemoteChainRegistryResponse = {};
+  for (const [key, entry] of Object.entries(raw)) {
+    if (!isRemoteChainEntry(entry)) {
+      logger.warn("chainRegistry: skipping invalid entry", { key });
+      continue;
+    }
+    out[key] = entry;
+  }
+  return out;
+};
+
+const buildChainFromEntry = (entry: RemoteChainEntry): Chain => ({
+  name: entry.name ?? `Chain ${entry.chainId}`,
+  title: entry.title,
+  chainId: entry.chainId,
+  shortName: entry.shortName,
+  network: entry.network,
+  networkId: entry.networkId,
+  nativeCurrency: entry.nativeCurrency,
+  rpc: entry.rpc ?? [],
+  faucets: entry.faucets,
+  infoURL: entry.infoURL,
+});
+
+const buildExtensionFromEntry = (
+  entry: RemoteChainEntry,
+  httpRpcs: string[],
+): RemoteSourcifyExtension => {
+  if (entry.sourcifyExtension) {
+    // The remote registry provided a full Sourcify extension. Trust it,
+    // but ensure `sourcifyName` and `supported` have sensible defaults.
+    const ext = entry.sourcifyExtension;
+    return {
+      ...ext,
+      sourcifyName: ext.sourcifyName ?? entry.name ?? `Chain ${entry.chainId}`,
+      supported: ext.supported ?? true,
+    };
+  }
+  return {
+    sourcifyName: entry.name ?? `Chain ${entry.chainId}`,
+    supported: true,
+    rpc: httpRpcs,
+  };
+};
+
+/**
+ * Fetches a remote chain registry and converts it to additions that can be
+ * merged into the local chains.json layer and sourcifyChainsExtensions layer.
+ *
+ * The caller is responsible for enforcing static-vs-remote precedence (i.e.
+ * not overwriting a chainId that already exists locally).
+ *
+ * On any failure (network error, non-2xx, malformed payload, timeout) this
+ * function logs a warning and returns empty additions. Callers that need to
+ * fail-fast should check the result emptiness or wrap with their own logic.
+ */
+export async function fetchChainRegistry(
+  options: ChainRegistryOptions,
+): Promise<ChainRegistryResult> {
+  const empty: ChainRegistryResult = {
+    chainsJsonAdditions: [],
+    extensionAdditions: {},
+  };
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (options.authToken) {
+    headers["Authorization"] = `Bearer ${options.authToken}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(options.url, {
+      headers,
+      signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+  } catch (error) {
+    logger.warn("chainRegistry: fetch failed", {
+      url: options.url,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return empty;
+  }
+
+  if (!response.ok) {
+    logger.warn("chainRegistry: non-2xx response", {
+      url: options.url,
+      status: response.status,
+    });
+    return empty;
+  }
+
+  let parsed: RemoteChainRegistryResponse;
+  try {
+    const raw = (await response.json()) as unknown;
+    parsed = parseResponse(raw);
+  } catch (error) {
+    logger.warn("chainRegistry: failed to parse response", {
+      url: options.url,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return empty;
+  }
+
+  const chainsJsonAdditions: Chain[] = [];
+  const extensionAdditions: Record<string, RemoteSourcifyExtension> = {};
+
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (entry.hidden) {
+      logger.debug("chainRegistry: skipping hidden chain", {
+        chainId: entry.chainId,
+        key,
+      });
+      continue;
+    }
+
+    const httpRpcs = (entry.rpc ?? []).filter(isHttpUrl);
+    const hasUsableRpc =
+      httpRpcs.length > 0 || (entry.sourcifyExtension?.rpc?.length ?? 0) > 0;
+
+    if (!hasUsableRpc) {
+      logger.warn("chainRegistry: skipping chain with no usable RPC", {
+        chainId: entry.chainId,
+        key,
+      });
+      continue;
+    }
+
+    chainsJsonAdditions.push(buildChainFromEntry(entry));
+    extensionAdditions[entry.chainId.toString()] = buildExtensionFromEntry(
+      entry,
+      httpRpcs,
+    );
+  }
+
+  logger.info("chainRegistry: loaded remote chains", {
+    url: options.url,
+    count: chainsJsonAdditions.length,
+  });
+
+  return { chainsJsonAdditions, extensionAdditions };
+}

--- a/services/server/src/config/default.js
+++ b/services/server/src/config/default.js
@@ -45,6 +45,16 @@ module.exports = {
   // verify-deprecated endpoint used in services/database/scripts.mjs. Used when recreating the DB with deprecated chains that don't have an RPC.
   verifyDeprecated: false,
   replaceContract: false,
+  // Optional remote chain registry. When `url` is set the server fetches
+  // additional chains at boot and merges them with the bundled chains.json
+  // and sourcify-chains-default.json. Static chains/extensions always win;
+  // remote entries are only added for chainIds that aren't already known.
+  // The bearer token (if any) lives in process.env.CHAIN_REGISTRY_AUTH_TOKEN.
+  chainRegistry: {
+    url: process.env.CHAIN_REGISTRY_URL || undefined,
+    required: false,
+    timeoutMs: 10000,
+  },
   brownoutV1: {
     enabled: false,
     windows: [],

--- a/services/server/src/server/cli.ts
+++ b/services/server/src/server/cli.ts
@@ -13,15 +13,18 @@ import yamljs from "yamljs";
 
 // local imports
 import logger from "../common/logger";
-import { sourcifyChainsMap } from "../sourcify-chains";
+import type { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
+import { buildSourcifyChainsMap } from "../sourcify-chains";
 import type { LibSourcifyConfig } from "./server";
 import { Server } from "./server";
 import { SolcLocal } from "./services/compiler/local/SolcLocal";
 import { VyperLocal } from "./services/compiler/local/VyperLocal";
 import { FeLocal } from "./services/compiler/local/FeLocal";
 
-export const getEtherscanApiKeyForEachChain = (): Record<string, string> =>
-  Object.entries(sourcifyChainsMap).reduce<Record<string, string>>(
+export const getEtherscanApiKeyForEachChain = (
+  chainsMap: SourcifyChainMap,
+): Record<string, string> =>
+  Object.entries(chainsMap).reduce<Record<string, string>>(
     (acc, [chainId, { supported, etherscanApi }]) => {
       const envName = supported ? etherscanApi?.apiKeyEnvName : undefined;
       const value = envName ? process.env[envName] : undefined;
@@ -85,153 +88,183 @@ export const fe = new FeLocal(feRepoPath);
 Object.defineProperty(RegExp.prototype, "toJSON", {
   value: RegExp.prototype.toString,
 });
-// Start Server
-logger.info("Starting server with config", {
-  config: JSON.stringify(config.util.toObject(), null, 2),
-});
-const server = new Server(
-  {
-    port: config.get("server.port"),
-    maxFileSize: config.get("server.maxFileSize"),
-    corsAllowedOrigins: config.get("corsAllowedOrigins"),
-    solc,
-    vyper,
-    fe,
-    chains: sourcifyChainsMap,
-    verifyDeprecated: config.get("verifyDeprecated"),
-    replaceContract: config.get("replaceContract"),
-    sourcifyPrivateToken: process.env.SOURCIFY_PRIVATE_TOKEN,
-    logLevel,
-    libSourcifyConfig,
-    sourcifyVerifyUi: process.env.SOURCIFY_VERIFY_UI,
-    sourcifyRepoUi: process.env.SOURCIFY_REPO_UI,
-    brownoutV1: {
-      enabled: config.get("brownoutV1.enabled"),
-      windows: config.get("brownoutV1.windows"),
-    },
-  },
-  {
-    initCompilers: config.get("initCompilers") || false,
-    sourcifyChainMap: sourcifyChainsMap,
-    solcRepoPath,
-    solJsonRepoPath,
-    vyperRepoPath,
-    feRepoPath,
-    workerIdleTimeout: process.env.WORKER_IDLE_TIMEOUT
-      ? parseInt(process.env.WORKER_IDLE_TIMEOUT)
-      : undefined,
-    concurrentVerificationsPerWorker: process.env
-      .CONCURRENT_VERIFICATIONS_PER_WORKER
-      ? parseInt(process.env.CONCURRENT_VERIFICATIONS_PER_WORKER)
-      : undefined,
-    debugDataS3Config:
-      process.env.DEBUG_DATA_S3_BUCKET && process.env.DEBUG_DATA_S3_REGION
-        ? {
-            bucket: process.env.DEBUG_DATA_S3_BUCKET,
-            region: process.env.DEBUG_DATA_S3_REGION,
-            accessKeyId: process.env.DEBUG_DATA_S3_ACCESS_KEY_ID,
-            secretAccessKey: process.env.DEBUG_DATA_S3_SECRET_ACCESS_KEY,
-            endpoint: process.env.DEBUG_DATA_S3_ENDPOINT,
-          }
-        : undefined,
-  },
-  {
-    serverUrl: config.get("serverUrl"),
-    enabledServices: {
-      read: config.get("storage.read"),
-      writeOrWarn: config.get("storage.writeOrWarn"),
-      writeOrErr: config.get("storage.writeOrErr"),
-    },
-    repositoryV1ServiceOptions: {
-      repositoryPath: config.get("repositoryV1.path"),
-    },
-    repositoryV2ServiceOptions: {
-      repositoryPath: config.has("repositoryV2.path")
-        ? config.get("repositoryV2.path")
-        : undefined,
-    },
-    s3RepositoryServiceOptions: {
-      bucket: process.env.S3_BUCKET as string,
-      region: process.env.S3_REGION as string,
-      accessKeyId: process.env.S3_ACCESS_KEY_ID as string,
-      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY as string,
-      endpoint: process.env.S3_ENDPOINT as string,
-    },
-    sourcifyDatabaseServiceOptions: {
-      postgres: {
-        host: process.env.SOURCIFY_POSTGRES_HOST as string,
-        database: process.env.SOURCIFY_POSTGRES_DB as string,
-        user: process.env.SOURCIFY_POSTGRES_USER as string,
-        password: process.env.SOURCIFY_POSTGRES_PASSWORD as string,
-        port: parseInt(process.env.SOURCIFY_POSTGRES_PORT || "5432"),
-        ssl:
-          process.env.SOURCIFY_POSTGRES_SSL === "true"
-            ? {
-                rejectUnauthorized:
-                  process.env.SOURCIFY_POSTGRES_SSL_REJECT_UNAUTHORIZED ===
-                  "true",
-              }
-            : undefined,
-      },
-      schema: process.env.SOURCIFY_POSTGRES_SCHEMA as string,
-      maxConnections: process.env.SOURCIFY_POSTGRES_MAX_CONNECTIONS
-        ? parseInt(process.env.SOURCIFY_POSTGRES_MAX_CONNECTIONS)
-        : undefined,
-    },
-    allianceDatabaseServiceOptions: {
-      googleCloudSql: {
-        instanceName: process.env
-          .ALLIANCE_GOOGLE_CLOUD_SQL_INSTANCE_NAME as string,
-        database: process.env.ALLIANCE_GOOGLE_CLOUD_SQL_DATABASE as string,
-        user: process.env.ALLIANCE_GOOGLE_CLOUD_SQL_USER as string,
-        password: process.env.ALLIANCE_GOOGLE_CLOUD_SQL_PASSWORD as string,
-      },
-      postgres: {
-        host: process.env.ALLIANCE_POSTGRES_HOST as string,
-        database: process.env.ALLIANCE_POSTGRES_DB as string,
-        user: process.env.ALLIANCE_POSTGRES_USER as string,
-        password: process.env.ALLIANCE_POSTGRES_PASSWORD as string,
-        port: parseInt(process.env.ALLIANCE_POSTGRES_PORT || "5432"),
-      },
-      schema: process.env.ALLIANCE_POSTGRES_SCHEMA as string,
-      maxConnections: process.env.ALLIANCE_DB_MAX_CONNECTIONS
-        ? parseInt(process.env.ALLIANCE_DB_MAX_CONNECTIONS)
-        : undefined,
-    },
-    etherscanVerifyApiServiceOptions: {
-      EtherscanVerify: {
-        defaultApiKey: process.env.ETHERSCAN_API_KEY as string,
-        // Extract the etherscanApiKey env vars from the supported chains
-        apiKeys: getEtherscanApiKeyForEachChain(),
-      },
-      BlockscoutVerify: {
-        defaultApiKey: process.env.BLOCKSCOUT_API_KEY as string,
-      },
-      RoutescanVerify: {
-        defaultApiKey: process.env.ROUTESCAN_API_KEY as string,
-      },
-    },
-  },
-);
 
-// Generate the swagger.json and serve it with SwaggerUI at /api-docs
-server.services.init().then(() => {
-  server
-    .loadSwagger(yamljs.load(path.join(__dirname, "..", "openapi.yaml"))) // load the openapi file with the $refs resolved
-    .then((swaggerDocument: any) => {
-      server.app.get("/api-docs/swagger.json", (req, res) => {
-        res.json(swaggerDocument);
-      });
-      server.app.use(
-        "/api-docs",
-        swaggerUi.serve,
-        swaggerUi.setup(swaggerDocument, {
-          customSiteTitle: "Sourcify API",
-          customfavIcon: "https://sourcify.dev/favicon.ico",
-        }),
-      );
-      server.app.listen(server.port, () => {
-        logger.info("Server listening", { port: server.port });
-      });
-    });
+async function bootstrap() {
+  // Optional remote chain registry. Static chains/extensions always win.
+  const chainRegistryUrl = config.has("chainRegistry.url")
+    ? (config.get("chainRegistry.url") as string | undefined)
+    : undefined;
+  const chainRegistryRequired = config.has("chainRegistry.required")
+    ? (config.get("chainRegistry.required") as boolean)
+    : false;
+  const chainRegistryTimeoutMs = config.has("chainRegistry.timeoutMs")
+    ? (config.get("chainRegistry.timeoutMs") as number)
+    : undefined;
+
+  const sourcifyChainsMap = await buildSourcifyChainsMap({
+    chainRegistry: chainRegistryUrl
+      ? {
+          url: chainRegistryUrl,
+          authToken: process.env.CHAIN_REGISTRY_AUTH_TOKEN,
+          timeoutMs: chainRegistryTimeoutMs,
+        }
+      : undefined,
+    chainRegistryRequired,
+  });
+
+  // Start Server
+  logger.info("Starting server with config", {
+    config: JSON.stringify(config.util.toObject(), null, 2),
+  });
+  const server = new Server(
+    {
+      port: config.get("server.port"),
+      maxFileSize: config.get("server.maxFileSize"),
+      corsAllowedOrigins: config.get("corsAllowedOrigins"),
+      solc,
+      vyper,
+      fe,
+      chains: sourcifyChainsMap,
+      verifyDeprecated: config.get("verifyDeprecated"),
+      replaceContract: config.get("replaceContract"),
+      sourcifyPrivateToken: process.env.SOURCIFY_PRIVATE_TOKEN,
+      logLevel,
+      libSourcifyConfig,
+      sourcifyVerifyUi: process.env.SOURCIFY_VERIFY_UI,
+      sourcifyRepoUi: process.env.SOURCIFY_REPO_UI,
+      brownoutV1: {
+        enabled: config.get("brownoutV1.enabled"),
+        windows: config.get("brownoutV1.windows"),
+      },
+    },
+    {
+      initCompilers: config.get("initCompilers") || false,
+      sourcifyChainMap: sourcifyChainsMap,
+      solcRepoPath,
+      solJsonRepoPath,
+      vyperRepoPath,
+      feRepoPath,
+      workerIdleTimeout: process.env.WORKER_IDLE_TIMEOUT
+        ? parseInt(process.env.WORKER_IDLE_TIMEOUT)
+        : undefined,
+      concurrentVerificationsPerWorker: process.env
+        .CONCURRENT_VERIFICATIONS_PER_WORKER
+        ? parseInt(process.env.CONCURRENT_VERIFICATIONS_PER_WORKER)
+        : undefined,
+      debugDataS3Config:
+        process.env.DEBUG_DATA_S3_BUCKET && process.env.DEBUG_DATA_S3_REGION
+          ? {
+              bucket: process.env.DEBUG_DATA_S3_BUCKET,
+              region: process.env.DEBUG_DATA_S3_REGION,
+              accessKeyId: process.env.DEBUG_DATA_S3_ACCESS_KEY_ID,
+              secretAccessKey: process.env.DEBUG_DATA_S3_SECRET_ACCESS_KEY,
+              endpoint: process.env.DEBUG_DATA_S3_ENDPOINT,
+            }
+          : undefined,
+    },
+    {
+      serverUrl: config.get("serverUrl"),
+      enabledServices: {
+        read: config.get("storage.read"),
+        writeOrWarn: config.get("storage.writeOrWarn"),
+        writeOrErr: config.get("storage.writeOrErr"),
+      },
+      repositoryV1ServiceOptions: {
+        repositoryPath: config.get("repositoryV1.path"),
+      },
+      repositoryV2ServiceOptions: {
+        repositoryPath: config.has("repositoryV2.path")
+          ? config.get("repositoryV2.path")
+          : undefined,
+      },
+      s3RepositoryServiceOptions: {
+        bucket: process.env.S3_BUCKET as string,
+        region: process.env.S3_REGION as string,
+        accessKeyId: process.env.S3_ACCESS_KEY_ID as string,
+        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY as string,
+        endpoint: process.env.S3_ENDPOINT as string,
+      },
+      sourcifyDatabaseServiceOptions: {
+        postgres: {
+          host: process.env.SOURCIFY_POSTGRES_HOST as string,
+          database: process.env.SOURCIFY_POSTGRES_DB as string,
+          user: process.env.SOURCIFY_POSTGRES_USER as string,
+          password: process.env.SOURCIFY_POSTGRES_PASSWORD as string,
+          port: parseInt(process.env.SOURCIFY_POSTGRES_PORT || "5432"),
+          ssl:
+            process.env.SOURCIFY_POSTGRES_SSL === "true"
+              ? {
+                  rejectUnauthorized:
+                    process.env.SOURCIFY_POSTGRES_SSL_REJECT_UNAUTHORIZED ===
+                    "true",
+                }
+              : undefined,
+        },
+        schema: process.env.SOURCIFY_POSTGRES_SCHEMA as string,
+        maxConnections: process.env.SOURCIFY_POSTGRES_MAX_CONNECTIONS
+          ? parseInt(process.env.SOURCIFY_POSTGRES_MAX_CONNECTIONS)
+          : undefined,
+      },
+      allianceDatabaseServiceOptions: {
+        googleCloudSql: {
+          instanceName: process.env
+            .ALLIANCE_GOOGLE_CLOUD_SQL_INSTANCE_NAME as string,
+          database: process.env.ALLIANCE_GOOGLE_CLOUD_SQL_DATABASE as string,
+          user: process.env.ALLIANCE_GOOGLE_CLOUD_SQL_USER as string,
+          password: process.env.ALLIANCE_GOOGLE_CLOUD_SQL_PASSWORD as string,
+        },
+        postgres: {
+          host: process.env.ALLIANCE_POSTGRES_HOST as string,
+          database: process.env.ALLIANCE_POSTGRES_DB as string,
+          user: process.env.ALLIANCE_POSTGRES_USER as string,
+          password: process.env.ALLIANCE_POSTGRES_PASSWORD as string,
+          port: parseInt(process.env.ALLIANCE_POSTGRES_PORT || "5432"),
+        },
+        schema: process.env.ALLIANCE_POSTGRES_SCHEMA as string,
+        maxConnections: process.env.ALLIANCE_DB_MAX_CONNECTIONS
+          ? parseInt(process.env.ALLIANCE_DB_MAX_CONNECTIONS)
+          : undefined,
+      },
+      etherscanVerifyApiServiceOptions: {
+        EtherscanVerify: {
+          defaultApiKey: process.env.ETHERSCAN_API_KEY as string,
+          // Extract the etherscanApiKey env vars from the supported chains
+          apiKeys: getEtherscanApiKeyForEachChain(sourcifyChainsMap),
+        },
+        BlockscoutVerify: {
+          defaultApiKey: process.env.BLOCKSCOUT_API_KEY as string,
+        },
+        RoutescanVerify: {
+          defaultApiKey: process.env.ROUTESCAN_API_KEY as string,
+        },
+      },
+    },
+  );
+
+  // Generate the swagger.json and serve it with SwaggerUI at /api-docs
+  await server.services.init();
+  const swaggerDocument = await server.loadSwagger(
+    yamljs.load(path.join(__dirname, "..", "openapi.yaml")), // load the openapi file with the $refs resolved
+  );
+  server.app.get("/api-docs/swagger.json", (req, res) => {
+    res.json(swaggerDocument);
+  });
+  server.app.use(
+    "/api-docs",
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerDocument, {
+      customSiteTitle: "Sourcify API",
+      customfavIcon: "https://sourcify.dev/favicon.ico",
+    }),
+  );
+  server.app.listen(server.port, () => {
+    logger.info("Server listening", { port: server.port });
+  });
+}
+
+bootstrap().catch((error) => {
+  logger.error("Server bootstrap failed", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exit(1);
 });

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -14,6 +14,10 @@ import rawSourcifyChainExtentions from "./sourcify-chains-default.json";
 import logger from "./common/logger";
 import fs from "fs";
 import path from "path";
+import {
+  fetchChainRegistry,
+  type ChainRegistryOptions,
+} from "./chain-registry";
 
 import dotenv from "dotenv";
 
@@ -38,39 +42,41 @@ interface SourcifyChainsExtensionsObjectWithHeaderEnvName {
   };
 }
 
-let sourcifyChainsExtensions: SourcifyChainsExtensionsObjectWithHeaderEnvName =
-  {};
-
-// If sourcify-chains.json exists, override sourcify-chains-default.json
-if (fs.existsSync(path.resolve(__dirname, "./sourcify-chains.json"))) {
-  logger.warn(
-    "Overriding default chains: using sourcify-chains.json instead of sourcify-chains-default.json",
-  );
-  const rawSourcifyChainExtentionsFromFile = fs.readFileSync(
-    path.resolve(__dirname, "./sourcify-chains.json"),
-    "utf8",
-  );
-  sourcifyChainsExtensions = JSON.parse(
-    rawSourcifyChainExtentionsFromFile,
-  ) as SourcifyChainsExtensionsObjectWithHeaderEnvName;
-}
-// sourcify-chains-default.json
-else {
-  sourcifyChainsExtensions =
-    rawSourcifyChainExtentions as SourcifyChainsExtensionsObjectWithHeaderEnvName;
-}
-
-const chainMapById = new Map<number, Chain>();
-// Add chains.json from ethereum-lists (chainId.network/chains.json)
-chainsRaw.forEach((chain) => chainMapById.set(chain.chainId, chain));
-// Chains that we decide to support but that are not in chains.json
-extraChainsRaw.forEach((chain) => {
-  // Skip if chainsRaw already defines this chainId so canonical entry wins
-  if (!chainMapById.has(chain.chainId)) {
-    chainMapById.set(chain.chainId, chain);
+function loadDefaultExtensions(): SourcifyChainsExtensionsObjectWithHeaderEnvName {
+  // If sourcify-chains.json exists, override sourcify-chains-default.json
+  if (fs.existsSync(path.resolve(__dirname, "./sourcify-chains.json"))) {
+    logger.warn(
+      "Overriding default chains: using sourcify-chains.json instead of sourcify-chains-default.json",
+    );
+    const rawSourcifyChainExtentionsFromFile = fs.readFileSync(
+      path.resolve(__dirname, "./sourcify-chains.json"),
+      "utf8",
+    );
+    return JSON.parse(
+      rawSourcifyChainExtentionsFromFile,
+    ) as SourcifyChainsExtensionsObjectWithHeaderEnvName;
   }
-});
-const allChains = Array.from(chainMapById.values());
+  // sourcify-chains-default.json
+  return rawSourcifyChainExtentions as SourcifyChainsExtensionsObjectWithHeaderEnvName;
+}
+
+const sourcifyChainsExtensions = loadDefaultExtensions();
+
+function loadDefaultAllChains(): Chain[] {
+  const chainMapById = new Map<number, Chain>();
+  // Add chains.json from ethereum-lists (chainId.network/chains.json)
+  chainsRaw.forEach((chain) => chainMapById.set(chain.chainId, chain));
+  // Chains that we decide to support but that are not in chains.json
+  extraChainsRaw.forEach((chain) => {
+    // Skip if chainsRaw already defines this chainId so canonical entry wins
+    if (!chainMapById.has(chain.chainId)) {
+      chainMapById.set(chain.chainId, chain);
+    }
+  });
+  return Array.from(chainMapById.values());
+}
+
+const allChains = loadDefaultAllChains();
 
 export const LOCAL_CHAINS: SourcifyChain[] = [
   new SourcifyChain({
@@ -239,95 +245,187 @@ function buildCustomRpcs(
   return rpcs;
 }
 
-const sourcifyChainsMap: SourcifyChainMap = {};
+/**
+ * Assembles a SourcifyChainMap from a chain metadata list (chains.json layer)
+ * and a sourcify chain extensions object (sourcify-chains-default.json layer).
+ *
+ * Pure: does not depend on module-level state. Used both for the static
+ * `sourcifyChainsMap` export and for the merged map produced by
+ * `buildSourcifyChainsMap()` once remote additions have been applied.
+ */
+function assembleSourcifyChainsMap(
+  chainsList: Chain[],
+  extensions: SourcifyChainsExtensionsObjectWithHeaderEnvName,
+): SourcifyChainMap {
+  const result: SourcifyChainMap = {};
 
-// Add test chains too if developing or testing
-if (process.env.NODE_ENV !== "production") {
-  for (const chain of LOCAL_CHAINS) {
-    sourcifyChainsMap[chain.chainId.toString()] = chain;
-  }
-}
-
-// iterate over chainid.network's chains.json file and get the chains included in sourcify-chains.json.
-// Merge the chains.json object with the values from sourcify-chains.json
-// Must iterate over all chains because it's not a mapping but an array.
-for (const chain of allChains) {
-  const chainId = chain.chainId;
-  if (chainId in sourcifyChainsMap) {
-    // Don't throw on test chains in development, override the chain.json item as test chains are found in chains.json.
-    if (
-      process.env.NODE_ENV !== "production" &&
-      LOCAL_CHAINS.map((c) => c.chainId).includes(chainId)
-    ) {
-      // do nothing.
-    } else {
-      const err = `Corrupt chains file (chains.json): multiple chains have the same chainId: ${chainId}`;
-      throw new Error(err);
+  // Add test chains too if developing or testing
+  if (process.env.NODE_ENV !== "production") {
+    for (const chain of LOCAL_CHAINS) {
+      result[chain.chainId.toString()] = chain;
     }
   }
 
-  if (chainId in sourcifyChainsExtensions) {
-    const sourcifyExtension = sourcifyChainsExtensions[chainId];
-
-    let rpcs: SourcifyRpc[] = [];
-    if (sourcifyExtension.rpc) {
-      rpcs = buildCustomRpcs(sourcifyExtension.rpc);
-    }
-    // Add rpcs of chains.json as a fallback
-    rpcs = [...rpcs, ...buildCustomRpcs(chain.rpc)];
-
-    // sourcifyExtension is spread later to overwrite chains.json values
-    // Exclude rpc from sourcifyExtension as we now use rpcs
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { rpc: _rpc, ...sourcifyExtensionWithoutRpc } = sourcifyExtension;
-    const sourcifyChain = new SourcifyChain({
-      ...chain,
-      ...sourcifyExtensionWithoutRpc,
-      rpcs,
-    });
-    sourcifyChainsMap[chainId] = sourcifyChain;
-  }
-}
-
-// Check if all chains in sourcify-chains.json are in chains.json
-const missingChains = [];
-for (const chainId in sourcifyChainsExtensions) {
-  if (!sourcifyChainsMap[chainId]) {
-    missingChains.push(chainId);
-  }
-}
-if (missingChains.length > 0) {
-  // Don't let CircleCI pass for the main repo if sourcify-chains.json has chains that are not in chains.json
-  if (process.env.CIRCLE_PROJECT_REPONAME === "sourcify") {
-    throw new Error(
-      `Some of the chains in sourcify-chains.json are not in chains.json: ${missingChains.join(
-        ",",
-      )}`,
-    );
-  }
-  // Don't throw for forks or others running Sourcify, instead add them to sourcifyChainsMap
-  else {
-    logger.warn(
-      `Some of the chains in sourcify-chains.json are not in chains.json`,
-      missingChains,
-    );
-    missingChains.forEach((chainId) => {
-      const chain = sourcifyChainsExtensions[chainId];
-      if (!chain.rpc) {
-        throw new Error(
-          `Chain ${chainId} is missing rpc in sourcify-chains.json`,
-        );
+  // iterate over chainid.network's chains.json file and get the chains included in sourcify-chains.json.
+  // Merge the chains.json object with the values from sourcify-chains.json
+  // Must iterate over all chains because it's not a mapping but an array.
+  for (const chain of chainsList) {
+    const chainId = chain.chainId;
+    if (chainId in result) {
+      // Don't throw on test chains in development, override the chain.json item as test chains are found in chains.json.
+      if (
+        process.env.NODE_ENV !== "production" &&
+        LOCAL_CHAINS.map((c) => c.chainId).includes(chainId)
+      ) {
+        // do nothing.
+      } else {
+        const err = `Corrupt chains file (chains.json): multiple chains have the same chainId: ${chainId}`;
+        throw new Error(err);
       }
-      const rpcs = buildCustomRpcs(chain.rpc);
-      sourcifyChainsMap[chainId] = new SourcifyChain({
-        name: chain.sourcifyName,
-        chainId: parseInt(chainId),
-        supported: chain.supported,
+    }
+
+    if (chainId in extensions) {
+      const sourcifyExtension = extensions[chainId];
+
+      let rpcs: SourcifyRpc[] = [];
+      if (sourcifyExtension.rpc) {
+        rpcs = buildCustomRpcs(sourcifyExtension.rpc);
+      }
+      // Add rpcs of chains.json as a fallback
+      rpcs = [...rpcs, ...buildCustomRpcs(chain.rpc)];
+
+      // sourcifyExtension is spread later to overwrite chains.json values
+      // Exclude rpc from sourcifyExtension as we now use rpcs
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { rpc: _rpc, ...sourcifyExtensionWithoutRpc } = sourcifyExtension;
+      const sourcifyChain = new SourcifyChain({
+        ...chain,
+        ...sourcifyExtensionWithoutRpc,
         rpcs,
-        fetchContractCreationTxUsing: chain.fetchContractCreationTxUsing,
       });
-    });
+      result[chainId] = sourcifyChain;
+    }
   }
+
+  // Check if all chains in sourcify-chains.json are in chains.json
+  const missingChains: string[] = [];
+  for (const chainId in extensions) {
+    if (!result[chainId]) {
+      missingChains.push(chainId);
+    }
+  }
+  if (missingChains.length > 0) {
+    // Don't let CircleCI pass for the main repo if sourcify-chains.json has chains that are not in chains.json
+    if (process.env.CIRCLE_PROJECT_REPONAME === "sourcify") {
+      throw new Error(
+        `Some of the chains in sourcify-chains.json are not in chains.json: ${missingChains.join(
+          ",",
+        )}`,
+      );
+    }
+    // Don't throw for forks or others running Sourcify, instead add them to result
+    else {
+      logger.warn(
+        `Some of the chains in sourcify-chains.json are not in chains.json`,
+        missingChains,
+      );
+      missingChains.forEach((chainId) => {
+        const chain = extensions[chainId];
+        if (!chain.rpc) {
+          throw new Error(
+            `Chain ${chainId} is missing rpc in sourcify-chains.json`,
+          );
+        }
+        const rpcs = buildCustomRpcs(chain.rpc);
+        result[chainId] = new SourcifyChain({
+          name: chain.sourcifyName,
+          chainId: parseInt(chainId),
+          supported: chain.supported,
+          rpcs,
+          fetchContractCreationTxUsing: chain.fetchContractCreationTxUsing,
+        });
+      });
+    }
+  }
+
+  return result;
 }
 
-export { sourcifyChainsMap };
+/**
+ * Static SourcifyChainMap built from the bundled chains.json,
+ * extra-chains.json and sourcify-chains-default.json (or sourcify-chains.json
+ * if present). This is the synchronous map used by tests and any caller that
+ * doesn't need the optional remote chain registry.
+ *
+ * Production code paths (the server bootstrap in cli.ts) should prefer
+ * `buildSourcifyChainsMap()` so a configured remote registry can augment the
+ * static set.
+ */
+export const sourcifyChainsMap = assembleSourcifyChainsMap(
+  allChains,
+  sourcifyChainsExtensions,
+);
+
+export interface BuildSourcifyChainsMapOptions {
+  chainRegistry?: ChainRegistryOptions;
+  /**
+   * If true, throw when the chain registry fetch fails or yields no entries.
+   * Defaults to false: failures fall back to the static map and are logged.
+   */
+  chainRegistryRequired?: boolean;
+}
+
+/**
+ * Builds a SourcifyChainMap, optionally augmenting the static set with chains
+ * fetched from a remote chain registry. Static config always wins: a chainId
+ * present in chains.json/extra-chains.json or sourcify-chains-default.json is
+ * never overwritten by a remote entry.
+ */
+export async function buildSourcifyChainsMap(
+  options: BuildSourcifyChainsMapOptions = {},
+): Promise<SourcifyChainMap> {
+  if (!options.chainRegistry) {
+    return assembleSourcifyChainsMap(allChains, sourcifyChainsExtensions);
+  }
+
+  const result = await fetchChainRegistry(options.chainRegistry);
+
+  const hasAdditions =
+    result.chainsJsonAdditions.length > 0 ||
+    Object.keys(result.extensionAdditions).length > 0;
+
+  if (!hasAdditions && options.chainRegistryRequired) {
+    throw new Error(
+      `chainRegistry: required registry at ${options.chainRegistry.url} returned no chains`,
+    );
+  }
+
+  // Merge remote additions, honoring static precedence on both layers.
+  const mergedChainIds = new Set(allChains.map((c) => c.chainId));
+  const mergedChains: Chain[] = [...allChains];
+  for (const chain of result.chainsJsonAdditions) {
+    if (mergedChainIds.has(chain.chainId)) {
+      logger.debug("chainRegistry: static chain wins over remote", {
+        chainId: chain.chainId,
+      });
+      continue;
+    }
+    mergedChains.push(chain);
+    mergedChainIds.add(chain.chainId);
+  }
+
+  const mergedExtensions: SourcifyChainsExtensionsObjectWithHeaderEnvName = {
+    ...sourcifyChainsExtensions,
+  };
+  for (const [chainId, ext] of Object.entries(result.extensionAdditions)) {
+    if (chainId in mergedExtensions) {
+      logger.debug("chainRegistry: static extension wins over remote", {
+        chainId,
+      });
+      continue;
+    }
+    mergedExtensions[chainId] = ext;
+  }
+
+  return assembleSourcifyChainsMap(mergedChains, mergedExtensions);
+}

--- a/services/server/test/unit/chain-registry.spec.ts
+++ b/services/server/test/unit/chain-registry.spec.ts
@@ -1,0 +1,200 @@
+import { expect } from "chai";
+import nock from "nock";
+import {
+  fetchChainRegistry,
+  type RemoteChainRegistryResponse,
+} from "../../src/chain-registry";
+
+const TEST_REGISTRY_HOST = "https://registry.example.com";
+const TEST_REGISTRY_PATH = "/chains";
+const TEST_REGISTRY_URL = `${TEST_REGISTRY_HOST}${TEST_REGISTRY_PATH}`;
+
+describe("chain-registry", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    expect(nock.isDone(), "all nock interceptors should be consumed").to.equal(
+      true,
+    );
+  });
+
+  it("fetches and converts a chainlist-shaped response", async () => {
+    const response: RemoteChainRegistryResponse = {
+      "424242": {
+        chainId: 424242,
+        name: "Example Chain",
+        rpc: ["https://rpc.example.com"],
+      },
+    };
+    nock(TEST_REGISTRY_HOST).get(TEST_REGISTRY_PATH).reply(200, response);
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.chainsJsonAdditions).to.have.length(1);
+    expect(result.chainsJsonAdditions[0]).to.include({
+      chainId: 424242,
+      name: "Example Chain",
+    });
+    expect(result.chainsJsonAdditions[0].rpc).to.deep.equal([
+      "https://rpc.example.com",
+    ]);
+    expect(result.extensionAdditions["424242"]).to.deep.include({
+      sourcifyName: "Example Chain",
+      supported: true,
+    });
+    expect(result.extensionAdditions["424242"].rpc).to.deep.equal([
+      "https://rpc.example.com",
+    ]);
+  });
+
+  it("skips entries marked hidden", async () => {
+    const response: RemoteChainRegistryResponse = {
+      "1": {
+        chainId: 1,
+        name: "Visible",
+        rpc: ["https://rpc.visible.example"],
+      },
+      "2": {
+        chainId: 2,
+        name: "Hidden",
+        rpc: ["https://rpc.hidden.example"],
+        hidden: true,
+      },
+    };
+    nock(TEST_REGISTRY_HOST).get(TEST_REGISTRY_PATH).reply(200, response);
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    const chainIds = result.chainsJsonAdditions.map((c) => c.chainId);
+    expect(chainIds).to.deep.equal([1]);
+    expect(result.extensionAdditions).to.have.keys("1");
+  });
+
+  it("drops non-http(s) RPC urls and skips entries with no usable RPC", async () => {
+    const response: RemoteChainRegistryResponse = {
+      "10": {
+        chainId: 10,
+        name: "Mixed RPCs",
+        rpc: ["wss://ws.example.com", "https://rpc.example.com"],
+      },
+      "11": {
+        chainId: 11,
+        name: "Only ws",
+        rpc: ["wss://ws.only.example.com"],
+      },
+    };
+    nock(TEST_REGISTRY_HOST).get(TEST_REGISTRY_PATH).reply(200, response);
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.chainsJsonAdditions.map((c) => c.chainId)).to.deep.equal([
+      10,
+    ]);
+    expect(result.extensionAdditions["10"].rpc).to.deep.equal([
+      "https://rpc.example.com",
+    ]);
+  });
+
+  it("preserves a remote sourcifyExtension when provided", async () => {
+    const response: RemoteChainRegistryResponse = {
+      "777": {
+        chainId: 777,
+        name: "Custom",
+        rpc: ["https://rpc.custom.example"],
+        sourcifyExtension: {
+          supported: true,
+          etherscanApi: {
+            supported: true,
+            apiKeyEnvName: "CUSTOM_ETHERSCAN_API_KEY",
+          },
+          rpc: [
+            {
+              type: "BaseRPC",
+              url: "https://custom.example/rpc",
+            },
+          ],
+        },
+      },
+    };
+    nock(TEST_REGISTRY_HOST).get(TEST_REGISTRY_PATH).reply(200, response);
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.extensionAdditions["777"].sourcifyName).to.equal("Custom");
+    expect(result.extensionAdditions["777"].etherscanApi).to.deep.equal({
+      supported: true,
+      apiKeyEnvName: "CUSTOM_ETHERSCAN_API_KEY",
+    });
+    expect(result.extensionAdditions["777"].rpc).to.deep.equal([
+      { type: "BaseRPC", url: "https://custom.example/rpc" },
+    ]);
+  });
+
+  it("sends an Authorization header when an authToken is provided", async () => {
+    nock(TEST_REGISTRY_HOST, {
+      reqheaders: { authorization: "Bearer test-token" },
+    })
+      .get(TEST_REGISTRY_PATH)
+      .reply(200, {});
+
+    const result = await fetchChainRegistry({
+      url: TEST_REGISTRY_URL,
+      authToken: "test-token",
+    });
+
+    expect(result.chainsJsonAdditions).to.deep.equal([]);
+    expect(result.extensionAdditions).to.deep.equal({});
+  });
+
+  it("returns empty additions on a non-2xx response", async () => {
+    nock(TEST_REGISTRY_HOST).get(TEST_REGISTRY_PATH).reply(503);
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.chainsJsonAdditions).to.deep.equal([]);
+    expect(result.extensionAdditions).to.deep.equal({});
+  });
+
+  it("returns empty additions on a malformed (non-object) payload", async () => {
+    nock(TEST_REGISTRY_HOST)
+      .get(TEST_REGISTRY_PATH)
+      .reply(200, "not-an-object");
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.chainsJsonAdditions).to.deep.equal([]);
+    expect(result.extensionAdditions).to.deep.equal({});
+  });
+
+  it("returns empty additions on a network error", async () => {
+    nock(TEST_REGISTRY_HOST)
+      .get(TEST_REGISTRY_PATH)
+      .replyWithError("connection refused");
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.chainsJsonAdditions).to.deep.equal([]);
+    expect(result.extensionAdditions).to.deep.equal({});
+  });
+
+  it("skips malformed entries but keeps valid ones", async () => {
+    nock(TEST_REGISTRY_HOST)
+      .get(TEST_REGISTRY_PATH)
+      .reply(200, {
+        bad: { name: "no chainId here" },
+        good: {
+          chainId: 99,
+          name: "Good",
+          rpc: ["https://rpc.good.example"],
+        },
+      });
+
+    const result = await fetchChainRegistry({ url: TEST_REGISTRY_URL });
+
+    expect(result.chainsJsonAdditions.map((c) => c.chainId)).to.deep.equal([
+      99,
+    ]);
+  });
+});


### PR DESCRIPTION
Adds an opt-in HTTP source for chain configuration that is merged with the
bundled chains.json + sourcify-chains-default.json at server boot. Static
config always wins; remote entries are only added for chainIds that aren't
already known locally. The /chains endpoint shape is unchanged.

- New chain-registry.ts: fetchChainRegistry() using native fetch, hand-written
  type guards, winston logger, AbortSignal.timeout. Graceful failure: returns
  empty additions on network/parse/non-2xx errors. Accepts a chainlist.org-
  shaped payload with an optional sourcifyExtension field for full parity
  with sourcify-chains-default.json (etherscanApi, fetchContractCreationTxUsing,
  typed RPCs).
- sourcify-chains.ts: extracted assembleSourcifyChainsMap() from the existing
  top-level merge logic. Exported buildSourcifyChainsMap(opts) merges remote
  additions before assembly. The synchronous sourcifyChainsMap export is
  preserved so existing test/integration imports keep working.
- cli.ts: wraps Server construction in async bootstrap(); awaits the chain
  map and threads it through getEtherscanApiKeyForEachChain(map).
- config/default.js: chainRegistry.{url, required, timeoutMs}. Bearer token
  lives in process.env.CHAIN_REGISTRY_AUTH_TOKEN.
- .env.dev: documents CHAIN_REGISTRY_URL and CHAIN_REGISTRY_AUTH_TOKEN.
- 9 unit tests in chain-registry.spec.ts using mocha+chai+nock.