### PR TITLE
add chain

### DIFF
--- a/services/server/src/sourcify-chains.json
+++ b/services/server/src/sourcify-chains.json
@@ -1,0 +1,30 @@
+{
+  "1": {
+    "sourcifyName": "Ethereum Mainnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://eth.blockscout.com/"
+      },
+      "routescanApi": {
+        "type": "mainnet"
+      },
+      "avalancheApi": true
+    },
+    "rpc": ["https://ethereum-rpc.publicnode.com"]
+  },
+  "47763": {
+    "sourcifyName": "Neo X Mainnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://xexplorer.neo.org/"
+      },
+      "routescanApi": {
+        "type": "mainnet"
+      },
+      "avalancheApi": true
+    },
+    "rpc": ["https://mainnet-2.rpc.banelabs.org"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for Neo X Mainnet (chainId: 47763).

## Chain Information

* Chain Name: Neo X Mainnet
* Chain ID: 47763
* RPC:

  * https://mainnet-1.rpc.banelabs.org
* Explorer:

  * https://xexplorer.neo.org

## Explorer Support

The explorer is Blockscout v2 compatible and supports the smart contract API endpoint required by Sourcify:

```bash id="hgn5ok"
curl https://xexplorer.neo.org/api/v2/smart-contracts/<contract-address>
```

The endpoint successfully returns contract creation bytecode and deployed bytecode.

## Changes

* Added Neo X Mainnet chain configuration
* Enabled verification support
* Configured `fetchContractCreationTxUsing.blockscoutApi`

Local verification completed successfully.

## Notes

Neo X explorer is compatible with Blockscout v2 APIs required by Sourcify verification.