### PR TITLE
clear deployer and blockNumber when creationTransactionHash validation fails

### DIFF
--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -271,6 +271,8 @@ export class Verification {
           error: e.message,
         });
         this.creatorTxHash = undefined;
+        this.blockNumber = undefined;
+        this.deployer = undefined;
       }
     }
 

--- a/services/server/test/integration/apiv2/verification/verify.json.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.json.spec.ts
@@ -592,6 +592,18 @@ describe("POST /v2/verify/:chainId/:address", function () {
     chai.expect(jobRes.body.error).to.not.exist;
     chai.expect(jobRes.body.contract.creationMatch).to.be.null;
     chai.expect(jobRes.body.contract.runtimeMatch).to.equal("exact_match");
+
+    // The deployer and blockNumber stored in contract_deployments must NOT
+    // come from the wrong transaction. Since the creationTransactionHash
+    // validation failed, these fields should be null.
+    const deploymentResult = await serverFixture.sourcifyDatabase.query(
+      `SELECT encode(deployer, 'hex') as deployer, block_number, encode(transaction_hash, 'hex') as transaction_hash
+       FROM contract_deployments`,
+    );
+    chai.expect(deploymentResult?.rows).to.have.length(1);
+    chai.expect(deploymentResult?.rows[0].transaction_hash).to.be.null;
+    chai.expect(deploymentResult?.rows[0].deployer).to.be.null;
+    chai.expect(deploymentResult?.rows[0].block_number).to.be.null;
   });
 
   describe("match upgrades", function () {


### PR DESCRIPTION
When a user provides a `creationTransactionHash` that doesn't match the contract address, `deployer` and `blockNumber` from that wrong transaction were still stored in the database. This happened because these fields were assigned before the address validation in `getContractCreationBytecodeAndReceipt`, and the catch block only cleared `creatorTxHash`.

The fix clears `blockNumber` and `deployer` in the catch block alongside `creatorTxHash`. A regression test is added that asserts all three fields are null in `contract_deployments` when a wrong creation tx hash is provided. 