### PR TITLE
fix(server): validate afterMatchId as numeric in v2 contracts list

### DIFF
--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -320,6 +320,7 @@ paths:
           description: The last `matchId` returned to get contracts older or newer than it (depending on `sort`)
           schema:
             type: string
+            pattern: '^\d+$'
         - $ref: "#/components/parameters/chainId"
       responses:
         "200":

--- a/services/server/test/integration/apiv2/lookup/contracts-by-chain.spec.ts
+++ b/services/server/test/integration/apiv2/lookup/contracts-by-chain.spec.ts
@@ -162,4 +162,15 @@ describe("GET /v2/contracts/:chainId", function () {
     chai.expect(res.body).to.have.property("errorId");
     chai.expect(res.body).to.have.property("message");
   });
+
+  it("should return a 400 when afterMatchId is not a non-negative integer", async function () {
+    const res = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/contracts/${chainFixture.chainId}?afterMatchId=m1`);
+
+    chai.expect(res.status).to.equal(400);
+    chai.expect(res.body.customCode).to.equal("invalid_parameter");
+    chai.expect(res.body).to.have.property("errorId");
+    chai.expect(res.body).to.have.property("message");
+  });
 });


### PR DESCRIPTION
## Summary

The `afterMatchId` query parameter on `GET /v2/contracts/{chainId}` was declared as a free-form string in `apiv2.yaml`, so any value passed OpenAPI validation. It was then bound directly to a `bigint` SQL parameter (`sourcify_matches.id`) in the cursor predicate built by `getSourcifyMatchesByChain`.

When a client sent a non-numeric value, Postgres rejected the parameter binding with SQLSTATE `22P02`:

```
ERROR:  invalid input syntax for type bigint: "m1"
```

The server's v2 error handler did not recognize this as a client-input problem, so it wrapped the pg error in `InternalError` and the client received:

- HTTP **500** with body `{ "customCode": "internal_error", "message": "The server encountered an unexpected error.", "errorId": "..." }`
- Two `logger.error` entries per occurrence (`API v2 internal error` + `Unexpected server error`)
- Spammy PG `ERROR` log lines that polluted Cloud SQL logs and made real errors harder to spot

Observed in production logs:

```
ERROR:  invalid input syntax for type bigint: "m1"
```

## Fix

- Add `pattern: '^\d+$'` to the `afterMatchId` parameter schema in `apiv2.yaml`. The OpenAPI validator now rejects non-numeric input with the standard `400 invalid_parameter` response before any DB call is made.
- Add an integration test in `contracts-by-chain.spec.ts` covering the rejection.

Note: the failed queries themselves had negligible DB cost (PG rejects during parameter binding, before any locks are taken), so this is not related to the recent lock-wait incident — only to log noise and incorrect 5xx responses for client input errors.