### PR TITLE
fix(compilers): escape non-ascii vyper json stdin

### DIFF
--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -11,6 +11,18 @@ import type {
 
 const HOST_VYPER_REPO = 'https://github.com/vyperlang/vyper/releases/download/';
 
+export function stringifyVyperJsonInput(
+  vyperJsonInput: VyperJsonInput,
+): string {
+  // Old Vyper release binaries can fail to encode raw non-ASCII stdin when
+  // running under an ASCII locale. Keep the transport ASCII-only while
+  // preserving the decoded standard-json input.
+  return JSON.stringify(vyperJsonInput).replace(
+    /[\u0080-\uFFFF]/g,
+    (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`,
+  );
+}
+
 export function findVyperPlatform(): string | false {
   if (
     process.platform === 'darwin' &&
@@ -53,7 +65,7 @@ export async function useVyperCompiler(
   );
 
   let compiled: string | undefined;
-  const inputStringified = JSON.stringify(vyperJsonInput);
+  const inputStringified = stringifyVyperJsonInput(vyperJsonInput);
   const startCompilation = Date.now();
   try {
     compiled = await asyncExec(

--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -14,7 +14,9 @@ const HOST_VYPER_REPO = 'https://github.com/vyperlang/vyper/releases/download/';
 export function stringifyVyperJsonInput(
   vyperJsonInput: VyperJsonInput,
 ): string {
+  // Keep stdin ASCII-only for locale-sensitive Vyper release binaries.
   return JSON.stringify(vyperJsonInput).replace(
+    // Escape non-ASCII UTF-16 code units, including surrogate pairs.
     /[\u0080-\uFFFF]/g,
     (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`,
   );

--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -14,9 +14,6 @@ const HOST_VYPER_REPO = 'https://github.com/vyperlang/vyper/releases/download/';
 export function stringifyVyperJsonInput(
   vyperJsonInput: VyperJsonInput,
 ): string {
-  // Old Vyper release binaries can fail to encode raw non-ASCII stdin when
-  // running under an ASCII locale. Keep the transport ASCII-only while
-  // preserving the decoded standard-json input.
   return JSON.stringify(vyperJsonInput).replace(
     /[\u0080-\uFFFF]/g,
     (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`,

--- a/packages/compilers/test/vyperCompiler.spec.ts
+++ b/packages/compilers/test/vyperCompiler.spec.ts
@@ -1,9 +1,34 @@
 import { expect } from 'chai';
-import { useVyperCompiler } from '../src/lib/vyperCompiler';
+import {
+  stringifyVyperJsonInput,
+  useVyperCompiler,
+} from '../src/lib/vyperCompiler';
 import path from 'path';
 
 describe('Verify Vyper Compiler', () => {
   const vyperRepoPath = path.join('/tmp', 'compilers-vyper-repo');
+
+  it('Should escape non-ASCII characters in standard-json stdin', function () {
+    const vyperJsonInput = {
+      language: 'Vyper' as const,
+      sources: {
+        'test.vy': {
+          content: '# ∫(rate * balance / totalSupply dt)\n',
+        },
+      },
+      settings: {
+        outputSelection: {
+          '*': ['*'],
+        },
+      },
+    };
+
+    const inputStringified = stringifyVyperJsonInput(vyperJsonInput);
+
+    expect(inputStringified).to.include('\\u222b');
+    expect(inputStringified).to.not.include('∫');
+    expect(JSON.parse(inputStringified)).to.deep.equal(vyperJsonInput);
+  });
 
   it('Should compile with vyper', async function () {
     const compiledJSON = await useVyperCompiler(

--- a/services/server/Dockerfile
+++ b/services/server/Dockerfile
@@ -39,8 +39,10 @@ LABEL org.opencontainers.image.licenses MIT
 # Set default value for ARG
 ARG NODE_ENV=production
 
-# Set environment variable
-ENV NODE_ENV=${NODE_ENV}
+# Set environment variables
+ENV NODE_ENV=${NODE_ENV} \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 WORKDIR /home/app/services/server
 # node command has to be used directly for SIGTERM handling (NOT npm start)


### PR DESCRIPTION
## Summary

- Serialize Vyper standard-json input as ASCII-only before writing it to compiler stdin.
- Preserve the decoded standard-json input exactly; non-ASCII source comments are represented as JSON unicode escapes such as `\u222b`, not rewritten in the source.
- Set the server production image locale to `C.UTF-8` as defense in depth for compiler child processes and other subprocesses.
- Add a regression for a Vyper source comment containing `∫` to prove the serialized payload contains no raw non-ASCII and parses back to the original input.

## Why

Sourcify currently sends `JSON.stringify(vyperJsonInput)` directly to Vyper `--standard-json` over stdin. Node keeps non-ASCII characters raw in that string, and the server image did not force a UTF-8 locale for compiler child processes.

Old Vyper release binaries can fail before compilation when they receive that raw stdin under an ASCII locale. This showed up on old verified Vyper sources that contain `∫` in comments. Escaping the JSON transport avoids the locale-sensitive binary path while still giving Vyper the exact same decoded source after JSON parse. Setting `LANG=C.UTF-8` and `LC_ALL=C.UTF-8` in the server image hardens the default container environment too, but the transport escape keeps this deterministic outside Docker as well.

Live contract example:

- Ethereum [`0x13Ba45c2B686c6db7C2E28BD3a9E8EDd24B894eD`](https://etherscan.io/address/0x13Ba45c2B686c6db7C2E28BD3a9E8EDd24B894eD#code) is verified on Etherscan with `vyper:0.3.1` and has `∫` in LiquidityGauge comments. With raw standard-json stdin under `LC_ALL=C`, the old release-binary path fails with `UnicodeEncodeError`; with JSON unicode escapes, the same source decodes and compiles.
- The same comment pattern also appears in an old `vyper:0.2.8` Etherscan source for Ethereum `0x2941f68fe10c16c8d710f4c51de91a82d7e89be2`.

## Evidence

- `npm test` in `packages/compilers`: 19 passing.
- `npm run check` in `packages/compilers`: eslint and prettier pass.
- `git diff --check -- services/server/Dockerfile`: pass.
- Manual reproduction: old `0.3.1` and `0.2.8` release binaries fail on raw `∫` standard-json under ASCII locale, then succeed when either the JSON payload is ASCII-escaped or the child process locale is set to `C.UTF-8`. Current `0.4.3` stable and `0.5.0a2` pre-release do not reproduce the failure, but the transport fix keeps old compiler support deterministic.
