### PR TITLE
feat: add hidden chain config option to filter chains from public listings

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -47,6 +47,12 @@ export class SourcifyChain {
   /** Whether the chain supports tracing, used for fetching the creation bytecode for factory contracts */
   readonly traceSupport?: boolean;
   readonly supported: boolean;
+  /**
+   * When true, the chain is hidden from public listings such as the /chains
+   * endpoint and the /v2/contract/all-chains/{address} response. Verification
+   * for the chain still works when its chainId is explicitly requested.
+   */
+  readonly hidden: boolean;
   readonly fetchContractCreationTxUsing?: FetchContractCreationTxMethods;
   readonly etherscanApi?: {
     supported: boolean;
@@ -73,6 +79,7 @@ export class SourcifyChain {
     this.title = sourcifyChainObj.title;
     this.chainId = sourcifyChainObj.chainId;
     this.supported = sourcifyChainObj.supported;
+    this.hidden = sourcifyChainObj.hidden ?? false;
     this.fetchContractCreationTxUsing =
       sourcifyChainObj.fetchContractCreationTxUsing;
     this.etherscanApi = sourcifyChainObj.etherscanApi;
@@ -124,6 +131,7 @@ export class SourcifyChain {
       // eslint-disable-next-line
       rpcs: this.rpcs.map(({ provider: _provider, ...rest }) => rest), // SourcifyChainInstance should not include class instances
       supported: this.supported,
+      hidden: this.hidden,
       fetchContractCreationTxUsing: this.fetchContractCreationTxUsing,
       etherscanApi: this.etherscanApi,
     };

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
@@ -6,6 +6,12 @@ export interface SourcifyChainsExtensionsObject {
 export type SourcifyChainExtension = {
   sourcifyName: string; // Keep it required to not forget name in sourcify-chains.json
   supported: boolean;
+  /**
+   * When true, the chain is hidden from public listings such as the /chains
+   * endpoint and the /v2/contract/all-chains/{address} response. Verification
+   * for the chain still works when its chainId is explicitly requested.
+   */
+  hidden?: boolean;
   etherscanApi?: {
     supported: boolean;
     apiKeyEnvName?: string;

--- a/services/server/src/server/apiv2/lookup/lookup.handlers.ts
+++ b/services/server/src/server/apiv2/lookup/lookup.handlers.ts
@@ -179,10 +179,18 @@ export async function getContractAllChainsEndpoint(
     address: req.params.address,
   });
   const services = req.app.get("services") as Services;
+  const chainRepository = req.app.get("chainRepository") as ChainRepository;
   const resultsObject = await services.storage.performServiceOperation(
     "getContractsAllChains",
     [req.params.address],
   );
+
+  // Filter out results for chains marked as hidden so they don't appear
+  // in endpoints that return a list of chains without an explicit chainId request.
+  resultsObject.results = resultsObject.results.filter((result) => {
+    const chain = chainRepository.sourcifyChainMap[String(result.chainId)];
+    return !chain?.hidden;
+  });
 
   if (resultsObject.results.length === 0) {
     res.status(StatusCodes.NOT_FOUND).json(resultsObject);

--- a/services/server/src/server/routes.ts
+++ b/services/server/src/server/routes.ts
@@ -58,7 +58,9 @@ router.post("/private/change-log-level", (req, res) => {
 
 router.get("/chains", (_req, res) => {
   const chainRepository = _req.app.get("chainRepository") as ChainRepository;
-  const sourcifyChainsArray = chainRepository.sourcifyChainsArray;
+  const sourcifyChainsArray = chainRepository.sourcifyChainsArray.filter(
+    (chain) => !chain.hidden,
+  );
   const sourcifyChains = sourcifyChainsArray.map(
     ({ rpcs, name, title, chainId, supported, etherscanApi }) => {
       return {

--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -304,6 +304,7 @@ export async function initializeSourcifyChains(opts: {
       name: extension.sourcifyName,
       chainId,
       supported: extension.supported,
+      hidden: extension.hidden ?? false,
       rpcs,
       etherscanApi: extension.etherscanApi,
       fetchContractCreationTxUsing: extension.fetchContractCreationTxUsing,


### PR DESCRIPTION
## Summary

Adds an optional `hidden` boolean field to `SourcifyChainExtension` that can be set in either the hardcoded `sourcify-chains.json` or the remote chains config (now supported via `chains.remoteUrl`).

When a chain is marked `hidden: true`:
- It is omitted from `GET /chains`
- Its entries are filtered out of `GET /v2/contract/all-chains/:address`

Verification and per-chain lookups by explicit `chainId` continue to work — `hidden` only suppresses inclusion in listings that return chains without an explicit chainId request.

## Changes

- `packages/lib-sourcify`: added `hidden?: boolean` to `SourcifyChainExtension`; `SourcifyChain` now exposes `readonly hidden: boolean` (defaults to `false`)
- `services/server/src/sourcify-chains.ts`: passes `hidden` through from local/remote config when constructing each `SourcifyChain`
- `services/server/src/server/routes.ts`: `GET /chains` filters out hidden chains
- `services/server/src/server/apiv2/lookup/lookup.handlers.ts`: `GET /v2/contract/all-chains/:address` filters out results from hidden chains

## Endpoints reviewed

Other endpoints that touch chains either accept explicit `chainId` parameters (verification routes, `/v2/contracts/:chainId`, `/v2/contract/:chainId/:address`, v1 `/check-by-addresses?chainIds=...`, etc.) or are internal-only logging — none required changes.