### PR TITLE
fix(server): drop full metadata payload from verifyFromMetadata debug log

### DIFF
--- a/services/server/src/server/apiv2/verification/verification.handlers.ts
+++ b/services/server/src/server/apiv2/verification/verification.handlers.ts
@@ -88,7 +88,6 @@ export async function verifyFromMetadataEndpoint(
     chainId: req.params.chainId,
     address: req.params.address,
     sources: req.body.sources,
-    metadata: req.body.metadata,
     creationTransactionHash: req.body.creationTransactionHash,
   });
 


### PR DESCRIPTION
## Summary

The `verifyFromMetadataEndpoint` debug log included the entire `metadata` JSON, which can be large and bloats logs. The other endpoints in the same file already follow the pattern of logging only identifying fields (chainId, address, etc.) and not the full request payload — this aligns `verifyFromMetadataEndpoint` with that pattern.

Note: `sources` is still logged here and is similarly large. Left as-is for now to keep the PR focused; happy to drop it in a follow-up if preferred.

## Test plan

- [ ] Hit `POST /v2/verify/:chainId/:address/metadata` with `LOG_LEVEL=debug` and confirm the log line no longer includes the metadata body

🤖 Generated with [Claude Code](https://claude.com/claude-code)