### PR TITLE
fix(lib-sourcify): support legacy Vyper immutable tails

### DIFF
--- a/packages/compilers-types/src/VyperTypes.ts
+++ b/packages/compilers-types/src/VyperTypes.ts
@@ -1,6 +1,7 @@
 import type { JsonFragment } from "ethers";
 import type { Devdoc } from "./CompilationTypes";
 import type { Userdoc } from "./CompilationTypes";
+import type { ImmutableReferences } from "./SolidityTypes";
 
 export interface VyperSettings {
   /** EVM version to compile for */
@@ -113,6 +114,7 @@ export interface VyperOutputContract {
       object: string;
       opcodes: string;
       sourceMap: string | VyperSourceMap;
+      immutableReferences?: ImmutableReferences;
     };
     methodIdentifiers: {
       [methodName: string]: string;

--- a/packages/compilers-types/src/VyperTypes.ts
+++ b/packages/compilers-types/src/VyperTypes.ts
@@ -80,11 +80,26 @@ export interface VyperStorageLayout {
   [variableName: string]: { type: string; slot: number; n_slots: number };
 }
 
+/**
+ * Vyper's `ir` output. Version 0.3.1 emits text LLL as a string; 0.3.2 and
+ * later (including 0.3.10+ and 0.4.x) emit a structured IR tree where each
+ * node is `{ <opcode>: [ ...args ] }` with number/string leaves. Modelled as
+ * a recursive JSON value (only string/number/array/object are emitted in
+ * practice) so consumers must narrow before reading into it.
+ */
+export type VyperIROutput =
+  | string
+  | number
+  | boolean
+  | null
+  | VyperIROutput[]
+  | { [key: string]: VyperIROutput };
+
 export interface VyperOutputContract {
   abi: JsonFragment[];
   userdoc: Userdoc;
   devdoc: Devdoc;
-  ir: string;
+  ir: VyperIROutput;
   layout?: {
     storage_layout: VyperStorageLayout;
   };

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -107,6 +107,9 @@ export class PreRunCompilation extends AbstractCompilation {
           return storedImmutableReferences;
         }
 
+        // Pre-run Vyper output reconstructed from the DB does not include `ir`.
+        // This fallback can still recover >=0.3.10 immutable references from
+        // CBOR, but legacy <0.3.10 references must already be stored.
         return returnImmutableReferences(
           this.compilerVersionCompatibleWithSemver!,
           this.creationBytecode,

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -24,7 +24,6 @@ import type {
 import {
   returnAuxdataStyle,
   returnFixedVyperVersion,
-  returnImmutableReferences,
 } from './VyperCompilation';
 
 export type Nullable<T> = T | null;
@@ -98,24 +97,7 @@ export class PreRunCompilation extends AbstractCompilation {
       case 'Vyper': {
         const compilationTarget = this
           .contractCompilerOutput as VyperOutputContract;
-        const storedImmutableReferences =
-          compilationTarget.evm.deployedBytecode.immutableReferences;
-        if (
-          storedImmutableReferences !== undefined &&
-          Object.keys(storedImmutableReferences).length > 0
-        ) {
-          return storedImmutableReferences;
-        }
-
-        // Pre-run Vyper output reconstructed from the DB does not include `ir`,
-        // so legacy <0.3.10 references must already be stored. Keep the old
-        // >=0.3.10 CBOR fallback for rows that have not been backfilled yet.
-        return returnImmutableReferences(
-          this.compilerVersionCompatibleWithSemver!,
-          this.creationBytecode,
-          this.runtimeBytecode,
-          this.auxdataStyle,
-        );
+        return compilationTarget.evm.deployedBytecode.immutableReferences || {};
       }
       case 'Fe':
         return {};

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -9,6 +9,7 @@ import type {
   SolidityOutputContract,
   VyperJsonInput,
   VyperOutput,
+  VyperOutputContract,
   FeJsonInput,
   FeOutput,
 } from '@ethereum-sourcify/compilers-types';
@@ -95,11 +96,24 @@ export class PreRunCompilation extends AbstractCompilation {
         return compilationTarget.evm.deployedBytecode.immutableReferences || {};
       }
       case 'Vyper': {
+        const compilationTarget = this
+          .contractCompilerOutput as VyperOutputContract;
+        const storedImmutableReferences =
+          compilationTarget.evm.deployedBytecode.immutableReferences;
+        if (
+          storedImmutableReferences !== undefined &&
+          Object.keys(storedImmutableReferences).length > 0
+        ) {
+          return storedImmutableReferences;
+        }
+
         return returnImmutableReferences(
           this.compilerVersionCompatibleWithSemver!,
           this.creationBytecode,
           this.runtimeBytecode,
           this.auxdataStyle,
+          this.compilerOutput as VyperOutput,
+          this.compilationTarget,
         );
       }
       case 'Fe':

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -107,16 +107,14 @@ export class PreRunCompilation extends AbstractCompilation {
           return storedImmutableReferences;
         }
 
-        // Pre-run Vyper output reconstructed from the DB does not include `ir`.
-        // This fallback can still recover >=0.3.10 immutable references from
-        // CBOR, but legacy <0.3.10 references must already be stored.
+        // Pre-run Vyper output reconstructed from the DB does not include `ir`,
+        // so legacy <0.3.10 references must already be stored. Keep the old
+        // >=0.3.10 CBOR fallback for rows that have not been backfilled yet.
         return returnImmutableReferences(
           this.compilerVersionCompatibleWithSemver!,
           this.creationBytecode,
           this.runtimeBytecode,
           this.auxdataStyle,
-          this.compilerOutput as VyperOutput,
-          this.compilationTarget,
         );
       }
       case 'Fe':

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -88,7 +88,9 @@ function isAstNode(node: unknown): node is VyperAstNode {
   return node !== null && typeof node === 'object';
 }
 
-function getImmutableTypeAnnotation(node: VyperAstNode): VyperAstNode | undefined {
+function getImmutableTypeAnnotation(
+  node: VyperAstNode,
+): VyperAstNode | undefined {
   const annotation = node.annotation;
   if (!isAstNode(annotation)) {
     return undefined;
@@ -174,7 +176,9 @@ function getTypeByteLength(
     if (subtypeByteLength === undefined) {
       return undefined;
     }
-    return DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE + maxLength * subtypeByteLength;
+    return (
+      DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE + maxLength * subtypeByteLength
+    );
   }
 
   const length = getSubscriptLength(annotation);
@@ -209,7 +213,6 @@ export function returnLegacyVyperImmutableReferences(
 
   const structs = collectStructDefinitions(ast);
   const runtimeByteLength = runtimeBytecode.substring(2).length / 2;
-  const immutableReferences: ImmutableReferences = {};
   let immutableOffset = 0;
 
   for (const node of ast.body.filter(isAstNode)) {
@@ -219,25 +222,29 @@ export function returnLegacyVyperImmutableReferences(
     }
 
     const immutableByteLength = getTypeByteLength(annotation, structs);
-    const immutableName = node.target?.id;
     if (
       immutableByteLength === undefined ||
       immutableByteLength <= 0 ||
-      typeof immutableName !== 'string'
+      typeof node.target?.id !== 'string'
     ) {
       return {};
     }
 
-    immutableReferences[immutableName] = [
-      {
-        length: immutableByteLength,
-        start: runtimeByteLength + immutableOffset,
-      },
-    ];
     immutableOffset += immutableByteLength;
   }
 
-  return immutableReferences;
+  if (immutableOffset === 0) {
+    return {};
+  }
+
+  return {
+    '0': [
+      {
+        length: immutableOffset,
+        start: runtimeByteLength,
+      },
+    ],
+  };
 }
 
 export function returnImmutableReferences(

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -74,329 +74,94 @@ export function returnAuxdataStyle(
   return AuxdataStyle.VYPER;
 }
 
-type VyperAstNode = Record<string, any>;
-type VyperStructDefinitions = Record<string, VyperAstNode[]>;
-type VyperIntegerConstants = Record<string, number>;
-
 const WORD_SIZE = 32;
-const DYNAMIC_ARRAY_OVERHEAD_WORDS = 1;
+const LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN =
+  /\[return,\s*(\d+),\s*\[add,\s*(\d+),\s*_lllsz\]\]/g;
 
-function ceil32(value: number): number {
-  return Math.ceil(value / WORD_SIZE) * WORD_SIZE;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isAstNode(node: unknown): node is VyperAstNode {
-  return node !== null && typeof node === 'object';
-}
-
-function getImmutableTypeAnnotation(
-  node: VyperAstNode,
-): VyperAstNode | undefined {
-  const annotation = node.annotation;
-  if (!isAstNode(annotation)) {
-    return undefined;
-  }
-
-  const immutableCall =
-    annotation.ast_type === 'Call' && annotation.func?.id === 'immutable';
-
-  if (immutableCall && isAstNode(annotation.args?.[0])) {
-    return annotation.args[0];
-  }
-
-  if (node.is_immutable === true) {
-    return annotation;
-  }
-
-  return undefined;
-}
-
-function collectStructDefinitions(ast: VyperAstNode): VyperStructDefinitions {
-  const structs: VyperStructDefinitions = {};
-  for (const node of ast.body ?? []) {
-    if (
-      isAstNode(node) &&
-      node.ast_type === 'StructDef' &&
-      typeof node.name === 'string' &&
-      Array.isArray(node.body)
-    ) {
-      structs[node.name] = node.body.filter(isAstNode);
-    }
-  }
-  return structs;
-}
-
-function getAstIntegerValue(node: VyperAstNode): number | undefined {
-  const value = node.value ?? node.n;
-  if (Number.isSafeInteger(value)) {
-    return value;
-  }
-  return undefined;
-}
-
-function evaluateIntegerExpression(
-  node: unknown,
-  constants: VyperIntegerConstants,
-): number | undefined {
-  if (!isAstNode(node)) {
-    return undefined;
-  }
-
-  const integerValue = getAstIntegerValue(node);
-  if (integerValue !== undefined) {
-    return integerValue;
-  }
-
-  if (node.ast_type === 'Name' && typeof node.id === 'string') {
-    return constants[node.id];
-  }
-
-  if (node.ast_type === 'UnaryOp') {
-    const operand = evaluateIntegerExpression(node.operand, constants);
-    if (operand === undefined) {
-      return undefined;
-    }
-    if (node.op?.ast_type === 'USub') {
-      return -operand;
-    }
-    if (node.op?.ast_type === 'UAdd') {
-      return operand;
-    }
-    return undefined;
-  }
-
-  if (node.ast_type !== 'BinOp') {
-    return undefined;
-  }
-
-  const left = evaluateIntegerExpression(node.left, constants);
-  const right = evaluateIntegerExpression(node.right, constants);
-  if (left === undefined || right === undefined) {
-    return undefined;
-  }
-
-  let result: number | undefined;
-  switch (node.op?.ast_type) {
-    case 'Add':
-      result = left + right;
-      break;
-    case 'Sub':
-      result = left - right;
-      break;
-    case 'Mult':
-      result = left * right;
-      break;
-    case 'Pow':
-      result = left ** right;
-      break;
-    case 'Div':
-    case 'FloorDiv':
-      if (right === 0 || left % right !== 0) {
-        return undefined;
-      }
-      result = left / right;
-      break;
-    default:
-      return undefined;
-  }
-
-  if (Number.isSafeInteger(result)) {
-    return result;
-  }
-  return undefined;
-}
-
-function getConstantTypeAnnotation(
-  node: VyperAstNode,
-): VyperAstNode | undefined {
-  const annotation = node.annotation;
-  if (!isAstNode(annotation)) {
-    return undefined;
-  }
-
-  if (node.is_constant === true) {
-    return annotation;
-  }
-
-  const constantCall =
-    annotation.ast_type === 'Call' && annotation.func?.id === 'constant';
-  if (constantCall && isAstNode(annotation.args?.[0])) {
-    return annotation.args[0];
-  }
-
-  return undefined;
-}
-
-function collectIntegerConstantDefinitions(
-  ast: VyperAstNode,
-): VyperIntegerConstants {
-  const constants: VyperIntegerConstants = {};
-  let pendingConstants: VyperAstNode[] = ast.body
-    .filter(isAstNode)
-    .filter(
-      (node: VyperAstNode) =>
-        typeof node.target?.id === 'string' &&
-        getConstantTypeAnnotation(node) !== undefined &&
-        isAstNode(node.value),
-    );
-
-  while (pendingConstants.length > 0) {
-    const remainingConstants: VyperAstNode[] = [];
-    let madeProgress = false;
-
-    for (const node of pendingConstants) {
-      const value = evaluateIntegerExpression(node.value, constants);
-      if (value === undefined) {
-        remainingConstants.push(node);
-        continue;
-      }
-
-      constants[node.target.id] = value;
-      madeProgress = true;
-    }
-
-    if (!madeProgress) {
-      break;
-    }
-    pendingConstants = remainingConstants;
-  }
-
-  return constants;
-}
-
-function getSubscriptLength(
-  node: VyperAstNode,
-  constants: VyperIntegerConstants,
-): number | undefined {
-  const value = node.slice?.value;
-  if (typeof value?.value === 'number') {
-    return value.value;
-  }
-  if (typeof value?.n === 'number') {
-    return value.n;
-  }
-  return evaluateIntegerExpression(value, constants);
-}
-
-function getTypeByteLength(
-  annotation: VyperAstNode,
-  structs: VyperStructDefinitions,
-  constants: VyperIntegerConstants,
-): number | undefined {
-  if (annotation.ast_type === 'Name' && typeof annotation.id === 'string') {
-    const structMembers = structs[annotation.id];
-    if (structMembers !== undefined) {
-      let structByteLength = 0;
-      for (const member of structMembers) {
-        const memberByteLength = getTypeByteLength(
-          member.annotation,
-          structs,
-          constants,
-        );
-        if (memberByteLength === undefined) {
-          return undefined;
-        }
-        structByteLength += memberByteLength;
-      }
-      return structByteLength;
-    }
-
-    // Base types, enums, and interface types occupy one word in Vyper's
-    // legacy immutable section.
-    return WORD_SIZE;
-  }
-
-  if (annotation.ast_type !== 'Subscript' || !isAstNode(annotation.value)) {
-    return undefined;
-  }
-
-  const typeName = annotation.value.id;
-  if (typeName === 'DynArray') {
-    const elements = annotation.slice?.value?.elements;
-    const subtype = elements?.[0];
-    const maxLength = evaluateIntegerExpression(elements?.[1], constants);
-    if (!isAstNode(subtype) || typeof maxLength !== 'number') {
-      return undefined;
-    }
-
-    const subtypeByteLength = getTypeByteLength(subtype, structs, constants);
-    if (subtypeByteLength === undefined) {
-      return undefined;
-    }
-    return (
-      DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE + maxLength * subtypeByteLength
-    );
-  }
-
-  const length = getSubscriptLength(annotation, constants);
-  if (length === undefined) {
-    return undefined;
-  }
-
-  if (typeName === 'Bytes' || typeName === 'String') {
-    return ceil32(length) + DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE;
-  }
-
-  const subtypeByteLength = getTypeByteLength(
-    annotation.value,
-    structs,
-    constants,
+function isValidImmutableLength(length: unknown): length is number {
+  return (
+    typeof length === 'number' &&
+    Number.isSafeInteger(length) &&
+    length > 0 &&
+    length % WORD_SIZE === 0
   );
-  if (subtypeByteLength === undefined) {
+}
+
+function collectStructuredIrImmutableLengths(
+  node: unknown,
+  lengths: number[] = [],
+): number[] {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      collectStructuredIrImmutableLengths(child, lengths);
+    }
+    return lengths;
+  }
+
+  if (!isRecord(node)) {
+    return lengths;
+  }
+
+  const deployNode = node.deploy;
+  if (Array.isArray(deployNode) && isValidImmutableLength(deployNode[2])) {
+    lengths.push(deployNode[2]);
+  }
+
+  for (const child of Object.values(node)) {
+    collectStructuredIrImmutableLengths(child, lengths);
+  }
+  return lengths;
+}
+
+function extractTextIrImmutableLengths(ir: string): number[] {
+  const lengths: number[] = [];
+  for (const match of ir.matchAll(LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN)) {
+    const length = Number(match[2]);
+    if (isValidImmutableLength(length)) {
+      lengths.push(length);
+    }
+  }
+  return lengths;
+}
+
+function getLegacyVyperImmutableLengthFromIr(ir: unknown): number | undefined {
+  const lengths =
+    typeof ir === 'string'
+      ? extractTextIrImmutableLengths(ir)
+      : collectStructuredIrImmutableLengths(ir);
+
+  if (lengths.length !== 1) {
     return undefined;
   }
-  return length * subtypeByteLength;
+  return lengths[0];
 }
 
 export function returnLegacyVyperImmutableReferences(
   compilerOutput: VyperOutput | undefined,
-  compilationTargetPath: string,
+  compilationTarget: CompilationTarget,
   runtimeBytecode: string,
 ): ImmutableReferences {
-  if (!compilerOutput?.sources) {
+  const compilationTargetContract =
+    compilerOutput?.contracts?.[compilationTarget.path]?.[
+      compilationTarget.name
+    ];
+  const immutableLength = getLegacyVyperImmutableLengthFromIr(
+    compilationTargetContract?.ir,
+  );
+  if (immutableLength === undefined) {
     return {};
   }
 
-  const ast = compilerOutput.sources[compilationTargetPath]?.ast;
-  if (!isAstNode(ast) || !Array.isArray(ast.body)) {
-    return {};
-  }
-
-  const structs = collectStructDefinitions(ast);
-  const constants = collectIntegerConstantDefinitions(ast);
   const runtimeByteLength = runtimeBytecode.substring(2).length / 2;
-  let immutableOffset = 0;
-
-  for (const node of ast.body.filter(isAstNode)) {
-    const annotation = getImmutableTypeAnnotation(node);
-    if (annotation === undefined) {
-      continue;
-    }
-
-    const immutableByteLength = getTypeByteLength(
-      annotation,
-      structs,
-      constants,
-    );
-    if (
-      immutableByteLength === undefined ||
-      immutableByteLength <= 0 ||
-      typeof node.target?.id !== 'string'
-    ) {
-      return {};
-    }
-
-    immutableOffset += immutableByteLength;
-  }
-
-  if (immutableOffset === 0) {
-    return {};
-  }
 
   return {
     '0': [
       {
-        length: immutableOffset,
+        length: immutableLength,
         start: runtimeByteLength,
       },
     ],

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -74,38 +74,170 @@ export function returnAuxdataStyle(
   return AuxdataStyle.VYPER;
 }
 
-function astContainsImmutableVariable(node: unknown): boolean {
-  if (!node || typeof node !== 'object') {
-    return false;
-  }
+type VyperAstNode = Record<string, any>;
+type VyperStructDefinitions = Record<string, VyperAstNode[]>;
 
-  const objectNode = node as Record<string, unknown>;
-  if (
-    objectNode.ast_type === 'VariableDecl' &&
-    objectNode.is_immutable === true
-  ) {
-    return true;
-  }
+const WORD_SIZE = 32;
+const DYNAMIC_ARRAY_OVERHEAD_WORDS = 1;
 
-  return Object.values(objectNode).some((value) => {
-    if (Array.isArray(value)) {
-      return value.some(astContainsImmutableVariable);
-    }
-    return astContainsImmutableVariable(value);
-  });
+function ceil32(value: number): number {
+  return Math.ceil(value / WORD_SIZE) * WORD_SIZE;
 }
 
-export function compilerOutputContainsImmutableVariables(
-  compilerOutput: VyperOutput | undefined,
-  compilationTargetPath: string,
-): boolean {
-  if (!compilerOutput?.sources) {
-    return false;
+function isAstNode(node: unknown): node is VyperAstNode {
+  return node !== null && typeof node === 'object';
+}
+
+function getImmutableTypeAnnotation(node: VyperAstNode): VyperAstNode | undefined {
+  const annotation = node.annotation;
+  if (!isAstNode(annotation)) {
+    return undefined;
   }
 
-  return astContainsImmutableVariable(
-    compilerOutput.sources[compilationTargetPath]?.ast,
-  );
+  const immutableCall =
+    annotation.ast_type === 'Call' && annotation.func?.id === 'immutable';
+
+  if (immutableCall && isAstNode(annotation.args?.[0])) {
+    return annotation.args[0];
+  }
+
+  if (node.is_immutable === true) {
+    return annotation;
+  }
+
+  return undefined;
+}
+
+function collectStructDefinitions(ast: VyperAstNode): VyperStructDefinitions {
+  const structs: VyperStructDefinitions = {};
+  for (const node of ast.body ?? []) {
+    if (
+      isAstNode(node) &&
+      node.ast_type === 'StructDef' &&
+      typeof node.name === 'string' &&
+      Array.isArray(node.body)
+    ) {
+      structs[node.name] = node.body.filter(isAstNode);
+    }
+  }
+  return structs;
+}
+
+function getSubscriptLength(node: VyperAstNode): number | undefined {
+  const value = node.slice?.value;
+  if (typeof value?.value === 'number') {
+    return value.value;
+  }
+  if (typeof value?.n === 'number') {
+    return value.n;
+  }
+  return undefined;
+}
+
+function getTypeByteLength(
+  annotation: VyperAstNode,
+  structs: VyperStructDefinitions,
+): number | undefined {
+  if (annotation.ast_type === 'Name' && typeof annotation.id === 'string') {
+    const structMembers = structs[annotation.id];
+    if (structMembers !== undefined) {
+      let structByteLength = 0;
+      for (const member of structMembers) {
+        const memberByteLength = getTypeByteLength(member.annotation, structs);
+        if (memberByteLength === undefined) {
+          return undefined;
+        }
+        structByteLength += memberByteLength;
+      }
+      return structByteLength;
+    }
+
+    // Base types, enums, and interface types occupy one word in Vyper's
+    // legacy immutable section.
+    return WORD_SIZE;
+  }
+
+  if (annotation.ast_type !== 'Subscript' || !isAstNode(annotation.value)) {
+    return undefined;
+  }
+
+  const typeName = annotation.value.id;
+  if (typeName === 'DynArray') {
+    const elements = annotation.slice?.value?.elements;
+    const subtype = elements?.[0];
+    const maxLength = elements?.[1]?.value ?? elements?.[1]?.n;
+    if (!isAstNode(subtype) || typeof maxLength !== 'number') {
+      return undefined;
+    }
+
+    const subtypeByteLength = getTypeByteLength(subtype, structs);
+    if (subtypeByteLength === undefined) {
+      return undefined;
+    }
+    return DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE + maxLength * subtypeByteLength;
+  }
+
+  const length = getSubscriptLength(annotation);
+  if (length === undefined) {
+    return undefined;
+  }
+
+  if (typeName === 'Bytes' || typeName === 'String') {
+    return ceil32(length) + DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE;
+  }
+
+  const subtypeByteLength = getTypeByteLength(annotation.value, structs);
+  if (subtypeByteLength === undefined) {
+    return undefined;
+  }
+  return length * subtypeByteLength;
+}
+
+export function returnLegacyVyperImmutableReferences(
+  compilerOutput: VyperOutput | undefined,
+  compilationTargetPath: string,
+  runtimeBytecode: string,
+): ImmutableReferences {
+  if (!compilerOutput?.sources) {
+    return {};
+  }
+
+  const ast = compilerOutput.sources[compilationTargetPath]?.ast;
+  if (!isAstNode(ast) || !Array.isArray(ast.body)) {
+    return {};
+  }
+
+  const structs = collectStructDefinitions(ast);
+  const runtimeByteLength = runtimeBytecode.substring(2).length / 2;
+  const immutableReferences: ImmutableReferences = {};
+  let immutableOffset = 0;
+
+  for (const node of ast.body.filter(isAstNode)) {
+    const annotation = getImmutableTypeAnnotation(node);
+    if (annotation === undefined) {
+      continue;
+    }
+
+    const immutableByteLength = getTypeByteLength(annotation, structs);
+    const immutableName = node.target?.id;
+    if (
+      immutableByteLength === undefined ||
+      immutableByteLength <= 0 ||
+      typeof immutableName !== 'string'
+    ) {
+      return {};
+    }
+
+    immutableReferences[immutableName] = [
+      {
+        length: immutableByteLength,
+        start: runtimeByteLength + immutableOffset,
+      },
+    ];
+    immutableOffset += immutableByteLength;
+  }
+
+  return immutableReferences;
 }
 
 export function returnImmutableReferences(

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -11,7 +11,6 @@ import type {
   VyperJsonInput,
   VyperOutput,
   VyperOutputContract,
-  VyperIROutput,
   ImmutableReferences,
   LinkReferences,
 } from '@ethereum-sourcify/compilers-types';
@@ -22,6 +21,10 @@ import type {
   IVyperCompiler,
 } from './CompilationTypes';
 import { CompilationError } from './CompilationTypes';
+import {
+  isValidImmutableLength,
+  returnLegacyVyperImmutableReferences,
+} from './legacyVyperImmutablesHelpers';
 
 export function returnFixedVyperVersion(compilerVersion: string): string {
   if (semver.valid(compilerVersion)) {
@@ -74,107 +77,6 @@ export function returnAuxdataStyle(
     return AuxdataStyle.VYPER_LT_0_3_10;
   }
   return AuxdataStyle.VYPER;
-}
-
-const WORD_SIZE = 32;
-const LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN =
-  /\[return,\s*(\d+),\s*\[add,\s*(\d+),\s*_lllsz\]\]/g;
-
-function isRecord(
-  value: VyperIROutput,
-): value is { [key: string]: VyperIROutput } {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isValidImmutableLength(length: VyperIROutput): length is number {
-  return (
-    typeof length === 'number' &&
-    Number.isSafeInteger(length) &&
-    length > 0 &&
-    length % WORD_SIZE === 0
-  );
-}
-
-function collectStructuredIrImmutableLengths(
-  node: VyperIROutput,
-  lengths: number[] = [],
-): number[] {
-  if (Array.isArray(node)) {
-    for (const child of node) {
-      collectStructuredIrImmutableLengths(child, lengths);
-    }
-    return lengths;
-  }
-
-  if (!isRecord(node)) {
-    return lengths;
-  }
-
-  const deployNode = node.deploy;
-  if (Array.isArray(deployNode) && isValidImmutableLength(deployNode[2])) {
-    lengths.push(deployNode[2]);
-  }
-
-  for (const child of Object.values(node)) {
-    collectStructuredIrImmutableLengths(child, lengths);
-  }
-  return lengths;
-}
-
-function extractTextIrImmutableLengths(ir: string): number[] {
-  const lengths: number[] = [];
-  for (const match of ir.matchAll(LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN)) {
-    const length = Number(match[2]);
-    if (isValidImmutableLength(length)) {
-      lengths.push(length);
-    }
-  }
-  return lengths;
-}
-
-function getLegacyVyperImmutableLengthFromIr(
-  ir: VyperIROutput | undefined,
-): number | undefined {
-  if (ir === undefined) {
-    return undefined;
-  }
-  const lengths =
-    typeof ir === 'string'
-      ? extractTextIrImmutableLengths(ir)
-      : collectStructuredIrImmutableLengths(ir);
-
-  if (lengths.length !== 1) {
-    return undefined;
-  }
-  return lengths[0];
-}
-
-export function returnLegacyVyperImmutableReferences(
-  compilerOutput: VyperOutput | undefined,
-  compilationTarget: CompilationTarget,
-  runtimeBytecode: string,
-): ImmutableReferences {
-  const compilationTargetContract =
-    compilerOutput?.contracts?.[compilationTarget.path]?.[
-      compilationTarget.name
-    ];
-  const immutableLength = getLegacyVyperImmutableLengthFromIr(
-    compilationTargetContract?.ir,
-  );
-  if (immutableLength === undefined) {
-    return {};
-  }
-
-  const runtimeByteLength = runtimeBytecode.substring(2).length / 2;
-
-  return {
-    '0': [
-      {
-        length: immutableLength,
-        start: runtimeByteLength,
-      },
-    ],
-  };
 }
 
 export function returnImmutableReferences(

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -74,6 +74,39 @@ export function returnAuxdataStyle(
   return AuxdataStyle.VYPER;
 }
 
+function astContainsImmutableVariable(node: unknown): boolean {
+  if (!node || typeof node !== 'object') {
+    return false;
+  }
+
+  const objectNode = node as Record<string, unknown>;
+  if (
+    objectNode.ast_type === 'VariableDecl' &&
+    objectNode.is_immutable === true
+  ) {
+    return true;
+  }
+
+  return Object.values(objectNode).some((value) => {
+    if (Array.isArray(value)) {
+      return value.some(astContainsImmutableVariable);
+    }
+    return astContainsImmutableVariable(value);
+  });
+}
+
+export function compilerOutputContainsImmutableVariables(
+  compilerOutput?: VyperOutput,
+): boolean {
+  if (!compilerOutput?.sources) {
+    return false;
+  }
+
+  return Object.values(compilerOutput.sources).some((source) =>
+    astContainsImmutableVariable(source.ast),
+  );
+}
+
 export function returnImmutableReferences(
   compilerVersion: string,
   creationBytecode: string,

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -76,6 +76,7 @@ export function returnAuxdataStyle(
 
 type VyperAstNode = Record<string, any>;
 type VyperStructDefinitions = Record<string, VyperAstNode[]>;
+type VyperIntegerConstants = Record<string, number>;
 
 const WORD_SIZE = 32;
 const DYNAMIC_ARRAY_OVERHEAD_WORDS = 1;
@@ -125,7 +126,148 @@ function collectStructDefinitions(ast: VyperAstNode): VyperStructDefinitions {
   return structs;
 }
 
-function getSubscriptLength(node: VyperAstNode): number | undefined {
+function getAstIntegerValue(node: VyperAstNode): number | undefined {
+  const value = node.value ?? node.n;
+  if (Number.isSafeInteger(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function evaluateIntegerExpression(
+  node: unknown,
+  constants: VyperIntegerConstants,
+): number | undefined {
+  if (!isAstNode(node)) {
+    return undefined;
+  }
+
+  const integerValue = getAstIntegerValue(node);
+  if (integerValue !== undefined) {
+    return integerValue;
+  }
+
+  if (node.ast_type === 'Name' && typeof node.id === 'string') {
+    return constants[node.id];
+  }
+
+  if (node.ast_type === 'UnaryOp') {
+    const operand = evaluateIntegerExpression(node.operand, constants);
+    if (operand === undefined) {
+      return undefined;
+    }
+    if (node.op?.ast_type === 'USub') {
+      return -operand;
+    }
+    if (node.op?.ast_type === 'UAdd') {
+      return operand;
+    }
+    return undefined;
+  }
+
+  if (node.ast_type !== 'BinOp') {
+    return undefined;
+  }
+
+  const left = evaluateIntegerExpression(node.left, constants);
+  const right = evaluateIntegerExpression(node.right, constants);
+  if (left === undefined || right === undefined) {
+    return undefined;
+  }
+
+  let result: number | undefined;
+  switch (node.op?.ast_type) {
+    case 'Add':
+      result = left + right;
+      break;
+    case 'Sub':
+      result = left - right;
+      break;
+    case 'Mult':
+      result = left * right;
+      break;
+    case 'Pow':
+      result = left ** right;
+      break;
+    case 'Div':
+    case 'FloorDiv':
+      if (right === 0 || left % right !== 0) {
+        return undefined;
+      }
+      result = left / right;
+      break;
+    default:
+      return undefined;
+  }
+
+  if (Number.isSafeInteger(result)) {
+    return result;
+  }
+  return undefined;
+}
+
+function getConstantTypeAnnotation(
+  node: VyperAstNode,
+): VyperAstNode | undefined {
+  const annotation = node.annotation;
+  if (!isAstNode(annotation)) {
+    return undefined;
+  }
+
+  if (node.is_constant === true) {
+    return annotation;
+  }
+
+  const constantCall =
+    annotation.ast_type === 'Call' && annotation.func?.id === 'constant';
+  if (constantCall && isAstNode(annotation.args?.[0])) {
+    return annotation.args[0];
+  }
+
+  return undefined;
+}
+
+function collectIntegerConstantDefinitions(
+  ast: VyperAstNode,
+): VyperIntegerConstants {
+  const constants: VyperIntegerConstants = {};
+  let pendingConstants: VyperAstNode[] = ast.body
+    .filter(isAstNode)
+    .filter(
+      (node: VyperAstNode) =>
+        typeof node.target?.id === 'string' &&
+        getConstantTypeAnnotation(node) !== undefined &&
+        isAstNode(node.value),
+    );
+
+  while (pendingConstants.length > 0) {
+    const remainingConstants: VyperAstNode[] = [];
+    let madeProgress = false;
+
+    for (const node of pendingConstants) {
+      const value = evaluateIntegerExpression(node.value, constants);
+      if (value === undefined) {
+        remainingConstants.push(node);
+        continue;
+      }
+
+      constants[node.target.id] = value;
+      madeProgress = true;
+    }
+
+    if (!madeProgress) {
+      break;
+    }
+    pendingConstants = remainingConstants;
+  }
+
+  return constants;
+}
+
+function getSubscriptLength(
+  node: VyperAstNode,
+  constants: VyperIntegerConstants,
+): number | undefined {
   const value = node.slice?.value;
   if (typeof value?.value === 'number') {
     return value.value;
@@ -133,19 +275,24 @@ function getSubscriptLength(node: VyperAstNode): number | undefined {
   if (typeof value?.n === 'number') {
     return value.n;
   }
-  return undefined;
+  return evaluateIntegerExpression(value, constants);
 }
 
 function getTypeByteLength(
   annotation: VyperAstNode,
   structs: VyperStructDefinitions,
+  constants: VyperIntegerConstants,
 ): number | undefined {
   if (annotation.ast_type === 'Name' && typeof annotation.id === 'string') {
     const structMembers = structs[annotation.id];
     if (structMembers !== undefined) {
       let structByteLength = 0;
       for (const member of structMembers) {
-        const memberByteLength = getTypeByteLength(member.annotation, structs);
+        const memberByteLength = getTypeByteLength(
+          member.annotation,
+          structs,
+          constants,
+        );
         if (memberByteLength === undefined) {
           return undefined;
         }
@@ -167,12 +314,12 @@ function getTypeByteLength(
   if (typeName === 'DynArray') {
     const elements = annotation.slice?.value?.elements;
     const subtype = elements?.[0];
-    const maxLength = elements?.[1]?.value ?? elements?.[1]?.n;
+    const maxLength = evaluateIntegerExpression(elements?.[1], constants);
     if (!isAstNode(subtype) || typeof maxLength !== 'number') {
       return undefined;
     }
 
-    const subtypeByteLength = getTypeByteLength(subtype, structs);
+    const subtypeByteLength = getTypeByteLength(subtype, structs, constants);
     if (subtypeByteLength === undefined) {
       return undefined;
     }
@@ -181,7 +328,7 @@ function getTypeByteLength(
     );
   }
 
-  const length = getSubscriptLength(annotation);
+  const length = getSubscriptLength(annotation, constants);
   if (length === undefined) {
     return undefined;
   }
@@ -190,7 +337,11 @@ function getTypeByteLength(
     return ceil32(length) + DYNAMIC_ARRAY_OVERHEAD_WORDS * WORD_SIZE;
   }
 
-  const subtypeByteLength = getTypeByteLength(annotation.value, structs);
+  const subtypeByteLength = getTypeByteLength(
+    annotation.value,
+    structs,
+    constants,
+  );
   if (subtypeByteLength === undefined) {
     return undefined;
   }
@@ -212,6 +363,7 @@ export function returnLegacyVyperImmutableReferences(
   }
 
   const structs = collectStructDefinitions(ast);
+  const constants = collectIntegerConstantDefinitions(ast);
   const runtimeByteLength = runtimeBytecode.substring(2).length / 2;
   let immutableOffset = 0;
 
@@ -221,7 +373,11 @@ export function returnLegacyVyperImmutableReferences(
       continue;
     }
 
-    const immutableByteLength = getTypeByteLength(annotation, structs);
+    const immutableByteLength = getTypeByteLength(
+      annotation,
+      structs,
+      constants,
+    );
     if (
       immutableByteLength === undefined ||
       immutableByteLength <= 0 ||

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -96,14 +96,15 @@ function astContainsImmutableVariable(node: unknown): boolean {
 }
 
 export function compilerOutputContainsImmutableVariables(
-  compilerOutput?: VyperOutput,
+  compilerOutput: VyperOutput | undefined,
+  compilationTargetPath: string,
 ): boolean {
   if (!compilerOutput?.sources) {
     return false;
   }
 
-  return Object.values(compilerOutput.sources).some((source) =>
-    astContainsImmutableVariable(source.ast),
+  return astContainsImmutableVariable(
+    compilerOutput.sources[compilationTargetPath]?.ast,
   );
 }
 

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -4,12 +4,14 @@ import {
   AuxdataStyle,
   decode,
   splitAuxdata,
+  type VyperDecodedObject,
 } from '@ethereum-sourcify/bytecode-utils';
 import semver, { gte, gt, lt } from 'semver';
 import type {
   VyperJsonInput,
   VyperOutput,
   VyperOutputContract,
+  VyperIROutput,
   ImmutableReferences,
   LinkReferences,
 } from '@ethereum-sourcify/compilers-types';
@@ -78,11 +80,13 @@ const WORD_SIZE = 32;
 const LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN =
   /\[return,\s*(\d+),\s*\[add,\s*(\d+),\s*_lllsz\]\]/g;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord(
+  value: VyperIROutput,
+): value is { [key: string]: VyperIROutput } {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isValidImmutableLength(length: unknown): length is number {
+function isValidImmutableLength(length: VyperIROutput): length is number {
   return (
     typeof length === 'number' &&
     Number.isSafeInteger(length) &&
@@ -92,7 +96,7 @@ function isValidImmutableLength(length: unknown): length is number {
 }
 
 function collectStructuredIrImmutableLengths(
-  node: unknown,
+  node: VyperIROutput,
   lengths: number[] = [],
 ): number[] {
   if (Array.isArray(node)) {
@@ -128,7 +132,12 @@ function extractTextIrImmutableLengths(ir: string): number[] {
   return lengths;
 }
 
-function getLegacyVyperImmutableLengthFromIr(ir: unknown): number | undefined {
+function getLegacyVyperImmutableLengthFromIr(
+  ir: VyperIROutput | undefined,
+): number | undefined {
+  if (ir === undefined) {
+    return undefined;
+  }
   const lengths =
     typeof ir === 'string'
       ? extractTextIrImmutableLengths(ir)
@@ -179,8 +188,14 @@ export function returnImmutableReferences(
   let immutableReferences: ImmutableReferences = {};
   if (gte(compilerVersion, '0.3.10')) {
     try {
-      const { immutableSize } = decode(creationBytecode, auxdataStyle);
-      if (isValidImmutableLength(immutableSize)) {
+      const { immutableSize } = decode(
+        creationBytecode,
+        auxdataStyle,
+      ) as VyperDecodedObject;
+      if (
+        immutableSize !== undefined &&
+        isValidImmutableLength(immutableSize)
+      ) {
         immutableReferences = {
           '0': [
             {

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -173,12 +173,14 @@ export function returnImmutableReferences(
   creationBytecode: string,
   runtimeBytecode: string,
   auxdataStyle: AuxdataStyle,
+  compilerOutput?: VyperOutput,
+  compilationTarget?: CompilationTarget,
 ): ImmutableReferences {
-  let immutableReferences = {};
+  let immutableReferences: ImmutableReferences = {};
   if (gte(compilerVersion, '0.3.10')) {
     try {
       const { immutableSize } = decode(creationBytecode, auxdataStyle);
-      if (immutableSize) {
+      if (isValidImmutableLength(immutableSize)) {
         immutableReferences = {
           '0': [
             {
@@ -193,6 +195,12 @@ export function returnImmutableReferences(
         creationBytecode: creationBytecode,
       });
     }
+  } else if (gte(compilerVersion, '0.3.1') && compilationTarget !== undefined) {
+    immutableReferences = returnLegacyVyperImmutableReferences(
+      compilerOutput,
+      compilationTarget,
+      runtimeBytecode,
+    );
   }
   return immutableReferences;
 }
@@ -286,6 +294,8 @@ export class VyperCompilation extends AbstractCompilation {
       this.creationBytecode,
       this.runtimeBytecode,
       this.auxdataStyle,
+      this.compilerOutput,
+      this.compilationTarget,
     );
   }
 

--- a/packages/lib-sourcify/src/Compilation/legacyVyperImmutablesHelpers.ts
+++ b/packages/lib-sourcify/src/Compilation/legacyVyperImmutablesHelpers.ts
@@ -75,8 +75,8 @@ function getLegacyVyperImmutableLengthFromIr(
   }
   const lengths =
     typeof ir === 'string'
-      ? extractTextIrImmutableLengths(ir) // ← 0.3.1: text LLL
-      : collectStructuredIrImmutableLengths(ir); // ← 0.3.2–0.3.9: structured IR tree
+      ? extractTextIrImmutableLengths(ir) // 0.3.1: text LLL
+      : collectStructuredIrImmutableLengths(ir); // 0.3.2-0.3.9: structured IR tree
 
   if (lengths.length !== 1) {
     return undefined;

--- a/packages/lib-sourcify/src/Compilation/legacyVyperImmutablesHelpers.ts
+++ b/packages/lib-sourcify/src/Compilation/legacyVyperImmutablesHelpers.ts
@@ -1,0 +1,113 @@
+import type {
+  VyperIROutput,
+  VyperOutput,
+  ImmutableReferences,
+} from '@ethereum-sourcify/compilers-types';
+import type { CompilationTarget } from './CompilationTypes';
+
+// Helpers for recovering immutable references on legacy Vyper contracts
+// (0.3.1 <= version < 0.3.10), where the immutable section size is not encoded
+// in the CBOR auxdata and must be derived from the compiler `ir` output.
+
+const WORD_SIZE = 32;
+const LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN =
+  /\[return,\s*(\d+),\s*\[add,\s*(\d+),\s*_lllsz\]\]/g;
+
+function isRecord(
+  value: VyperIROutput,
+): value is { [key: string]: VyperIROutput } {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isValidImmutableLength(
+  length: VyperIROutput,
+): length is number {
+  return (
+    typeof length === 'number' &&
+    Number.isSafeInteger(length) &&
+    length > 0 &&
+    length % WORD_SIZE === 0
+  );
+}
+
+function collectStructuredIrImmutableLengths(
+  node: VyperIROutput,
+  lengths: number[] = [],
+): number[] {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      collectStructuredIrImmutableLengths(child, lengths);
+    }
+    return lengths;
+  }
+
+  if (!isRecord(node)) {
+    return lengths;
+  }
+
+  const deployNode = node.deploy;
+  if (Array.isArray(deployNode) && isValidImmutableLength(deployNode[2])) {
+    lengths.push(deployNode[2]);
+  }
+
+  for (const child of Object.values(node)) {
+    collectStructuredIrImmutableLengths(child, lengths);
+  }
+  return lengths;
+}
+
+function extractTextIrImmutableLengths(ir: string): number[] {
+  const lengths: number[] = [];
+  for (const match of ir.matchAll(LEGACY_VYPER_TEXT_IR_IMMUTABLE_RETURN)) {
+    const length = Number(match[2]);
+    if (isValidImmutableLength(length)) {
+      lengths.push(length);
+    }
+  }
+  return lengths;
+}
+
+function getLegacyVyperImmutableLengthFromIr(
+  ir: VyperIROutput | undefined,
+): number | undefined {
+  if (ir === undefined) {
+    return undefined;
+  }
+  const lengths =
+    typeof ir === 'string'
+      ? extractTextIrImmutableLengths(ir)
+      : collectStructuredIrImmutableLengths(ir);
+
+  if (lengths.length !== 1) {
+    return undefined;
+  }
+  return lengths[0];
+}
+
+export function returnLegacyVyperImmutableReferences(
+  compilerOutput: VyperOutput | undefined,
+  compilationTarget: CompilationTarget,
+  runtimeBytecode: string,
+): ImmutableReferences {
+  const compilationTargetContract =
+    compilerOutput?.contracts?.[compilationTarget.path]?.[
+      compilationTarget.name
+    ];
+  const immutableLength = getLegacyVyperImmutableLengthFromIr(
+    compilationTargetContract?.ir,
+  );
+  if (immutableLength === undefined) {
+    return {};
+  }
+
+  const runtimeByteLength = runtimeBytecode.substring(2).length / 2;
+
+  return {
+    '0': [
+      {
+        length: immutableLength,
+        start: runtimeByteLength,
+      },
+    ],
+  };
+}

--- a/packages/lib-sourcify/src/Compilation/legacyVyperImmutablesHelpers.ts
+++ b/packages/lib-sourcify/src/Compilation/legacyVyperImmutablesHelpers.ts
@@ -75,8 +75,8 @@ function getLegacyVyperImmutableLengthFromIr(
   }
   const lengths =
     typeof ir === 'string'
-      ? extractTextIrImmutableLengths(ir)
-      : collectStructuredIrImmutableLengths(ir);
+      ? extractTextIrImmutableLengths(ir) // ← 0.3.1: text LLL
+      : collectStructuredIrImmutableLengths(ir); // ← 0.3.2–0.3.9: structured IR tree
 
   if (lengths.length !== 1) {
     return undefined;

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -158,7 +158,8 @@ export function inferLegacyVyperImmutableReferences(
   const runtimeByteLength = populatedRecompiledBytecode.length / 2;
 
   // Legacy Vyper metadata does not encode immutable size. Keep this fallback
-  // limited to prefix-identical runtimes with the AST-derived immutable layout.
+  // limited to prefix-identical runtimes with the compiler-derived immutable
+  // tail length.
   if (
     onchainRuntimeBytecode.length <= populatedRecompiledBytecode.length ||
     !onchainRuntimeBytecode.startsWith(populatedRecompiledBytecode)

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -232,7 +232,9 @@ export function extractImmutablesTransformation(
         immutableValue +
         populatedRecompiledBytecode.slice(start * 2 + length * 2);
     } else if (isVyperImmutableAuxdataStyle(auxdataStyle)) {
-      // For Vyper, insert the immutable value.
+      // For Vyper, append the immutable tail before auxdata normalization.
+      // Any prefix difference remains in populatedRecompiledBytecode and is
+      // rejected by the final bytecode comparison.
       populatedRecompiledBytecode =
         populatedRecompiledBytecode + immutableValue;
     }

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -13,6 +13,7 @@ import { logError } from '../logger';
 import semver from 'semver';
 
 const abiCoder = AbiCoder.defaultAbiCoder();
+const LEGACY_VYPER_IMMUTABLE_BYTE_LENGTH = 32;
 
 export type Transformation = {
   type: 'insert' | 'replace' | 'delete';
@@ -156,6 +157,8 @@ export function inferLegacyVyperImmutableReferences(
     populatedRecompiledBytecodeWith0x.slice(2);
   const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
 
+  // Legacy Vyper metadata does not encode immutable size. Keep this fallback
+  // limited to prefix-identical runtimes with the observed single-word tail.
   if (
     onchainRuntimeBytecode.length <= populatedRecompiledBytecode.length ||
     !onchainRuntimeBytecode.startsWith(populatedRecompiledBytecode)
@@ -165,7 +168,7 @@ export function inferLegacyVyperImmutableReferences(
 
   const immutableLength =
     (onchainRuntimeBytecode.length - populatedRecompiledBytecode.length) / 2;
-  if (immutableLength <= 0 || immutableLength % 32 !== 0) {
+  if (immutableLength !== LEGACY_VYPER_IMMUTABLE_BYTE_LENGTH) {
     return {};
   }
 

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -124,73 +124,6 @@ function isVyperImmutableAuxdataStyle(auxdataStyle: AuxdataStyle): boolean {
   );
 }
 
-function getValidatedVyperImmutableReferences(
-  populatedRecompiledBytecodeWith0x: string,
-  onchainRuntimeBytecodeWith0x: string,
-  auxdataStyle: AuxdataStyle,
-  immutableReferences: ImmutableReferences,
-): ImmutableReferences {
-  if (
-    Object.keys(immutableReferences).length === 0 ||
-    !isVyperImmutableAuxdataStyle(auxdataStyle)
-  ) {
-    return immutableReferences;
-  }
-
-  const populatedRecompiledBytecode =
-    populatedRecompiledBytecodeWith0x.slice(2);
-  const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
-  const runtimeByteLength = populatedRecompiledBytecode.length / 2;
-
-  // Vyper appends immutable values as a tail after the compiler runtime.
-  // Only record/apply the transformation when the observed onchain tail length
-  // exactly matches the compiler-derived references.
-  if (
-    onchainRuntimeBytecode.length <= populatedRecompiledBytecode.length ||
-    !onchainRuntimeBytecode.startsWith(populatedRecompiledBytecode)
-  ) {
-    return {};
-  }
-
-  const immutableLength =
-    (onchainRuntimeBytecode.length - populatedRecompiledBytecode.length) / 2;
-  const expectedImmutableLength = getImmutableReferencesByteLength(
-    immutableReferences,
-    runtimeByteLength,
-  );
-  if (
-    expectedImmutableLength === undefined ||
-    immutableLength !== expectedImmutableLength
-  ) {
-    return {};
-  }
-
-  return immutableReferences;
-}
-
-function getImmutableReferencesByteLength(
-  immutableReferences: ImmutableReferences,
-  runtimeByteLength: number,
-): number | undefined {
-  const references: Array<{ length: number; start: number }> = [];
-
-  for (const refs of Object.values(immutableReferences)) {
-    references.push(...refs);
-  }
-
-  references.sort((a, b) => a.start - b.start);
-
-  let nextStart = runtimeByteLength;
-  for (const reference of references) {
-    if (reference.length <= 0 || reference.start !== nextStart) {
-      return undefined;
-    }
-    nextStart += reference.length;
-  }
-
-  return nextStart - runtimeByteLength;
-}
-
 // returns the full bytecode with the call protection replaced with the real address
 export function extractCallProtectionTransformation(
   populatedRecompiledBytecode: string,
@@ -240,21 +173,13 @@ export function extractImmutablesTransformation(
   // Remove "0x" from the beginning of both bytecodes.
   const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
   let populatedRecompiledBytecode = populatedRecompiledBytecodeWith0x.slice(2);
-  const effectiveImmutableReferences = getValidatedVyperImmutableReferences(
-    populatedRecompiledBytecodeWith0x,
-    onchainRuntimeBytecodeWith0x,
-    auxdataStyle,
-    immutableReferences,
-  );
 
   const immutableReferenceEntries: Array<{
     astId: string;
     reference: { length: number; start: number };
   }> = [];
 
-  for (const [astId, references] of Object.entries(
-    effectiveImmutableReferences,
-  )) {
+  for (const [astId, references] of Object.entries(immutableReferences)) {
     for (const reference of references) {
       immutableReferenceEntries.push({ astId, reference });
     }
@@ -267,6 +192,24 @@ export function extractImmutablesTransformation(
   immutableReferenceEntries.forEach(({ astId, reference }) => {
     const { start, length } = reference;
 
+    // Extract the immutable value from the onchain bytecode.
+    const immutableValue = onchainRuntimeBytecode.slice(
+      start * 2,
+      start * 2 + length * 2,
+    );
+
+    // Safeguard against the IR heuristic: slice() can read past the end of the
+    // onchain bytecode and silently return a shorter value, so throw if the
+    // extracted immutable isn't the expected length.
+    if (
+      isVyperImmutableAuxdataStyle(auxdataStyle) &&
+      immutableValue.length !== length * 2
+    ) {
+      throw new Error(
+        `Vyper immutable length mismatch: expected ${length} bytes at offset ${start}, got ${immutableValue.length / 2}`,
+      );
+    }
+
     // Save the transformation
     transformations.push(
       ImmutablesTransformation(
@@ -274,12 +217,6 @@ export function extractImmutablesTransformation(
         astId,
         auxdataStyle === AuxdataStyle.SOLIDITY ? 'replace' : 'insert',
       ),
-    );
-
-    // Extract the immutable value from the onchain bytecode.
-    const immutableValue = onchainRuntimeBytecode.slice(
-      start * 2,
-      start * 2 + length * 2,
     );
 
     // Save the transformation value

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -186,9 +186,13 @@ function getImmutableReferencesByteLength(
   immutableReferences: ImmutableReferences,
   runtimeByteLength: number,
 ): number | undefined {
-  const references = Object.values(immutableReferences)
-    .flat()
-    .sort((a, b) => a.start - b.start);
+  const references: Array<{ length: number; start: number }> = [];
+
+  for (const refs of Object.values(immutableReferences)) {
+    references.push(...refs);
+  }
+
+  references.sort((a, b) => a.start - b.start);
 
   let nextStart = runtimeByteLength;
   for (const reference of references) {
@@ -263,11 +267,22 @@ export function extractImmutablesTransformation(
           compilerVersion,
         );
 
-  const immutableReferenceEntries = Object.entries(effectiveImmutableReferences)
-    .flatMap(([astId, references]) =>
-      references.map((reference) => ({ astId, reference })),
-    )
-    .sort((a, b) => a.reference.start - b.reference.start);
+  const immutableReferenceEntries: Array<{
+    astId: string;
+    reference: { length: number; start: number };
+  }> = [];
+
+  for (const [astId, references] of Object.entries(
+    effectiveImmutableReferences,
+  )) {
+    for (const reference of references) {
+      immutableReferenceEntries.push({ astId, reference });
+    }
+  }
+
+  immutableReferenceEntries.sort(
+    (a, b) => a.reference.start - b.reference.start,
+  );
 
   immutableReferenceEntries.forEach(({ astId, reference }) => {
     const { start, length } = reference;
@@ -301,7 +316,8 @@ export function extractImmutablesTransformation(
         populatedRecompiledBytecode.slice(start * 2 + length * 2);
     } else if (isVyperImmutableAuxdataStyle(auxdataStyle)) {
       // For Vyper, insert the immutable value.
-      populatedRecompiledBytecode = populatedRecompiledBytecode + immutableValue;
+      populatedRecompiledBytecode =
+        populatedRecompiledBytecode + immutableValue;
     }
   });
   return {

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -10,6 +10,7 @@ import type {
 import type { InterfaceAbi } from 'ethers';
 import { AbiCoder, id as keccak256Str, Interface } from 'ethers';
 import { logError } from '../logger';
+import semver from 'semver';
 
 const abiCoder = AbiCoder.defaultAbiCoder();
 
@@ -115,6 +116,69 @@ export interface TransformationValues {
   };
 }
 
+function isVyperImmutableAuxdataStyle(auxdataStyle: AuxdataStyle): boolean {
+  return (
+    auxdataStyle === AuxdataStyle.VYPER ||
+    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_10 ||
+    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_5 ||
+    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_4
+  );
+}
+
+function isLegacyVyperImmutableAuxdataStyle(
+  auxdataStyle: AuxdataStyle,
+): boolean {
+  return (
+    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_10 ||
+    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_5 ||
+    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_4
+  );
+}
+
+export function inferLegacyVyperImmutableReferences(
+  populatedRecompiledBytecodeWith0x: string,
+  onchainRuntimeBytecodeWith0x: string,
+  auxdataStyle: AuxdataStyle,
+  compilerVersion?: string,
+  hasImmutableVariables = false,
+): ImmutableReferences {
+  if (
+    !hasImmutableVariables ||
+    compilerVersion === undefined ||
+    !isLegacyVyperImmutableAuxdataStyle(auxdataStyle) ||
+    !semver.gte(compilerVersion, '0.3.1') ||
+    !semver.lt(compilerVersion, '0.3.10')
+  ) {
+    return {};
+  }
+
+  const populatedRecompiledBytecode =
+    populatedRecompiledBytecodeWith0x.slice(2);
+  const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
+
+  if (
+    onchainRuntimeBytecode.length <= populatedRecompiledBytecode.length ||
+    !onchainRuntimeBytecode.startsWith(populatedRecompiledBytecode)
+  ) {
+    return {};
+  }
+
+  const immutableLength =
+    (onchainRuntimeBytecode.length - populatedRecompiledBytecode.length) / 2;
+  if (immutableLength <= 0 || immutableLength % 32 !== 0) {
+    return {};
+  }
+
+  return {
+    '0': [
+      {
+        length: immutableLength,
+        start: populatedRecompiledBytecode.length / 2,
+      },
+    ],
+  };
+}
+
 // returns the full bytecode with the call protection replaced with the real address
 export function extractCallProtectionTransformation(
   populatedRecompiledBytecode: string,
@@ -158,15 +222,27 @@ export function extractImmutablesTransformation(
   onchainRuntimeBytecodeWith0x: string,
   immutableReferences: ImmutableReferences,
   auxdataStyle: AuxdataStyle,
+  compilerVersion?: string,
+  hasImmutableVariables = false,
 ) {
   const transformations: Transformation[] = [];
   const transformationValues: TransformationValues = {};
   // Remove "0x" from the beginning of both bytecodes.
   const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
   let populatedRecompiledBytecode = populatedRecompiledBytecodeWith0x.slice(2);
+  const effectiveImmutableReferences =
+    Object.keys(immutableReferences).length > 0
+      ? immutableReferences
+      : inferLegacyVyperImmutableReferences(
+          populatedRecompiledBytecodeWith0x,
+          onchainRuntimeBytecodeWith0x,
+          auxdataStyle,
+          compilerVersion,
+          hasImmutableVariables,
+        );
 
-  Object.keys(immutableReferences).forEach((astId) => {
-    immutableReferences[astId].forEach((reference) => {
+  Object.keys(effectiveImmutableReferences).forEach((astId) => {
+    effectiveImmutableReferences[astId].forEach((reference) => {
       const { start, length } = reference;
 
       // Save the transformation
@@ -196,7 +272,7 @@ export function extractImmutablesTransformation(
           populatedRecompiledBytecode.slice(0, start * 2) +
           immutableValue +
           populatedRecompiledBytecode.slice(start * 2 + length * 2);
-      } else if (auxdataStyle === AuxdataStyle.VYPER) {
+      } else if (isVyperImmutableAuxdataStyle(auxdataStyle)) {
         // For Vyper, insert the immutable value.
         populatedRecompiledBytecode =
           populatedRecompiledBytecode + immutableValue;

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -10,7 +10,6 @@ import type {
 import type { InterfaceAbi } from 'ethers';
 import { AbiCoder, id as keccak256Str, Interface } from 'ethers';
 import { logError } from '../logger';
-import semver from 'semver';
 
 const abiCoder = AbiCoder.defaultAbiCoder();
 
@@ -125,31 +124,17 @@ function isVyperImmutableAuxdataStyle(auxdataStyle: AuxdataStyle): boolean {
   );
 }
 
-function isLegacyVyperImmutableAuxdataStyle(
-  auxdataStyle: AuxdataStyle,
-): boolean {
-  return (
-    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_10 ||
-    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_5 ||
-    auxdataStyle === AuxdataStyle.VYPER_LT_0_3_4
-  );
-}
-
-export function inferLegacyVyperImmutableReferences(
+function getValidatedVyperImmutableReferences(
   populatedRecompiledBytecodeWith0x: string,
   onchainRuntimeBytecodeWith0x: string,
   auxdataStyle: AuxdataStyle,
-  legacyImmutableReferences: ImmutableReferences,
-  compilerVersion?: string,
+  immutableReferences: ImmutableReferences,
 ): ImmutableReferences {
   if (
-    Object.keys(legacyImmutableReferences).length === 0 ||
-    compilerVersion === undefined ||
-    !isLegacyVyperImmutableAuxdataStyle(auxdataStyle) ||
-    !semver.gte(compilerVersion, '0.3.1') ||
-    !semver.lt(compilerVersion, '0.3.10')
+    Object.keys(immutableReferences).length === 0 ||
+    !isVyperImmutableAuxdataStyle(auxdataStyle)
   ) {
-    return {};
+    return immutableReferences;
   }
 
   const populatedRecompiledBytecode =
@@ -157,9 +142,9 @@ export function inferLegacyVyperImmutableReferences(
   const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
   const runtimeByteLength = populatedRecompiledBytecode.length / 2;
 
-  // Legacy Vyper metadata does not encode immutable size. Keep this fallback
-  // limited to prefix-identical runtimes with the compiler-derived immutable
-  // tail length.
+  // Vyper appends immutable values as a tail after the compiler runtime.
+  // Only record/apply the transformation when the observed onchain tail length
+  // exactly matches the compiler-derived references.
   if (
     onchainRuntimeBytecode.length <= populatedRecompiledBytecode.length ||
     !onchainRuntimeBytecode.startsWith(populatedRecompiledBytecode)
@@ -170,7 +155,7 @@ export function inferLegacyVyperImmutableReferences(
   const immutableLength =
     (onchainRuntimeBytecode.length - populatedRecompiledBytecode.length) / 2;
   const expectedImmutableLength = getImmutableReferencesByteLength(
-    legacyImmutableReferences,
+    immutableReferences,
     runtimeByteLength,
   );
   if (
@@ -180,7 +165,7 @@ export function inferLegacyVyperImmutableReferences(
     return {};
   }
 
-  return legacyImmutableReferences;
+  return immutableReferences;
 }
 
 function getImmutableReferencesByteLength(
@@ -249,24 +234,18 @@ export function extractImmutablesTransformation(
   onchainRuntimeBytecodeWith0x: string,
   immutableReferences: ImmutableReferences,
   auxdataStyle: AuxdataStyle,
-  legacyImmutableReferences: ImmutableReferences = {},
-  compilerVersion?: string,
 ) {
   const transformations: Transformation[] = [];
   const transformationValues: TransformationValues = {};
   // Remove "0x" from the beginning of both bytecodes.
   const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
   let populatedRecompiledBytecode = populatedRecompiledBytecodeWith0x.slice(2);
-  const effectiveImmutableReferences =
-    Object.keys(immutableReferences).length > 0
-      ? immutableReferences
-      : inferLegacyVyperImmutableReferences(
-          populatedRecompiledBytecodeWith0x,
-          onchainRuntimeBytecodeWith0x,
-          auxdataStyle,
-          legacyImmutableReferences,
-          compilerVersion,
-        );
+  const effectiveImmutableReferences = getValidatedVyperImmutableReferences(
+    populatedRecompiledBytecodeWith0x,
+    onchainRuntimeBytecodeWith0x,
+    auxdataStyle,
+    immutableReferences,
+  );
 
   const immutableReferenceEntries: Array<{
     astId: string;

--- a/packages/lib-sourcify/src/Verification/Transformations.ts
+++ b/packages/lib-sourcify/src/Verification/Transformations.ts
@@ -13,7 +13,6 @@ import { logError } from '../logger';
 import semver from 'semver';
 
 const abiCoder = AbiCoder.defaultAbiCoder();
-const LEGACY_VYPER_IMMUTABLE_BYTE_LENGTH = 32;
 
 export type Transformation = {
   type: 'insert' | 'replace' | 'delete';
@@ -140,11 +139,11 @@ export function inferLegacyVyperImmutableReferences(
   populatedRecompiledBytecodeWith0x: string,
   onchainRuntimeBytecodeWith0x: string,
   auxdataStyle: AuxdataStyle,
+  legacyImmutableReferences: ImmutableReferences,
   compilerVersion?: string,
-  hasImmutableVariables = false,
 ): ImmutableReferences {
   if (
-    !hasImmutableVariables ||
+    Object.keys(legacyImmutableReferences).length === 0 ||
     compilerVersion === undefined ||
     !isLegacyVyperImmutableAuxdataStyle(auxdataStyle) ||
     !semver.gte(compilerVersion, '0.3.1') ||
@@ -156,9 +155,10 @@ export function inferLegacyVyperImmutableReferences(
   const populatedRecompiledBytecode =
     populatedRecompiledBytecodeWith0x.slice(2);
   const onchainRuntimeBytecode = onchainRuntimeBytecodeWith0x.slice(2);
+  const runtimeByteLength = populatedRecompiledBytecode.length / 2;
 
   // Legacy Vyper metadata does not encode immutable size. Keep this fallback
-  // limited to prefix-identical runtimes with the observed single-word tail.
+  // limited to prefix-identical runtimes with the AST-derived immutable layout.
   if (
     onchainRuntimeBytecode.length <= populatedRecompiledBytecode.length ||
     !onchainRuntimeBytecode.startsWith(populatedRecompiledBytecode)
@@ -168,18 +168,37 @@ export function inferLegacyVyperImmutableReferences(
 
   const immutableLength =
     (onchainRuntimeBytecode.length - populatedRecompiledBytecode.length) / 2;
-  if (immutableLength !== LEGACY_VYPER_IMMUTABLE_BYTE_LENGTH) {
+  const expectedImmutableLength = getImmutableReferencesByteLength(
+    legacyImmutableReferences,
+    runtimeByteLength,
+  );
+  if (
+    expectedImmutableLength === undefined ||
+    immutableLength !== expectedImmutableLength
+  ) {
     return {};
   }
 
-  return {
-    '0': [
-      {
-        length: immutableLength,
-        start: populatedRecompiledBytecode.length / 2,
-      },
-    ],
-  };
+  return legacyImmutableReferences;
+}
+
+function getImmutableReferencesByteLength(
+  immutableReferences: ImmutableReferences,
+  runtimeByteLength: number,
+): number | undefined {
+  const references = Object.values(immutableReferences)
+    .flat()
+    .sort((a, b) => a.start - b.start);
+
+  let nextStart = runtimeByteLength;
+  for (const reference of references) {
+    if (reference.length <= 0 || reference.start !== nextStart) {
+      return undefined;
+    }
+    nextStart += reference.length;
+  }
+
+  return nextStart - runtimeByteLength;
 }
 
 // returns the full bytecode with the call protection replaced with the real address
@@ -225,8 +244,8 @@ export function extractImmutablesTransformation(
   onchainRuntimeBytecodeWith0x: string,
   immutableReferences: ImmutableReferences,
   auxdataStyle: AuxdataStyle,
+  legacyImmutableReferences: ImmutableReferences = {},
   compilerVersion?: string,
-  hasImmutableVariables = false,
 ) {
   const transformations: Transformation[] = [];
   const transformationValues: TransformationValues = {};
@@ -240,47 +259,50 @@ export function extractImmutablesTransformation(
           populatedRecompiledBytecodeWith0x,
           onchainRuntimeBytecodeWith0x,
           auxdataStyle,
+          legacyImmutableReferences,
           compilerVersion,
-          hasImmutableVariables,
         );
 
-  Object.keys(effectiveImmutableReferences).forEach((astId) => {
-    effectiveImmutableReferences[astId].forEach((reference) => {
-      const { start, length } = reference;
+  const immutableReferenceEntries = Object.entries(effectiveImmutableReferences)
+    .flatMap(([astId, references]) =>
+      references.map((reference) => ({ astId, reference })),
+    )
+    .sort((a, b) => a.reference.start - b.reference.start);
 
-      // Save the transformation
-      transformations.push(
-        ImmutablesTransformation(
-          start,
-          astId,
-          auxdataStyle === AuxdataStyle.SOLIDITY ? 'replace' : 'insert',
-        ),
-      );
+  immutableReferenceEntries.forEach(({ astId, reference }) => {
+    const { start, length } = reference;
 
-      // Extract the immutable value from the onchain bytecode.
-      const immutableValue = onchainRuntimeBytecode.slice(
-        start * 2,
-        start * 2 + length * 2,
-      );
+    // Save the transformation
+    transformations.push(
+      ImmutablesTransformation(
+        start,
+        astId,
+        auxdataStyle === AuxdataStyle.SOLIDITY ? 'replace' : 'insert',
+      ),
+    );
 
-      // Save the transformation value
-      if (transformationValues.immutables === undefined) {
-        transformationValues.immutables = {};
-      }
-      transformationValues.immutables[astId] = `0x${immutableValue}`;
+    // Extract the immutable value from the onchain bytecode.
+    const immutableValue = onchainRuntimeBytecode.slice(
+      start * 2,
+      start * 2 + length * 2,
+    );
 
-      if (auxdataStyle === AuxdataStyle.SOLIDITY) {
-        // Replace the placeholder in the recompiled bytecode with the onchain immutable value.
-        populatedRecompiledBytecode =
-          populatedRecompiledBytecode.slice(0, start * 2) +
-          immutableValue +
-          populatedRecompiledBytecode.slice(start * 2 + length * 2);
-      } else if (isVyperImmutableAuxdataStyle(auxdataStyle)) {
-        // For Vyper, insert the immutable value.
-        populatedRecompiledBytecode =
-          populatedRecompiledBytecode + immutableValue;
-      }
-    });
+    // Save the transformation value
+    if (transformationValues.immutables === undefined) {
+      transformationValues.immutables = {};
+    }
+    transformationValues.immutables[astId] = `0x${immutableValue}`;
+
+    if (auxdataStyle === AuxdataStyle.SOLIDITY) {
+      // Replace the placeholder in the recompiled bytecode with the onchain immutable value.
+      populatedRecompiledBytecode =
+        populatedRecompiledBytecode.slice(0, start * 2) +
+        immutableValue +
+        populatedRecompiledBytecode.slice(start * 2 + length * 2);
+    } else if (isVyperImmutableAuxdataStyle(auxdataStyle)) {
+      // For Vyper, insert the immutable value.
+      populatedRecompiledBytecode = populatedRecompiledBytecode + immutableValue;
+    }
   });
   return {
     populatedRecompiledBytecode: '0x' + populatedRecompiledBytecode,

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -34,6 +34,7 @@ import type {
 import { SolidityBugType, VerificationError } from './VerificationTypes';
 import type {
   VyperJsonInput,
+  VyperOutput,
   VyperOutputContract,
   ImmutableReferences,
   SolidityOutputContract,
@@ -42,6 +43,7 @@ import type {
   Metadata,
 } from '@ethereum-sourcify/compilers-types';
 import { SolidityMetadataContract } from '../Validation/SolidityMetadataContract';
+import { compilerOutputContainsImmutableVariables } from '../Compilation/VyperCompilation';
 import type { VyperCompilation } from '../Compilation/VyperCompilation';
 
 function auxdataLacksMetadataOrIntegrityHash(
@@ -523,6 +525,15 @@ export class Verification {
       this.onchainRuntimeBytecode,
       this.compilation.immutableReferences,
       this.compilation.auxdataStyle,
+      this.compilation.language === 'Vyper'
+        ? ((this.compilation as VyperCompilation)
+            .compilerVersionCompatibleWithSemver ??
+            this.compilation.compilerVersion)
+        : this.compilation.compilerVersion,
+      this.compilation.language === 'Vyper' &&
+        compilerOutputContainsImmutableVariables(
+          this.compilation.compilerOutput as VyperOutput | undefined,
+        ),
     );
 
     const matchBytecodesResult = await this.matchBytecodes(

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -43,7 +43,7 @@ import type {
   Metadata,
 } from '@ethereum-sourcify/compilers-types';
 import { SolidityMetadataContract } from '../Validation/SolidityMetadataContract';
-import { compilerOutputContainsImmutableVariables } from '../Compilation/VyperCompilation';
+import { returnLegacyVyperImmutableReferences } from '../Compilation/VyperCompilation';
 import type { VyperCompilation } from '../Compilation/VyperCompilation';
 
 function auxdataLacksMetadataOrIntegrityHash(
@@ -519,22 +519,27 @@ export class Verification {
         this.onchainRuntimeBytecode,
       );
 
+    const legacyVyperImmutableReferences =
+      this.compilation.language === 'Vyper'
+        ? returnLegacyVyperImmutableReferences(
+            this.compilation.compilerOutput as VyperOutput | undefined,
+            this.compilation.compilationTarget.path,
+            callProtectionTransformationResult.populatedRecompiledBytecode,
+          )
+        : {};
+
     // Handle immutable references
     const immutablesTransformationResult = extractImmutablesTransformation(
       callProtectionTransformationResult.populatedRecompiledBytecode,
       this.onchainRuntimeBytecode,
       this.compilation.immutableReferences,
       this.compilation.auxdataStyle,
+      legacyVyperImmutableReferences,
       this.compilation.language === 'Vyper'
         ? ((this.compilation as VyperCompilation)
             .compilerVersionCompatibleWithSemver ??
             this.compilation.compilerVersion)
         : this.compilation.compilerVersion,
-      this.compilation.language === 'Vyper' &&
-        compilerOutputContainsImmutableVariables(
-          this.compilation.compilerOutput as VyperOutput | undefined,
-          this.compilation.compilationTarget.path,
-        ),
     );
 
     const matchBytecodesResult = await this.matchBytecodes(

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -523,7 +523,7 @@ export class Verification {
       this.compilation.language === 'Vyper'
         ? returnLegacyVyperImmutableReferences(
             this.compilation.compilerOutput as VyperOutput | undefined,
-            this.compilation.compilationTarget.path,
+            this.compilation.compilationTarget,
             callProtectionTransformationResult.populatedRecompiledBytecode,
           )
         : {};

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -533,6 +533,7 @@ export class Verification {
       this.compilation.language === 'Vyper' &&
         compilerOutputContainsImmutableVariables(
           this.compilation.compilerOutput as VyperOutput | undefined,
+          this.compilation.compilationTarget.path,
         ),
     );
 

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -34,7 +34,6 @@ import type {
 import { SolidityBugType, VerificationError } from './VerificationTypes';
 import type {
   VyperJsonInput,
-  VyperOutput,
   VyperOutputContract,
   ImmutableReferences,
   SolidityOutputContract,
@@ -43,7 +42,6 @@ import type {
   Metadata,
 } from '@ethereum-sourcify/compilers-types';
 import { SolidityMetadataContract } from '../Validation/SolidityMetadataContract';
-import { returnLegacyVyperImmutableReferences } from '../Compilation/VyperCompilation';
 import type { VyperCompilation } from '../Compilation/VyperCompilation';
 
 function auxdataLacksMetadataOrIntegrityHash(
@@ -519,27 +517,12 @@ export class Verification {
         this.onchainRuntimeBytecode,
       );
 
-    const legacyVyperImmutableReferences =
-      this.compilation.language === 'Vyper'
-        ? returnLegacyVyperImmutableReferences(
-            this.compilation.compilerOutput as VyperOutput | undefined,
-            this.compilation.compilationTarget,
-            callProtectionTransformationResult.populatedRecompiledBytecode,
-          )
-        : {};
-
     // Handle immutable references
     const immutablesTransformationResult = extractImmutablesTransformation(
       callProtectionTransformationResult.populatedRecompiledBytecode,
       this.onchainRuntimeBytecode,
       this.compilation.immutableReferences,
       this.compilation.auxdataStyle,
-      legacyVyperImmutableReferences,
-      this.compilation.language === 'Vyper'
-        ? ((this.compilation as VyperCompilation)
-            .compilerVersionCompatibleWithSemver ??
-            this.compilation.compilerVersion)
-        : this.compilation.compilerVersion,
     );
 
     const matchBytecodesResult = await this.matchBytecodes(

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -4,7 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import fs from 'fs';
 import {
-  compilerOutputContainsImmutableVariables,
+  returnLegacyVyperImmutableReferences,
   VyperCompilation,
 } from '../../src/Compilation/VyperCompilation';
 import { vyperCompiler } from '../utils';
@@ -770,46 +770,109 @@ describe('VyperCompilation outputSelection version gating', () => {
   });
 });
 
-describe('compilerOutputContainsImmutableVariables', () => {
-  it('detects Vyper immutable declarations from compiler AST output', () => {
+describe('returnLegacyVyperImmutableReferences', () => {
+  it('derives references from unwrapped Vyper 0.3.7 immutable annotations', () => {
     const compilerOutput = {
       sources: {
         'test.vy': {
           id: 0,
-          ast: {
-            ast_type: 'Module',
-            body: [
-              {
-                ast_type: 'VariableDecl',
-                is_immutable: true,
-              },
-            ],
-          },
+          ast: moduleAst([
+            variableDecl('A', subscript(name('uint256'), 3)),
+            variableDecl('B', subscript(name('String'), 10)),
+          ]),
         },
       },
     };
 
     expect(
-      compilerOutputContainsImmutableVariables(compilerOutput as any, 'test.vy'),
-    ).to.equal(true);
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        'test.vy',
+        '0x6000',
+      ),
+    ).to.deep.equal({
+      A: [{ length: 96, start: 2 }],
+      B: [{ length: 64, start: 98 }],
+    });
   });
 
-  it('returns false when compiler AST output has no immutable declarations', () => {
+  it('derives references from wrapped Vyper 0.3.4-0.3.6 immutable annotations', () => {
     const compilerOutput = {
       sources: {
         'test.vy': {
           id: 0,
-          ast: {
-            ast_type: 'Module',
-            body: [{ ast_type: 'FunctionDef' }],
-          },
+          ast: moduleAst([
+            variableDecl('A', immutableCall(subscript(name('uint256'), 3))),
+            variableDecl('B', immutableCall(subscript(name('String'), 10))),
+          ]),
         },
       },
     };
 
     expect(
-      compilerOutputContainsImmutableVariables(compilerOutput as any, 'test.vy'),
-    ).to.equal(false);
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        'test.vy',
+        '0x6000',
+      ),
+    ).to.deep.equal({
+      A: [{ length: 96, start: 2 }],
+      B: [{ length: 64, start: 98 }],
+    });
+  });
+
+  it('derives references from old Vyper 0.3.1-0.3.3 AnnAssign immutables', () => {
+    const compilerOutput = {
+      sources: {
+        'test.vy': {
+          id: 0,
+          ast: moduleAst([
+            annAssign('A', immutableCall(subscript(name('uint256'), 3))),
+            annAssign('B', immutableCall(subscript(name('String'), 10))),
+          ]),
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        'test.vy',
+        '0x6000',
+      ),
+    ).to.deep.equal({
+      A: [{ length: 96, start: 2 }],
+      B: [{ length: 64, start: 98 }],
+    });
+  });
+
+  it('derives references for structs and dynamic arrays', () => {
+    const compilerOutput = {
+      sources: {
+        'test.vy': {
+          id: 0,
+          ast: moduleAst([
+            structDef('MyStruct', [
+              ['a', name('uint256')],
+              ['b', name('address')],
+            ]),
+            variableDecl('C', name('MyStruct')),
+            variableDecl('D', dynArray(name('uint256'), 3)),
+          ]),
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        'test.vy',
+        '0x60',
+      ),
+    ).to.deep.equal({
+      C: [{ length: 64, start: 1 }],
+      D: [{ length: 128, start: 65 }],
+    });
   });
 
   it('only checks the compilation target source for immutable declarations', () => {
@@ -824,30 +887,98 @@ describe('compilerOutputContainsImmutableVariables', () => {
         },
         'unused.vy': {
           id: 1,
-          ast: {
-            ast_type: 'Module',
-            body: [
-              {
-                ast_type: 'VariableDecl',
-                is_immutable: true,
-              },
-            ],
-          },
+          ast: moduleAst([variableDecl('A', name('uint256'))]),
         },
       },
     };
 
     expect(
-      compilerOutputContainsImmutableVariables(
+      returnLegacyVyperImmutableReferences(
         compilerOutput as any,
         'target.vy',
+        '0x6000',
       ),
-    ).to.equal(false);
+    ).to.deep.equal({});
     expect(
-      compilerOutputContainsImmutableVariables(
+      returnLegacyVyperImmutableReferences(
         compilerOutput as any,
         'unused.vy',
+        '0x6000',
       ),
-    ).to.equal(true);
+    ).to.deep.equal({
+      A: [{ length: 32, start: 2 }],
+    });
   });
 });
+
+function moduleAst(body: any[]) {
+  return { ast_type: 'Module', body };
+}
+
+function name(id: string) {
+  return { ast_type: 'Name', id };
+}
+
+function int(value: number) {
+  return { ast_type: 'Int', value };
+}
+
+function subscript(value: any, length: number) {
+  return {
+    ast_type: 'Subscript',
+    value,
+    slice: {
+      ast_type: 'Index',
+      value: int(length),
+    },
+  };
+}
+
+function dynArray(subtype: any, maxLength: number) {
+  return {
+    ast_type: 'Subscript',
+    value: name('DynArray'),
+    slice: {
+      ast_type: 'Index',
+      value: {
+        ast_type: 'Tuple',
+        elements: [subtype, int(maxLength)],
+      },
+    },
+  };
+}
+
+function immutableCall(annotation: any) {
+  return {
+    ast_type: 'Call',
+    func: name('immutable'),
+    args: [annotation],
+  };
+}
+
+function variableDecl(variableName: string, annotation: any) {
+  return {
+    ast_type: 'VariableDecl',
+    is_immutable: true,
+    target: name(variableName),
+    annotation,
+  };
+}
+
+function annAssign(variableName: string, annotation: any) {
+  return {
+    ast_type: 'AnnAssign',
+    target: name(variableName),
+    annotation,
+  };
+}
+
+function structDef(structName: string, members: Array<[string, any]>) {
+  return {
+    ast_type: 'StructDef',
+    name: structName,
+    body: members.map(([memberName, annotation]) =>
+      annAssign(memberName, annotation),
+    ),
+  };
+}

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -825,6 +825,79 @@ describe('returnLegacyVyperImmutableReferences', () => {
     });
   });
 
+  it('derives a synthetic tail reference from real Vyper 0.3.7 mixed public and non-public immutable ASTs', async () => {
+    const contractFileName = 'test.vy';
+    const contractContent = `# @version 0.3.7
+
+TARGET: public(immutable(address))
+SALT: immutable(bytes32)
+
+
+@external
+def __init__(_target: address, _salt: bytes32):
+    TARGET = _target
+    SALT = _salt
+
+
+@external
+@view
+def salt() -> bytes32:
+    return SALT
+`;
+    const compilation = new VyperCompilation(
+      vyperCompiler,
+      '0.3.7+commit.6020b8bb',
+      {
+        language: 'Vyper',
+        sources: {
+          [contractFileName]: {
+            content: contractContent,
+          },
+        },
+        settings: {
+          evmVersion: 'istanbul',
+          outputSelection: {
+            '*': ['evm.bytecode'],
+          },
+        },
+      },
+      {
+        name: contractFileName.split('.')[0],
+        path: contractFileName,
+      },
+    );
+
+    await compilation.compile();
+
+    const ast = compilation.compilerOutput?.sources?.[contractFileName]?.ast;
+    const declarations = ast?.body.filter(
+      (node: any) => node.ast_type === 'VariableDecl',
+    );
+    const targetDecl = declarations?.find(
+      (node: any) => node.target?.id === 'TARGET',
+    );
+    const saltDecl = declarations?.find(
+      (node: any) => node.target?.id === 'SALT',
+    );
+    expect(targetDecl?.target?.id).to.equal('TARGET');
+    expect(targetDecl?.is_public).to.equal(true);
+    expect(targetDecl?.is_immutable).to.equal(true);
+    expect(targetDecl?.annotation?.id).to.equal('address');
+    expect(saltDecl?.target?.id).to.equal('SALT');
+    expect(saltDecl?.is_public).to.equal(false);
+    expect(saltDecl?.is_immutable).to.equal(true);
+    expect(saltDecl?.annotation?.id).to.equal('bytes32');
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilation.compilerOutput,
+        contractFileName,
+        compilation.runtimeBytecode,
+      ),
+    ).to.deep.equal({
+      '0': [{ length: 64, start: compilation.runtimeBytecode.length / 2 - 1 }],
+    });
+  });
+
   it('derives a synthetic tail reference from unwrapped Vyper 0.3.7 immutable annotations', () => {
     const compilerOutput = {
       sources: {

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -829,14 +829,26 @@ describe('returnLegacyVyperImmutableReferences', () => {
     const contractFileName = 'test.vy';
     const contractContent = `# @version 0.3.7
 
+N_COINS: constant(int128) = 2
+N_STABLECOINS: constant(int128) = 3
+N_UL_COINS: constant(int128) = N_COINS + N_STABLECOINS - 1
 TARGET: public(immutable(address))
 SALT: immutable(bytes32)
+COINS: immutable(address[N_COINS])
+UNDERLYING_COINS: immutable(address[N_UL_COINS])
 
 
 @external
-def __init__(_target: address, _salt: bytes32):
+def __init__(
+    _target: address,
+    _salt: bytes32,
+    _coins: address[N_COINS],
+    _underlying_coins: address[N_UL_COINS]
+):
     TARGET = _target
     SALT = _salt
+    COINS = _coins
+    UNDERLYING_COINS = _underlying_coins
 
 
 @external
@@ -879,6 +891,12 @@ def salt() -> bytes32:
     const saltDecl = declarations?.find(
       (node: any) => node.target?.id === 'SALT',
     );
+    const coinsDecl = declarations?.find(
+      (node: any) => node.target?.id === 'COINS',
+    );
+    const underlyingCoinsDecl = declarations?.find(
+      (node: any) => node.target?.id === 'UNDERLYING_COINS',
+    );
     expect(targetDecl?.target?.id).to.equal('TARGET');
     expect(targetDecl?.is_public).to.equal(true);
     expect(targetDecl?.is_immutable).to.equal(true);
@@ -887,6 +905,12 @@ def salt() -> bytes32:
     expect(saltDecl?.is_public).to.equal(false);
     expect(saltDecl?.is_immutable).to.equal(true);
     expect(saltDecl?.annotation?.id).to.equal('bytes32');
+    expect(coinsDecl?.is_immutable).to.equal(true);
+    expect(coinsDecl?.annotation?.slice?.value?.id).to.equal('N_COINS');
+    expect(underlyingCoinsDecl?.is_immutable).to.equal(true);
+    expect(underlyingCoinsDecl?.annotation?.slice?.value?.id).to.equal(
+      'N_UL_COINS',
+    );
     expect(
       returnLegacyVyperImmutableReferences(
         compilation.compilerOutput,
@@ -894,7 +918,7 @@ def salt() -> bytes32:
         compilation.runtimeBytecode,
       ),
     ).to.deep.equal({
-      '0': [{ length: 64, start: compilation.runtimeBytecode.length / 2 - 1 }],
+      '0': [{ length: 256, start: compilation.runtimeBytecode.length / 2 - 1 }],
     });
   });
 
@@ -967,6 +991,51 @@ def salt() -> bytes32:
       ),
     ).to.deep.equal({
       '0': [{ length: 160, start: 2 }],
+    });
+  });
+
+  it('resolves legacy Vyper integer constants in immutable array bounds', () => {
+    const compilerOutput = {
+      sources: {
+        'test.vy': {
+          id: 0,
+          ast: moduleAst([
+            annAssign('N_COINS', constantCall(name('int128')), int(2)),
+            annAssign('N_STABLECOINS', constantCall(name('int128')), int(3)),
+            annAssign(
+              'N_UL_COINS',
+              constantCall(name('int128')),
+              binOp(
+                binOp(name('N_COINS'), 'Add', name('N_STABLECOINS')),
+                'Sub',
+                int(1),
+              ),
+            ),
+            annAssign(
+              'COINS',
+              immutableCall(
+                subscriptWithLength(name('address'), name('N_COINS')),
+              ),
+            ),
+            annAssign(
+              'UNDERLYING_COINS',
+              immutableCall(
+                subscriptWithLength(name('address'), name('N_UL_COINS')),
+              ),
+            ),
+          ]),
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        'test.vy',
+        '0x6000',
+      ),
+    ).to.deep.equal({
+      '0': [{ length: 192, start: 2 }],
     });
   });
 
@@ -1047,12 +1116,16 @@ function int(value: number) {
 }
 
 function subscript(value: any, length: number) {
+  return subscriptWithLength(value, int(length));
+}
+
+function subscriptWithLength(value: any, length: any) {
   return {
     ast_type: 'Subscript',
     value,
     slice: {
       ast_type: 'Index',
-      value: int(length),
+      value: length,
     },
   };
 }
@@ -1079,6 +1152,25 @@ function immutableCall(annotation: any) {
   };
 }
 
+function constantCall(annotation: any) {
+  return {
+    ast_type: 'Call',
+    func: name('constant'),
+    args: [annotation],
+  };
+}
+
+function binOp(left: any, op: string, right: any) {
+  return {
+    ast_type: 'BinOp',
+    left,
+    op: {
+      ast_type: op,
+    },
+    right,
+  };
+}
+
 function variableDecl(variableName: string, annotation: any) {
   return {
     ast_type: 'VariableDecl',
@@ -1088,12 +1180,16 @@ function variableDecl(variableName: string, annotation: any) {
   };
 }
 
-function annAssign(variableName: string, annotation: any) {
-  return {
+function annAssign(variableName: string, annotation: any, value?: any) {
+  const node: any = {
     ast_type: 'AnnAssign',
     target: name(variableName),
     annotation,
   };
+  if (value !== undefined) {
+    node.value = value;
+  }
+  return node;
 }
 
 function structDef(structName: string, members: Array<[string, any]>) {

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -790,7 +790,7 @@ describe('compilerOutputContainsImmutableVariables', () => {
     };
 
     expect(
-      compilerOutputContainsImmutableVariables(compilerOutput as any),
+      compilerOutputContainsImmutableVariables(compilerOutput as any, 'test.vy'),
     ).to.equal(true);
   });
 
@@ -808,7 +808,46 @@ describe('compilerOutputContainsImmutableVariables', () => {
     };
 
     expect(
-      compilerOutputContainsImmutableVariables(compilerOutput as any),
+      compilerOutputContainsImmutableVariables(compilerOutput as any, 'test.vy'),
     ).to.equal(false);
+  });
+
+  it('only checks the compilation target source for immutable declarations', () => {
+    const compilerOutput = {
+      sources: {
+        'target.vy': {
+          id: 0,
+          ast: {
+            ast_type: 'Module',
+            body: [{ ast_type: 'FunctionDef' }],
+          },
+        },
+        'unused.vy': {
+          id: 1,
+          ast: {
+            ast_type: 'Module',
+            body: [
+              {
+                ast_type: 'VariableDecl',
+                is_immutable: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(
+      compilerOutputContainsImmutableVariables(
+        compilerOutput as any,
+        'target.vy',
+      ),
+    ).to.equal(false);
+    expect(
+      compilerOutputContainsImmutableVariables(
+        compilerOutput as any,
+        'unused.vy',
+      ),
+    ).to.equal(true);
   });
 });

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -8,6 +8,7 @@ import {
   returnImmutableReferences,
   VyperCompilation,
 } from '../../src/Compilation/VyperCompilation';
+import { PreRunCompilation } from '../../src/Compilation/PreRunCompilation';
 import { returnLegacyVyperImmutableReferences } from '../../src/Compilation/legacyVyperImmutablesHelpers';
 import { vyperCompiler } from '../utils';
 
@@ -773,6 +774,88 @@ describe('VyperCompilation outputSelection version gating', () => {
 });
 
 describe('returnLegacyVyperImmutableReferences', () => {
+  async function compileLegacyImmutable(
+    compilerVersion: string,
+    sourceVersion: string,
+  ): Promise<VyperCompilation> {
+    const contractFileName = 'test.vy';
+    const contractContent = `# @version ${sourceVersion}
+
+TARGET: immutable(address)
+
+
+@external
+def __init__(_target: address):
+    TARGET = _target
+
+
+@external
+@view
+def target() -> address:
+    return TARGET
+`;
+    const compilation = new VyperCompilation(
+      vyperCompiler,
+      compilerVersion,
+      {
+        language: 'Vyper',
+        sources: {
+          [contractFileName]: {
+            content: contractContent,
+          },
+        },
+        settings: {
+          evmVersion: 'istanbul',
+          outputSelection: {
+            '*': ['evm.bytecode'],
+          },
+        },
+      },
+      {
+        name: contractFileName.split('.')[0],
+        path: contractFileName,
+      },
+    );
+
+    await compilation.compile();
+    return compilation;
+  }
+
+  function expectSingleTailReference(
+    compilation: VyperCompilation,
+    length: number,
+  ) {
+    expect(compilation.immutableReferences).to.deep.equal({
+      '0': [
+        {
+          length,
+          start: compilation.runtimeBytecode.length / 2 - 1,
+        },
+      ],
+    });
+  }
+
+  it('derives a synthetic tail reference from real Vyper 0.3.1 text IR', async () => {
+    const compilation = await compileLegacyImmutable('0.3.1', '0.3.1');
+
+    expectSingleTailReference(compilation, 32);
+    expect(typeof (compilation.contractCompilerOutput as any).ir).to.equal(
+      'string',
+    );
+  });
+
+  it('derives a synthetic tail reference from real Vyper 0.3.2 structured IR', async () => {
+    const compilation = await compileLegacyImmutable(
+      '0.3.2+commit.3b6a4117',
+      '0.3.2',
+    );
+
+    expectSingleTailReference(compilation, 32);
+    expect(typeof (compilation.contractCompilerOutput as any).ir).to.equal(
+      'object',
+    );
+  });
+
   it('derives a synthetic tail reference from real Vyper 0.3.7 structured IR', async () => {
     const contractPath = path.join(
       __dirname,
@@ -976,6 +1059,31 @@ def salt() -> bytes32:
     ).to.deep.equal({});
   });
 
+  it('ignores ambiguous structured IR immutable lengths', () => {
+    const compilerOutput = {
+      contracts: {
+        'test.vy': {
+          test: {
+            ir: {
+              seq: [
+                { deploy: [256, { runtime: [] }, 32] },
+                { deploy: [320, { runtime: [] }, 64] },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        { name: 'test', path: 'test.vy' },
+        '0x6000',
+      ),
+    ).to.deep.equal({});
+  });
+
   it('ignores zero structured IR immutable length', () => {
     const compilerOutput = {
       contracts: {
@@ -1030,5 +1138,72 @@ def salt() -> bytes32:
     ).to.deep.equal({
       '0': [{ length: 32, start: 2 }],
     });
+  });
+
+  it('uses stored Vyper immutable references for pre-run compiler outputs without IR', () => {
+    const immutableReferences = {
+      '0': [{ length: 32, start: 3 }],
+    };
+    const preRunCompilation = new PreRunCompilation(
+      vyperCompiler,
+      '0.3.7+commit.6020b8bb',
+      {
+        language: 'Vyper',
+        sources: {
+          'test.vy': {
+            content: '',
+          },
+        },
+        settings: {
+          outputSelection: {
+            '*': [],
+          },
+        },
+      },
+      {
+        compiler: '0.3.7+commit.6020b8bb',
+        contracts: {
+          'test.vy': {
+            test: {
+              abi: [],
+              userdoc: {
+                kind: 'user',
+                methods: {},
+              },
+              devdoc: {
+                kind: 'dev',
+                methods: {},
+              },
+              evm: {
+                bytecode: {
+                  object: '600102',
+                  opcodes: '',
+                },
+                deployedBytecode: {
+                  object: '600102',
+                  opcodes: '',
+                  sourceMap: '',
+                  immutableReferences,
+                },
+                methodIdentifiers: {},
+              },
+            },
+          },
+        },
+        sources: {
+          'test.vy': {
+            id: 0,
+            ast: {},
+          },
+        },
+      } as any,
+      { name: 'test', path: 'test.vy' },
+      {},
+      {},
+    );
+
+    expect(preRunCompilation.immutableReferences).to.deep.equal(
+      immutableReferences,
+    );
   });
 });

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -3,7 +3,10 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import fs from 'fs';
-import { VyperCompilation } from '../../src/Compilation/VyperCompilation';
+import {
+  compilerOutputContainsImmutableVariables,
+  VyperCompilation,
+} from '../../src/Compilation/VyperCompilation';
 import { vyperCompiler } from '../utils';
 
 chai.use(chaiAsPromised);
@@ -764,5 +767,48 @@ describe('VyperCompilation outputSelection version gating', () => {
     expect(outputs).to.include('devdoc');
     expect(outputs).to.include('layout');
     expect(outputs).to.include('evm.bytecode.sourceMap');
+  });
+});
+
+describe('compilerOutputContainsImmutableVariables', () => {
+  it('detects Vyper immutable declarations from compiler AST output', () => {
+    const compilerOutput = {
+      sources: {
+        'test.vy': {
+          id: 0,
+          ast: {
+            ast_type: 'Module',
+            body: [
+              {
+                ast_type: 'VariableDecl',
+                is_immutable: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(
+      compilerOutputContainsImmutableVariables(compilerOutput as any),
+    ).to.equal(true);
+  });
+
+  it('returns false when compiler AST output has no immutable declarations', () => {
+    const compilerOutput = {
+      sources: {
+        'test.vy': {
+          id: 0,
+          ast: {
+            ast_type: 'Module',
+            body: [{ ast_type: 'FunctionDef' }],
+          },
+        },
+      },
+    };
+
+    expect(
+      compilerOutputContainsImmutableVariables(compilerOutput as any),
+    ).to.equal(false);
   });
 });

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -3,7 +3,9 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import fs from 'fs';
+import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 import {
+  returnImmutableReferences,
   returnLegacyVyperImmutableReferences,
   VyperCompilation,
 } from '../../src/Compilation/VyperCompilation';
@@ -809,13 +811,7 @@ describe('returnLegacyVyperImmutableReferences', () => {
 
     await compilation.compile();
 
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilation.compilerOutput,
-        compilation.compilationTarget,
-        compilation.runtimeBytecode,
-      ),
-    ).to.deep.equal({
+    expect(compilation.immutableReferences).to.deep.equal({
       '0': [{ length: 32, start: 88 }],
     });
   });
@@ -876,13 +872,7 @@ def salt() -> bytes32:
 
     await compilation.compile();
 
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilation.compilerOutput,
-        compilation.compilationTarget,
-        compilation.runtimeBytecode,
-      ),
-    ).to.deep.equal({
+    expect(compilation.immutableReferences).to.deep.equal({
       '0': [{ length: 256, start: compilation.runtimeBytecode.length / 2 - 1 }],
     });
   });
@@ -905,14 +895,40 @@ def salt() -> bytes32:
     };
 
     expect(
-      returnLegacyVyperImmutableReferences(
+      returnImmutableReferences(
+        '0.3.1',
+        '0x',
+        '0x600102',
+        AuxdataStyle.VYPER_LT_0_3_4,
         compilerOutput as any,
         { name: 'test', path: 'test.vy' },
-        '0x600102',
       ),
     ).to.deep.equal({
       '0': [{ length: 64, start: 3 }],
     });
+  });
+
+  it('does not derive a legacy immutable reference before Vyper 0.3.1', () => {
+    const compilerOutput = {
+      contracts: {
+        'test.vy': {
+          test: {
+            ir: '[return, 320, [add, 64, _lllsz]]',
+          },
+        },
+      },
+    };
+
+    expect(
+      returnImmutableReferences(
+        '0.3.0',
+        '0x',
+        '0x600102',
+        AuxdataStyle.VYPER_LT_0_3_4,
+        compilerOutput as any,
+        { name: 'test', path: 'test.vy' },
+      ),
+    ).to.deep.equal({});
   });
 
   it('ignores ambiguous Vyper 0.3.1 text IR immutable lengths', () => {
@@ -945,6 +961,28 @@ def salt() -> bytes32:
           test: {
             ir: {
               deploy: [256, { runtime: [] }, 31],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        { name: 'test', path: 'test.vy' },
+        '0x6000',
+      ),
+    ).to.deep.equal({});
+  });
+
+  it('ignores zero structured IR immutable length', () => {
+    const compilerOutput = {
+      contracts: {
+        'test.vy': {
+          test: {
+            ir: {
+              deploy: [256, { runtime: [] }, 0],
             },
           },
         },

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -771,7 +771,61 @@ describe('VyperCompilation outputSelection version gating', () => {
 });
 
 describe('returnLegacyVyperImmutableReferences', () => {
-  it('derives references from unwrapped Vyper 0.3.7 immutable annotations', () => {
+  it('derives a synthetic tail reference from the real Vyper 0.3.7 AST', async () => {
+    const contractPath = path.join(
+      __dirname,
+      '..',
+      'sources',
+      'Vyper',
+      'legacyImmutables_0_3_7',
+    );
+    const contractFileName = 'test.vy';
+    const contractContent = fs.readFileSync(
+      path.join(contractPath, contractFileName),
+      'utf8',
+    );
+    const compilation = new VyperCompilation(
+      vyperCompiler,
+      '0.3.7+commit.6020b8bb',
+      {
+        language: 'Vyper',
+        sources: {
+          [contractFileName]: {
+            content: contractContent,
+          },
+        },
+        settings: {
+          evmVersion: 'istanbul',
+          outputSelection: {
+            '*': ['evm.bytecode'],
+          },
+        },
+      },
+      {
+        name: contractFileName.split('.')[0],
+        path: contractFileName,
+      },
+    );
+
+    await compilation.compile();
+
+    const ast = compilation.compilerOutput?.sources?.[contractFileName]?.ast;
+    const targetDecl = ast?.body.find(
+      (node: any) => node.ast_type === 'VariableDecl',
+    );
+    expect(targetDecl?.target?.id).to.equal('TARGET');
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilation.compilerOutput,
+        contractFileName,
+        compilation.runtimeBytecode,
+      ),
+    ).to.deep.equal({
+      '0': [{ length: 32, start: 88 }],
+    });
+  });
+
+  it('derives a synthetic tail reference from unwrapped Vyper 0.3.7 immutable annotations', () => {
     const compilerOutput = {
       sources: {
         'test.vy': {
@@ -791,12 +845,11 @@ describe('returnLegacyVyperImmutableReferences', () => {
         '0x6000',
       ),
     ).to.deep.equal({
-      A: [{ length: 96, start: 2 }],
-      B: [{ length: 64, start: 98 }],
+      '0': [{ length: 160, start: 2 }],
     });
   });
 
-  it('derives references from wrapped Vyper 0.3.4-0.3.6 immutable annotations', () => {
+  it('derives a synthetic tail reference from wrapped Vyper 0.3.4-0.3.6 immutable annotations', () => {
     const compilerOutput = {
       sources: {
         'test.vy': {
@@ -816,12 +869,11 @@ describe('returnLegacyVyperImmutableReferences', () => {
         '0x6000',
       ),
     ).to.deep.equal({
-      A: [{ length: 96, start: 2 }],
-      B: [{ length: 64, start: 98 }],
+      '0': [{ length: 160, start: 2 }],
     });
   });
 
-  it('derives references from old Vyper 0.3.1-0.3.3 AnnAssign immutables', () => {
+  it('derives a synthetic tail reference from old Vyper 0.3.1-0.3.3 AnnAssign immutables', () => {
     const compilerOutput = {
       sources: {
         'test.vy': {
@@ -841,12 +893,11 @@ describe('returnLegacyVyperImmutableReferences', () => {
         '0x6000',
       ),
     ).to.deep.equal({
-      A: [{ length: 96, start: 2 }],
-      B: [{ length: 64, start: 98 }],
+      '0': [{ length: 160, start: 2 }],
     });
   });
 
-  it('derives references for structs and dynamic arrays', () => {
+  it('derives a synthetic tail reference for structs and dynamic arrays', () => {
     const compilerOutput = {
       sources: {
         'test.vy': {
@@ -870,8 +921,7 @@ describe('returnLegacyVyperImmutableReferences', () => {
         '0x60',
       ),
     ).to.deep.equal({
-      C: [{ length: 64, start: 1 }],
-      D: [{ length: 128, start: 65 }],
+      '0': [{ length: 192, start: 1 }],
     });
   });
 
@@ -906,7 +956,7 @@ describe('returnLegacyVyperImmutableReferences', () => {
         '0x6000',
       ),
     ).to.deep.equal({
-      A: [{ length: 32, start: 2 }],
+      '0': [{ length: 32, start: 2 }],
     });
   });
 });

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -4,6 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import fs from 'fs';
 import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
+import type { ImmutableReferences } from '@ethereum-sourcify/compilers-types';
 import {
   returnImmutableReferences,
   VyperCompilation,
@@ -1140,11 +1141,10 @@ def salt() -> bytes32:
     });
   });
 
-  it('uses stored Vyper immutable references for pre-run compiler outputs without IR', () => {
-    const immutableReferences = {
-      '0': [{ length: 32, start: 3 }],
-    };
-    const preRunCompilation = new PreRunCompilation(
+  function createPreRunVyperCompilation(
+    immutableReferences?: ImmutableReferences,
+  ) {
+    return new PreRunCompilation(
       vyperCompiler,
       '0.3.7+commit.6020b8bb',
       {
@@ -1183,7 +1183,9 @@ def salt() -> bytes32:
                   object: '600102',
                   opcodes: '',
                   sourceMap: '',
-                  immutableReferences,
+                  ...(immutableReferences !== undefined
+                    ? { immutableReferences }
+                    : {}),
                 },
                 methodIdentifiers: {},
               },
@@ -1201,9 +1203,22 @@ def salt() -> bytes32:
       {},
       {},
     );
+  }
+
+  it('uses stored Vyper immutable references for pre-run compiler outputs without IR', () => {
+    const immutableReferences = {
+      '0': [{ length: 32, start: 3 }],
+    };
+    const preRunCompilation = createPreRunVyperCompilation(immutableReferences);
 
     expect(preRunCompilation.immutableReferences).to.deep.equal(
       immutableReferences,
     );
+  });
+
+  it('does not infer missing Vyper immutable references for pre-run compiler outputs', () => {
+    const preRunCompilation = createPreRunVyperCompilation();
+
+    expect(preRunCompilation.immutableReferences).to.deep.equal({});
   });
 });

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -771,7 +771,7 @@ describe('VyperCompilation outputSelection version gating', () => {
 });
 
 describe('returnLegacyVyperImmutableReferences', () => {
-  it('derives a synthetic tail reference from the real Vyper 0.3.7 AST', async () => {
+  it('derives a synthetic tail reference from real Vyper 0.3.7 structured IR', async () => {
     const contractPath = path.join(
       __dirname,
       '..',
@@ -809,15 +809,10 @@ describe('returnLegacyVyperImmutableReferences', () => {
 
     await compilation.compile();
 
-    const ast = compilation.compilerOutput?.sources?.[contractFileName]?.ast;
-    const targetDecl = ast?.body.find(
-      (node: any) => node.ast_type === 'VariableDecl',
-    );
-    expect(targetDecl?.target?.id).to.equal('TARGET');
     expect(
       returnLegacyVyperImmutableReferences(
         compilation.compilerOutput,
-        contractFileName,
+        compilation.compilationTarget,
         compilation.runtimeBytecode,
       ),
     ).to.deep.equal({
@@ -825,7 +820,7 @@ describe('returnLegacyVyperImmutableReferences', () => {
     });
   });
 
-  it('derives a synthetic tail reference from real Vyper 0.3.7 mixed public and non-public immutable ASTs', async () => {
+  it('uses compiler-resolved structured IR size for Vyper 0.3.7 constant-bound immutables', async () => {
     const contractFileName = 'test.vy';
     const contractContent = `# @version 0.3.7
 
@@ -881,40 +876,10 @@ def salt() -> bytes32:
 
     await compilation.compile();
 
-    const ast = compilation.compilerOutput?.sources?.[contractFileName]?.ast;
-    const declarations = ast?.body.filter(
-      (node: any) => node.ast_type === 'VariableDecl',
-    );
-    const targetDecl = declarations?.find(
-      (node: any) => node.target?.id === 'TARGET',
-    );
-    const saltDecl = declarations?.find(
-      (node: any) => node.target?.id === 'SALT',
-    );
-    const coinsDecl = declarations?.find(
-      (node: any) => node.target?.id === 'COINS',
-    );
-    const underlyingCoinsDecl = declarations?.find(
-      (node: any) => node.target?.id === 'UNDERLYING_COINS',
-    );
-    expect(targetDecl?.target?.id).to.equal('TARGET');
-    expect(targetDecl?.is_public).to.equal(true);
-    expect(targetDecl?.is_immutable).to.equal(true);
-    expect(targetDecl?.annotation?.id).to.equal('address');
-    expect(saltDecl?.target?.id).to.equal('SALT');
-    expect(saltDecl?.is_public).to.equal(false);
-    expect(saltDecl?.is_immutable).to.equal(true);
-    expect(saltDecl?.annotation?.id).to.equal('bytes32');
-    expect(coinsDecl?.is_immutable).to.equal(true);
-    expect(coinsDecl?.annotation?.slice?.value?.id).to.equal('N_COINS');
-    expect(underlyingCoinsDecl?.is_immutable).to.equal(true);
-    expect(underlyingCoinsDecl?.annotation?.slice?.value?.id).to.equal(
-      'N_UL_COINS',
-    );
     expect(
       returnLegacyVyperImmutableReferences(
         compilation.compilerOutput,
-        contractFileName,
+        compilation.compilationTarget,
         compilation.runtimeBytecode,
       ),
     ).to.deep.equal({
@@ -922,164 +887,44 @@ def salt() -> bytes32:
     });
   });
 
-  it('derives a synthetic tail reference from unwrapped Vyper 0.3.7 immutable annotations', () => {
+  it('derives a synthetic tail reference from Vyper 0.3.1 text IR', () => {
     const compilerOutput = {
-      sources: {
+      contracts: {
         'test.vy': {
-          id: 0,
-          ast: moduleAst([
-            variableDecl('A', subscript(name('uint256'), 3)),
-            variableDecl('B', subscript(name('String'), 10)),
-          ]),
-        },
-      },
-    };
-
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilerOutput as any,
-        'test.vy',
-        '0x6000',
-      ),
-    ).to.deep.equal({
-      '0': [{ length: 160, start: 2 }],
-    });
-  });
-
-  it('derives a synthetic tail reference from wrapped Vyper 0.3.4-0.3.6 immutable annotations', () => {
-    const compilerOutput = {
-      sources: {
-        'test.vy': {
-          id: 0,
-          ast: moduleAst([
-            variableDecl('A', immutableCall(subscript(name('uint256'), 3))),
-            variableDecl('B', immutableCall(subscript(name('String'), 10))),
-          ]),
-        },
-      },
-    };
-
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilerOutput as any,
-        'test.vy',
-        '0x6000',
-      ),
-    ).to.deep.equal({
-      '0': [{ length: 160, start: 2 }],
-    });
-  });
-
-  it('derives a synthetic tail reference from old Vyper 0.3.1-0.3.3 AnnAssign immutables', () => {
-    const compilerOutput = {
-      sources: {
-        'test.vy': {
-          id: 0,
-          ast: moduleAst([
-            annAssign('A', immutableCall(subscript(name('uint256'), 3))),
-            annAssign('B', immutableCall(subscript(name('String'), 10))),
-          ]),
-        },
-      },
-    };
-
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilerOutput as any,
-        'test.vy',
-        '0x6000',
-      ),
-    ).to.deep.equal({
-      '0': [{ length: 160, start: 2 }],
-    });
-  });
-
-  it('resolves legacy Vyper integer constants in immutable array bounds', () => {
-    const compilerOutput = {
-      sources: {
-        'test.vy': {
-          id: 0,
-          ast: moduleAst([
-            annAssign('N_COINS', constantCall(name('int128')), int(2)),
-            annAssign('N_STABLECOINS', constantCall(name('int128')), int(3)),
-            annAssign(
-              'N_UL_COINS',
-              constantCall(name('int128')),
-              binOp(
-                binOp(name('N_COINS'), 'Add', name('N_STABLECOINS')),
-                'Sub',
-                int(1),
-              ),
-            ),
-            annAssign(
-              'COINS',
-              immutableCall(
-                subscriptWithLength(name('address'), name('N_COINS')),
-              ),
-            ),
-            annAssign(
-              'UNDERLYING_COINS',
-              immutableCall(
-                subscriptWithLength(name('address'), name('N_UL_COINS')),
-              ),
-            ),
-          ]),
-        },
-      },
-    };
-
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilerOutput as any,
-        'test.vy',
-        '0x6000',
-      ),
-    ).to.deep.equal({
-      '0': [{ length: 192, start: 2 }],
-    });
-  });
-
-  it('derives a synthetic tail reference for structs and dynamic arrays', () => {
-    const compilerOutput = {
-      sources: {
-        'test.vy': {
-          id: 0,
-          ast: moduleAst([
-            structDef('MyStruct', [
-              ['a', name('uint256')],
-              ['b', name('address')],
-            ]),
-            variableDecl('C', name('MyStruct')),
-            variableDecl('D', dynArray(name('uint256'), 3)),
-          ]),
-        },
-      },
-    };
-
-    expect(
-      returnLegacyVyperImmutableReferences(
-        compilerOutput as any,
-        'test.vy',
-        '0x60',
-      ),
-    ).to.deep.equal({
-      '0': [{ length: 192, start: 1 }],
-    });
-  });
-
-  it('only checks the compilation target source for immutable declarations', () => {
-    const compilerOutput = {
-      sources: {
-        'target.vy': {
-          id: 0,
-          ast: {
-            ast_type: 'Module',
-            body: [{ ast_type: 'FunctionDef' }],
+          test: {
+            ir: `
+              [seq,
+                [mstore, [add, 320, _lllsz], [mload, 256]],
+                [mstore, [add, 352, _lllsz], [mload, 288]],
+                [return, 320, [add, 64, _lllsz]]]
+              ]
+            `,
           },
         },
-        'unused.vy': {
-          id: 1,
-          ast: moduleAst([variableDecl('A', name('uint256'))]),
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        { name: 'test', path: 'test.vy' },
+        '0x600102',
+      ),
+    ).to.deep.equal({
+      '0': [{ length: 64, start: 3 }],
+    });
+  });
+
+  it('ignores ambiguous Vyper 0.3.1 text IR immutable lengths', () => {
+    const compilerOutput = {
+      contracts: {
+        'test.vy': {
+          test: {
+            ir: `
+              [return, 256, [add, 32, _lllsz]]
+              [return, 320, [add, 64, _lllsz]]
+            `,
+          },
         },
       },
     };
@@ -1087,14 +932,61 @@ def salt() -> bytes32:
     expect(
       returnLegacyVyperImmutableReferences(
         compilerOutput as any,
-        'target.vy',
+        { name: 'test', path: 'test.vy' },
+        '0x6000',
+      ),
+    ).to.deep.equal({});
+  });
+
+  it('ignores invalid structured IR immutable lengths', () => {
+    const compilerOutput = {
+      contracts: {
+        'test.vy': {
+          test: {
+            ir: {
+              deploy: [256, { runtime: [] }, 31],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        { name: 'test', path: 'test.vy' },
+        '0x6000',
+      ),
+    ).to.deep.equal({});
+  });
+
+  it('only checks the compilation target contract IR', () => {
+    const compilerOutput = {
+      contracts: {
+        'target.vy': {
+          target: {
+            ir: { seq: [] },
+          },
+          unused: {
+            ir: {
+              deploy: [256, { runtime: [] }, 32],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      returnLegacyVyperImmutableReferences(
+        compilerOutput as any,
+        { name: 'target', path: 'target.vy' },
         '0x6000',
       ),
     ).to.deep.equal({});
     expect(
       returnLegacyVyperImmutableReferences(
         compilerOutput as any,
-        'unused.vy',
+        { name: 'unused', path: 'target.vy' },
         '0x6000',
       ),
     ).to.deep.equal({
@@ -1102,102 +994,3 @@ def salt() -> bytes32:
     });
   });
 });
-
-function moduleAst(body: any[]) {
-  return { ast_type: 'Module', body };
-}
-
-function name(id: string) {
-  return { ast_type: 'Name', id };
-}
-
-function int(value: number) {
-  return { ast_type: 'Int', value };
-}
-
-function subscript(value: any, length: number) {
-  return subscriptWithLength(value, int(length));
-}
-
-function subscriptWithLength(value: any, length: any) {
-  return {
-    ast_type: 'Subscript',
-    value,
-    slice: {
-      ast_type: 'Index',
-      value: length,
-    },
-  };
-}
-
-function dynArray(subtype: any, maxLength: number) {
-  return {
-    ast_type: 'Subscript',
-    value: name('DynArray'),
-    slice: {
-      ast_type: 'Index',
-      value: {
-        ast_type: 'Tuple',
-        elements: [subtype, int(maxLength)],
-      },
-    },
-  };
-}
-
-function immutableCall(annotation: any) {
-  return {
-    ast_type: 'Call',
-    func: name('immutable'),
-    args: [annotation],
-  };
-}
-
-function constantCall(annotation: any) {
-  return {
-    ast_type: 'Call',
-    func: name('constant'),
-    args: [annotation],
-  };
-}
-
-function binOp(left: any, op: string, right: any) {
-  return {
-    ast_type: 'BinOp',
-    left,
-    op: {
-      ast_type: op,
-    },
-    right,
-  };
-}
-
-function variableDecl(variableName: string, annotation: any) {
-  return {
-    ast_type: 'VariableDecl',
-    is_immutable: true,
-    target: name(variableName),
-    annotation,
-  };
-}
-
-function annAssign(variableName: string, annotation: any, value?: any) {
-  const node: any = {
-    ast_type: 'AnnAssign',
-    target: name(variableName),
-    annotation,
-  };
-  if (value !== undefined) {
-    node.value = value;
-  }
-  return node;
-}
-
-function structDef(structName: string, members: Array<[string, any]>) {
-  return {
-    ast_type: 'StructDef',
-    name: structName,
-    body: members.map(([memberName, annotation]) =>
-      annAssign(memberName, annotation),
-    ),
-  };
-}

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -6,9 +6,9 @@ import fs from 'fs';
 import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 import {
   returnImmutableReferences,
-  returnLegacyVyperImmutableReferences,
   VyperCompilation,
 } from '../../src/Compilation/VyperCompilation';
+import { returnLegacyVyperImmutableReferences } from '../../src/Compilation/legacyVyperImmutablesHelpers';
 import { vyperCompiler } from '../utils';
 
 chai.use(chaiAsPromised);

--- a/packages/lib-sourcify/test/Verification/Transformations.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Transformations.spec.ts
@@ -132,5 +132,72 @@ describe('Transformations', () => {
 
       expect(immutableReferences).to.deep.equal({});
     });
+
+    it('does not infer a legacy Vyper immutable for an oversized tail', () => {
+      const onchainRuntimeWithOversizedTail =
+        onchainRuntime + '00'.repeat(32);
+
+      const immutableReferences = inferLegacyVyperImmutableReferences(
+        recompiledRuntime,
+        onchainRuntimeWithOversizedTail,
+        AuxdataStyle.VYPER_LT_0_3_10,
+        compilerVersion,
+        true,
+      );
+
+      expect(immutableReferences).to.deep.equal({});
+    });
+
+    [
+      {
+        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_4,
+        compilerVersion: '0.3.1+commit.b6b9fb7b',
+      },
+      {
+        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_5,
+        compilerVersion: '0.3.4+commit.f31f0ec4',
+      },
+      {
+        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_10,
+        compilerVersion: '0.3.9+commit.66b96705',
+      },
+    ].forEach(({ auxdataStyle, compilerVersion }) => {
+      it(`infers a legacy Vyper immutable for ${compilerVersion}`, () => {
+        const immutableReferences = inferLegacyVyperImmutableReferences(
+          recompiledRuntime,
+          onchainRuntime,
+          auxdataStyle,
+          compilerVersion,
+          true,
+        );
+
+        expect(immutableReferences).to.deep.equal({
+          '0': [{ length: 32, start: immutableOffset }],
+        });
+      });
+    });
+
+    [
+      {
+        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_4,
+        compilerVersion: '0.3.0+commit.8d3d8f8b',
+      },
+      {
+        auxdataStyle: AuxdataStyle.VYPER,
+        compilerVersion: '0.3.10+commit.91361694',
+      },
+    ].forEach(({ auxdataStyle, compilerVersion }) => {
+      it(`does not infer a legacy Vyper immutable for ${compilerVersion}`, () => {
+        const immutableReferences = inferLegacyVyperImmutableReferences(
+          recompiledRuntime,
+          onchainRuntime,
+          auxdataStyle,
+          compilerVersion,
+          true,
+        );
+
+        expect(immutableReferences).to.deep.equal({});
+      });
+    });
   });
 });

--- a/packages/lib-sourcify/test/Verification/Transformations.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Transformations.spec.ts
@@ -3,7 +3,6 @@ import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 import {
   AuxdataTransformation,
   extractImmutablesTransformation,
-  inferLegacyVyperImmutableReferences,
 } from '../../src/Verification/Transformations';
 
 describe('Transformations', () => {
@@ -61,8 +60,7 @@ describe('Transformations', () => {
     });
   });
 
-  describe('legacy Vyper immutable transformations', () => {
-    const compilerVersion = '0.3.7+commit.6020b8bb';
+  describe('Vyper immutable transformations', () => {
     const recompiledRuntime = '0x6000a165767970657283000307000b';
     const immutableValue =
       '0x000000000000000000000000216ce6e49e2e713e41383ba4c5d84a0d36189640';
@@ -72,26 +70,12 @@ describe('Transformations', () => {
       '0': [{ length: 32, start: immutableOffset }],
     };
 
-    it('infers the synthetic immutable reference for an append-only legacy Vyper tail', () => {
-      const immutableReferences = inferLegacyVyperImmutableReferences(
-        recompiledRuntime,
-        onchainRuntime,
-        AuxdataStyle.VYPER_LT_0_3_10,
-        legacyImmutableReferences,
-        compilerVersion,
-      );
-
-      expect(immutableReferences).to.deep.equal(legacyImmutableReferences);
-    });
-
     it('appends the observed immutable value for legacy Vyper runtimes', () => {
       const result = extractImmutablesTransformation(
         recompiledRuntime,
         onchainRuntime,
-        {},
-        AuxdataStyle.VYPER_LT_0_3_10,
         legacyImmutableReferences,
-        compilerVersion,
+        AuxdataStyle.VYPER_LT_0_3_10,
       );
 
       expect(result.populatedRecompiledBytecode).to.equal(onchainRuntime);
@@ -110,7 +94,31 @@ describe('Transformations', () => {
       });
     });
 
-    it('appends a multiword legacy Vyper immutable tail using the derived length', () => {
+    it('appends the observed immutable value for Vyper 0.3.10+ runtimes', () => {
+      const result = extractImmutablesTransformation(
+        recompiledRuntime,
+        onchainRuntime,
+        legacyImmutableReferences,
+        AuxdataStyle.VYPER,
+      );
+
+      expect(result.populatedRecompiledBytecode).to.equal(onchainRuntime);
+      expect(result.transformations).to.deep.equal([
+        {
+          type: 'insert',
+          reason: 'immutable',
+          offset: immutableOffset,
+          id: '0',
+        },
+      ]);
+      expect(result.transformationValues).to.deep.equal({
+        immutables: {
+          '0': immutableValue,
+        },
+      });
+    });
+
+    it('appends a multiword Vyper immutable tail using the derived length', () => {
       const firstImmutableValue = '11'.repeat(32);
       const secondImmutableValue = '22'.repeat(64);
       const multiwordOnchainRuntime =
@@ -122,10 +130,8 @@ describe('Transformations', () => {
       const result = extractImmutablesTransformation(
         recompiledRuntime,
         multiwordOnchainRuntime,
-        {},
-        AuxdataStyle.VYPER_LT_0_3_10,
         multiwordImmutableReferences,
-        compilerVersion,
+        AuxdataStyle.VYPER_LT_0_3_10,
       );
 
       expect(result.populatedRecompiledBytecode).to.equal(
@@ -146,92 +152,88 @@ describe('Transformations', () => {
       });
     });
 
-    it('does not infer a legacy Vyper immutable without derived references', () => {
-      const immutableReferences = inferLegacyVyperImmutableReferences(
+    it('does not record a phantom Vyper immutable when the bytecodes already match', () => {
+      const result = extractImmutablesTransformation(
         recompiledRuntime,
-        onchainRuntime,
-        AuxdataStyle.VYPER_LT_0_3_10,
-        {},
-        compilerVersion,
-      );
-
-      expect(immutableReferences).to.deep.equal({});
-    });
-
-    it('does not infer a legacy Vyper immutable for the 0.3.10+ auxdata layout', () => {
-      const immutableReferences = inferLegacyVyperImmutableReferences(
         recompiledRuntime,
-        onchainRuntime,
-        AuxdataStyle.VYPER,
         legacyImmutableReferences,
-        '0.3.10+commit.91361694',
+        AuxdataStyle.VYPER_LT_0_3_10,
       );
 
-      expect(immutableReferences).to.deep.equal({});
+      expect(result.populatedRecompiledBytecode).to.equal(recompiledRuntime);
+      expect(result.transformations).to.deep.equal([]);
+      expect(result.transformationValues).to.deep.equal({});
     });
 
-    it('does not infer a legacy Vyper immutable for an oversized tail', () => {
+    it('does not append a Vyper immutable for an oversized tail', () => {
       const onchainRuntimeWithOversizedTail = onchainRuntime + '00'.repeat(32);
 
-      const immutableReferences = inferLegacyVyperImmutableReferences(
+      const result = extractImmutablesTransformation(
         recompiledRuntime,
         onchainRuntimeWithOversizedTail,
-        AuxdataStyle.VYPER_LT_0_3_10,
         legacyImmutableReferences,
-        compilerVersion,
+        AuxdataStyle.VYPER_LT_0_3_10,
       );
 
-      expect(immutableReferences).to.deep.equal({});
+      expect(result.populatedRecompiledBytecode).to.equal(recompiledRuntime);
+      expect(result.transformations).to.deep.equal([]);
+      expect(result.transformationValues).to.deep.equal({});
+    });
+
+    it('does not append a Vyper immutable when the runtime prefix differs', () => {
+      const onchainRuntimeWithPrefixDifference =
+        '0x6100' + recompiledRuntime.slice(6) + immutableValue.slice(2);
+
+      const result = extractImmutablesTransformation(
+        recompiledRuntime,
+        onchainRuntimeWithPrefixDifference,
+        legacyImmutableReferences,
+        AuxdataStyle.VYPER_LT_0_3_10,
+      );
+
+      expect(result.populatedRecompiledBytecode).to.equal(recompiledRuntime);
+      expect(result.transformations).to.deep.equal([]);
+      expect(result.transformationValues).to.deep.equal({});
     });
 
     [
-      {
-        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_4,
-        compilerVersion: '0.3.1+commit.b6b9fb7b',
-      },
-      {
-        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_5,
-        compilerVersion: '0.3.4+commit.f31f0ec4',
-      },
-      {
-        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_10,
-        compilerVersion: '0.3.9+commit.66b96705',
-      },
-    ].forEach(({ auxdataStyle, compilerVersion }) => {
-      it(`infers a legacy Vyper immutable for ${compilerVersion}`, () => {
-        const immutableReferences = inferLegacyVyperImmutableReferences(
+      AuxdataStyle.VYPER_LT_0_3_4,
+      AuxdataStyle.VYPER_LT_0_3_5,
+      AuxdataStyle.VYPER_LT_0_3_10,
+      AuxdataStyle.VYPER,
+    ].forEach((auxdataStyle) => {
+      it(`validates and appends a Vyper immutable for ${auxdataStyle}`, () => {
+        const result = extractImmutablesTransformation(
           recompiledRuntime,
           onchainRuntime,
-          auxdataStyle,
           legacyImmutableReferences,
-          compilerVersion,
+          auxdataStyle,
         );
 
-        expect(immutableReferences).to.deep.equal(legacyImmutableReferences);
+        expect(result.populatedRecompiledBytecode).to.equal(onchainRuntime);
+        expect(result.transformations).to.have.length(1);
       });
     });
 
-    [
-      {
-        auxdataStyle: AuxdataStyle.VYPER_LT_0_3_4,
-        compilerVersion: '0.3.0+commit.8d3d8f8b',
-      },
-      {
-        auxdataStyle: AuxdataStyle.VYPER,
-        compilerVersion: '0.3.10+commit.91361694',
-      },
-    ].forEach(({ auxdataStyle, compilerVersion }) => {
-      it(`does not infer a legacy Vyper immutable for ${compilerVersion}`, () => {
-        const immutableReferences = inferLegacyVyperImmutableReferences(
-          recompiledRuntime,
-          onchainRuntime,
-          auxdataStyle,
-          legacyImmutableReferences,
-          compilerVersion,
-        );
+    it('keeps Solidity immutable replacement behavior unchanged', () => {
+      const solidityRecompiledRuntime =
+        '0x6000' + '00'.repeat(32) + 'a165627a7a72305820';
+      const solidityOnchainRuntime =
+        '0x6000' + immutableValue.slice(2) + 'a165627a7a72305820';
+      const solidityImmutableReferences = {
+        '1': [{ length: 32, start: 2 }],
+      };
 
-        expect(immutableReferences).to.deep.equal({});
-      });
+      const result = extractImmutablesTransformation(
+        solidityRecompiledRuntime,
+        solidityOnchainRuntime,
+        solidityImmutableReferences,
+        AuxdataStyle.SOLIDITY,
+      );
+
+      expect(result.populatedRecompiledBytecode).to.equal(
+        solidityOnchainRuntime,
+      );
     });
   });
 });

--- a/packages/lib-sourcify/test/Verification/Transformations.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Transformations.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { AuxdataTransformation } from '../../src/Verification/Transformations';
+import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
+import {
+  AuxdataTransformation,
+  extractImmutablesTransformation,
+  inferLegacyVyperImmutableReferences,
+} from '../../src/Verification/Transformations';
 
 describe('Transformations', () => {
   describe('AuxdataTransformation', () => {
@@ -53,6 +58,79 @@ describe('Transformations', () => {
       expect(() => AuxdataTransformation('delete', 10)).to.throw(
         'Invalid cborAuxdata delete transformation: length is required.',
       );
+    });
+  });
+
+  describe('legacy Vyper immutable transformations', () => {
+    const compilerVersion = '0.3.7+commit.6020b8bb';
+    const recompiledRuntime = '0x6000a165767970657283000307000b';
+    const immutableValue =
+      '0x000000000000000000000000216ce6e49e2e713e41383ba4c5d84a0d36189640';
+    const onchainRuntime = recompiledRuntime + immutableValue.slice(2);
+    const immutableOffset = 15;
+
+    it('infers a synthetic immutable reference for an append-only legacy Vyper tail', () => {
+      const immutableReferences = inferLegacyVyperImmutableReferences(
+        recompiledRuntime,
+        onchainRuntime,
+        AuxdataStyle.VYPER_LT_0_3_10,
+        compilerVersion,
+        true,
+      );
+
+      expect(immutableReferences).to.deep.equal({
+        '0': [{ length: 32, start: immutableOffset }],
+      });
+    });
+
+    it('appends the observed immutable value for legacy Vyper runtimes', () => {
+      const result = extractImmutablesTransformation(
+        recompiledRuntime,
+        onchainRuntime,
+        {},
+        AuxdataStyle.VYPER_LT_0_3_10,
+        compilerVersion,
+        true,
+      );
+
+      expect(result.populatedRecompiledBytecode).to.equal(onchainRuntime);
+      expect(result.transformations).to.deep.equal([
+        {
+          type: 'insert',
+          reason: 'immutable',
+          offset: immutableOffset,
+          id: '0',
+        },
+      ]);
+      expect(result.transformationValues).to.deep.equal({
+        immutables: {
+          '0': immutableValue,
+        },
+      });
+    });
+
+    it('does not infer a legacy Vyper immutable without an AST immutable declaration', () => {
+      const immutableReferences = inferLegacyVyperImmutableReferences(
+        recompiledRuntime,
+        onchainRuntime,
+        AuxdataStyle.VYPER_LT_0_3_10,
+        compilerVersion,
+        false,
+      );
+
+      expect(immutableReferences).to.deep.equal({});
+    });
+
+    it('does not infer a legacy Vyper immutable for the 0.3.10+ auxdata layout', () => {
+      const immutableReferences = inferLegacyVyperImmutableReferences(
+        recompiledRuntime,
+        onchainRuntime,
+        AuxdataStyle.VYPER,
+        '0.3.10+commit.91361694',
+        true,
+      );
+
+      expect(immutableReferences).to.deep.equal({});
     });
   });
 });

--- a/packages/lib-sourcify/test/Verification/Transformations.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Transformations.spec.ts
@@ -69,10 +69,10 @@ describe('Transformations', () => {
     const onchainRuntime = recompiledRuntime + immutableValue.slice(2);
     const immutableOffset = 15;
     const legacyImmutableReferences = {
-      VALUE: [{ length: 32, start: immutableOffset }],
+      '0': [{ length: 32, start: immutableOffset }],
     };
 
-    it('infers a synthetic immutable reference for an append-only legacy Vyper tail', () => {
+    it('infers the synthetic immutable reference for an append-only legacy Vyper tail', () => {
       const immutableReferences = inferLegacyVyperImmutableReferences(
         recompiledRuntime,
         onchainRuntime,
@@ -100,24 +100,23 @@ describe('Transformations', () => {
           type: 'insert',
           reason: 'immutable',
           offset: immutableOffset,
-          id: 'VALUE',
+          id: '0',
         },
       ]);
       expect(result.transformationValues).to.deep.equal({
         immutables: {
-          VALUE: immutableValue,
+          '0': immutableValue,
         },
       });
     });
 
-    it('appends multiword legacy Vyper immutable values using the derived layout', () => {
+    it('appends a multiword legacy Vyper immutable tail using the derived length', () => {
       const firstImmutableValue = '11'.repeat(32);
       const secondImmutableValue = '22'.repeat(64);
       const multiwordOnchainRuntime =
         recompiledRuntime + firstImmutableValue + secondImmutableValue;
       const multiwordImmutableReferences = {
-        A: [{ length: 32, start: immutableOffset }],
-        B: [{ length: 64, start: immutableOffset + 32 }],
+        '0': [{ length: 96, start: immutableOffset }],
       };
 
       const result = extractImmutablesTransformation(
@@ -137,19 +136,12 @@ describe('Transformations', () => {
           type: 'insert',
           reason: 'immutable',
           offset: immutableOffset,
-          id: 'A',
-        },
-        {
-          type: 'insert',
-          reason: 'immutable',
-          offset: immutableOffset + 32,
-          id: 'B',
+          id: '0',
         },
       ]);
       expect(result.transformationValues).to.deep.equal({
         immutables: {
-          A: `0x${firstImmutableValue}`,
-          B: `0x${secondImmutableValue}`,
+          '0': `0x${firstImmutableValue}${secondImmutableValue}`,
         },
       });
     });
@@ -179,8 +171,7 @@ describe('Transformations', () => {
     });
 
     it('does not infer a legacy Vyper immutable for an oversized tail', () => {
-      const onchainRuntimeWithOversizedTail =
-        onchainRuntime + '00'.repeat(32);
+      const onchainRuntimeWithOversizedTail = onchainRuntime + '00'.repeat(32);
 
       const immutableReferences = inferLegacyVyperImmutableReferences(
         recompiledRuntime,

--- a/packages/lib-sourcify/test/Verification/Transformations.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Transformations.spec.ts
@@ -68,19 +68,20 @@ describe('Transformations', () => {
       '0x000000000000000000000000216ce6e49e2e713e41383ba4c5d84a0d36189640';
     const onchainRuntime = recompiledRuntime + immutableValue.slice(2);
     const immutableOffset = 15;
+    const legacyImmutableReferences = {
+      VALUE: [{ length: 32, start: immutableOffset }],
+    };
 
     it('infers a synthetic immutable reference for an append-only legacy Vyper tail', () => {
       const immutableReferences = inferLegacyVyperImmutableReferences(
         recompiledRuntime,
         onchainRuntime,
         AuxdataStyle.VYPER_LT_0_3_10,
+        legacyImmutableReferences,
         compilerVersion,
-        true,
       );
 
-      expect(immutableReferences).to.deep.equal({
-        '0': [{ length: 32, start: immutableOffset }],
-      });
+      expect(immutableReferences).to.deep.equal(legacyImmutableReferences);
     });
 
     it('appends the observed immutable value for legacy Vyper runtimes', () => {
@@ -89,8 +90,8 @@ describe('Transformations', () => {
         onchainRuntime,
         {},
         AuxdataStyle.VYPER_LT_0_3_10,
+        legacyImmutableReferences,
         compilerVersion,
-        true,
       );
 
       expect(result.populatedRecompiledBytecode).to.equal(onchainRuntime);
@@ -99,23 +100,67 @@ describe('Transformations', () => {
           type: 'insert',
           reason: 'immutable',
           offset: immutableOffset,
-          id: '0',
+          id: 'VALUE',
         },
       ]);
       expect(result.transformationValues).to.deep.equal({
         immutables: {
-          '0': immutableValue,
+          VALUE: immutableValue,
         },
       });
     });
 
-    it('does not infer a legacy Vyper immutable without an AST immutable declaration', () => {
+    it('appends multiword legacy Vyper immutable values using the derived layout', () => {
+      const firstImmutableValue = '11'.repeat(32);
+      const secondImmutableValue = '22'.repeat(64);
+      const multiwordOnchainRuntime =
+        recompiledRuntime + firstImmutableValue + secondImmutableValue;
+      const multiwordImmutableReferences = {
+        A: [{ length: 32, start: immutableOffset }],
+        B: [{ length: 64, start: immutableOffset + 32 }],
+      };
+
+      const result = extractImmutablesTransformation(
+        recompiledRuntime,
+        multiwordOnchainRuntime,
+        {},
+        AuxdataStyle.VYPER_LT_0_3_10,
+        multiwordImmutableReferences,
+        compilerVersion,
+      );
+
+      expect(result.populatedRecompiledBytecode).to.equal(
+        multiwordOnchainRuntime,
+      );
+      expect(result.transformations).to.deep.equal([
+        {
+          type: 'insert',
+          reason: 'immutable',
+          offset: immutableOffset,
+          id: 'A',
+        },
+        {
+          type: 'insert',
+          reason: 'immutable',
+          offset: immutableOffset + 32,
+          id: 'B',
+        },
+      ]);
+      expect(result.transformationValues).to.deep.equal({
+        immutables: {
+          A: `0x${firstImmutableValue}`,
+          B: `0x${secondImmutableValue}`,
+        },
+      });
+    });
+
+    it('does not infer a legacy Vyper immutable without derived references', () => {
       const immutableReferences = inferLegacyVyperImmutableReferences(
         recompiledRuntime,
         onchainRuntime,
         AuxdataStyle.VYPER_LT_0_3_10,
+        {},
         compilerVersion,
-        false,
       );
 
       expect(immutableReferences).to.deep.equal({});
@@ -126,8 +171,8 @@ describe('Transformations', () => {
         recompiledRuntime,
         onchainRuntime,
         AuxdataStyle.VYPER,
+        legacyImmutableReferences,
         '0.3.10+commit.91361694',
-        true,
       );
 
       expect(immutableReferences).to.deep.equal({});
@@ -141,8 +186,8 @@ describe('Transformations', () => {
         recompiledRuntime,
         onchainRuntimeWithOversizedTail,
         AuxdataStyle.VYPER_LT_0_3_10,
+        legacyImmutableReferences,
         compilerVersion,
-        true,
       );
 
       expect(immutableReferences).to.deep.equal({});
@@ -167,13 +212,11 @@ describe('Transformations', () => {
           recompiledRuntime,
           onchainRuntime,
           auxdataStyle,
+          legacyImmutableReferences,
           compilerVersion,
-          true,
         );
 
-        expect(immutableReferences).to.deep.equal({
-          '0': [{ length: 32, start: immutableOffset }],
-        });
+        expect(immutableReferences).to.deep.equal(legacyImmutableReferences);
       });
     });
 
@@ -192,8 +235,8 @@ describe('Transformations', () => {
           recompiledRuntime,
           onchainRuntime,
           auxdataStyle,
+          legacyImmutableReferences,
           compilerVersion,
-          true,
         );
 
         expect(immutableReferences).to.deep.equal({});

--- a/packages/lib-sourcify/test/Verification/Transformations.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Transformations.spec.ts
@@ -152,20 +152,21 @@ describe('Transformations', () => {
       });
     });
 
-    it('does not record a phantom Vyper immutable when the bytecodes already match', () => {
-      const result = extractImmutablesTransformation(
-        recompiledRuntime,
-        recompiledRuntime,
-        legacyImmutableReferences,
-        AuxdataStyle.VYPER_LT_0_3_10,
-      );
-
-      expect(result.populatedRecompiledBytecode).to.equal(recompiledRuntime);
-      expect(result.transformations).to.deep.equal([]);
-      expect(result.transformationValues).to.deep.equal({});
+    it('throws when the onchain bytecode lacks the inferred Vyper immutable tail', () => {
+      expect(() =>
+        extractImmutablesTransformation(
+          recompiledRuntime,
+          recompiledRuntime,
+          legacyImmutableReferences,
+          AuxdataStyle.VYPER_LT_0_3_10,
+        ),
+      ).to.throw('Vyper immutable length mismatch');
     });
 
-    it('does not append a Vyper immutable for an oversized tail', () => {
+    it('does not reconstruct an oversized onchain runtime', () => {
+      // The immutable tail is appended, but the populated bytecode does not
+      // equal the longer onchain runtime, so the matchBytecodes comparison
+      // rejects it (no false match).
       const onchainRuntimeWithOversizedTail = onchainRuntime + '00'.repeat(32);
 
       const result = extractImmutablesTransformation(
@@ -175,12 +176,15 @@ describe('Transformations', () => {
         AuxdataStyle.VYPER_LT_0_3_10,
       );
 
-      expect(result.populatedRecompiledBytecode).to.equal(recompiledRuntime);
-      expect(result.transformations).to.deep.equal([]);
-      expect(result.transformationValues).to.deep.equal({});
+      expect(result.populatedRecompiledBytecode).to.not.equal(
+        onchainRuntimeWithOversizedTail,
+      );
     });
 
-    it('does not append a Vyper immutable when the runtime prefix differs', () => {
+    it('does not reconstruct a runtime whose prefix differs', () => {
+      // The immutable tail is appended, but since the runtime prefix differs the
+      // populated bytecode does not equal the onchain runtime, so matchBytecodes
+      // rejects it (no false match).
       const onchainRuntimeWithPrefixDifference =
         '0x6100' + recompiledRuntime.slice(6) + immutableValue.slice(2);
 
@@ -191,9 +195,9 @@ describe('Transformations', () => {
         AuxdataStyle.VYPER_LT_0_3_10,
       );
 
-      expect(result.populatedRecompiledBytecode).to.equal(recompiledRuntime);
-      expect(result.transformations).to.deep.equal([]);
-      expect(result.transformationValues).to.deep.equal({});
+      expect(result.populatedRecompiledBytecode).to.not.equal(
+        onchainRuntimeWithPrefixDifference,
+      );
     });
 
     [

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -1453,6 +1453,64 @@ describe('Verification Class Tests', () => {
       });
     });
 
+    it('should verify a Vyper 0.3.7 contract with legacy immutables', async () => {
+      const contractFolderPath = path.join(
+        __dirname,
+        '..',
+        'sources',
+        'Vyper',
+        'legacyImmutables_0_3_7',
+      );
+      const immutableAddress = await signer.getAddress();
+      const { contractAddress } = await deployFromAbiAndBytecode(
+        signer,
+        contractFolderPath,
+        [immutableAddress],
+      );
+
+      const vyperCompilation = await createVyperCompilation(
+        contractFolderPath,
+        '0.3.7+commit.6020b8bb',
+      );
+
+      const verification = new Verification(
+        vyperCompilation,
+        sourcifyChainHardhat,
+        contractAddress,
+      );
+      await verification.verify();
+
+      expectVerification(verification, {
+        status: {
+          runtimeMatch: 'partial',
+          creationMatch: null,
+        },
+        transformations: {
+          runtime: {
+            list: [
+              {
+                type: 'insert',
+                reason: 'immutable',
+                offset: 88,
+                id: '0',
+              },
+            ],
+            values: {
+              immutables: {
+                '0': `0x${'0'.repeat(24)}${immutableAddress
+                  .slice(2)
+                  .toLowerCase()}`,
+              },
+            },
+          },
+          creation: {
+            list: [],
+            values: {},
+          },
+        },
+      });
+    });
+
     it('should add constructor transformation with correct offset and arguments for Vyper contract', async () => {
       const contractFolderPath = path.join(
         __dirname,

--- a/packages/lib-sourcify/test/sources/Vyper/legacyImmutables_0_3_7/artifact.json
+++ b/packages/lib-sourcify/test/sources/Vyper/legacyImmutables_0_3_7/artifact.json
@@ -1,0 +1,28 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "name": "_target",
+          "type": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "target",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x602061008e6000396000518060a01c6100895760405234610089576040516060526100586100306008396100786008f36003361161000c57610040565b60003560e01c346100465763d4b83992811861003e576004361061004657602061005860003960005160405260206040f35b505b60006000fd5b600080fda165767970657283000307000b005b600080fd"
+}

--- a/packages/lib-sourcify/test/sources/Vyper/legacyImmutables_0_3_7/test.vy
+++ b/packages/lib-sourcify/test/sources/Vyper/legacyImmutables_0_3_7/test.vy
@@ -1,0 +1,14 @@
+# @version 0.3.7
+
+TARGET: immutable(address)
+
+
+@external
+def __init__(_target: address):
+    TARGET = _target
+
+
+@external
+@view
+def target() -> address:
+    return TARGET

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -793,10 +793,18 @@ export async function getDatabaseColumnsFromVerification(
     cborAuxdata: verification.compilation.creationBytecodeCborAuxdata || null,
   };
 
-  let immutableReferences = null;
-  // immutableReferences for Vyper are not a compiler output and should not be stored
+  let immutableReferences: ImmutableReferences | null = null;
   if (verification.compilation.language === "Solidity") {
     immutableReferences = verification.compilation.immutableReferences || null;
+  } else if (verification.compilation.language === "Vyper") {
+    const vyperImmutableReferences =
+      verification.compilation.immutableReferences;
+    if (
+      vyperImmutableReferences &&
+      Object.keys(vyperImmutableReferences).length > 0
+    ) {
+      immutableReferences = vyperImmutableReferences;
+    }
   }
   const runtimeCodeArtifacts = {
     sourceMap: compilerOutput?.evm.deployedBytecode?.sourceMap || null,

--- a/services/server/test/integration/verification-cases/testdata/vyper/constructor_args_immutables.json
+++ b/services/server/test/integration/verification-cases/testdata/vyper/constructor_args_immutables.json
@@ -245,7 +245,9 @@
         },
         "pc_ast_map_item_keys": ["source_id", "node_id"]
       },
-      "immutableReferences": null,
+      "immutableReferences": {
+        "0": [{ "length": 96, "start": 167 }]
+      },
       "linkReferences": null,
       "cborAuxdata": {}
     },

--- a/services/server/test/unit/utils/database-util.spec.ts
+++ b/services/server/test/unit/utils/database-util.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from "chai";
+import { getDatabaseColumnsFromVerification } from "../../../src/server/services/utils/database-util";
+
+describe("database-util", () => {
+  it("stores non-empty Vyper immutable references in runtime code artifacts", async () => {
+    const immutableReferences = {
+      "0": [{ length: 32, start: 3 }],
+    };
+
+    const databaseColumns = await getDatabaseColumnsFromVerification({
+      address: "0x0000000000000000000000000000000000000001",
+      chainId: 1,
+      status: {
+        runtimeMatch: "perfect",
+        creationMatch: "perfect",
+      },
+      onchainRuntimeBytecode: "0x600102",
+      onchainCreationBytecode: "0x6000600102",
+      transformations: {
+        runtime: {
+          list: [],
+          values: {},
+        },
+        creation: {
+          list: [],
+          values: {},
+        },
+      },
+      deploymentInfo: {
+        blockNumber: 1,
+        txIndex: 0,
+        deployer: "0x0000000000000000000000000000000000000002",
+        txHash:
+          "0x0000000000000000000000000000000000000000000000000000000000000003",
+      },
+      compilation: {
+        language: "Vyper",
+        compilerVersion: "0.3.7+commit.6020b8bb",
+        creationBytecode: "0x6000600102",
+        runtimeBytecode: "0x600102",
+        immutableReferences,
+        runtimeBytecodeCborAuxdata: {},
+        creationBytecodeCborAuxdata: {},
+        compilationTarget: {
+          path: "test.vy",
+          name: "test",
+        },
+        sources: {
+          "test.vy": "# @version 0.3.7\n",
+        },
+        jsonInput: {
+          language: "Vyper",
+          sources: {
+            "test.vy": {
+              content: "# @version 0.3.7\n",
+            },
+          },
+          settings: {
+            outputSelection: {
+              "*": [],
+            },
+          },
+        },
+        compilerOutput: {
+          sources: {
+            "test.vy": {
+              id: 0,
+              ast: {},
+            },
+          },
+        },
+        contractCompilerOutput: {
+          abi: [],
+          userdoc: {},
+          devdoc: {},
+          evm: {
+            bytecode: {
+              object: "6000600102",
+              opcodes: "",
+            },
+            deployedBytecode: {
+              object: "600102",
+              opcodes: "",
+              sourceMap: "",
+            },
+          },
+        },
+      },
+    } as any);
+
+    expect(
+      databaseColumns.compiledContract.runtime_code_artifacts
+        .immutableReferences,
+    ).to.deep.equal(immutableReferences);
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `VyperCompilation.immutableReferences` so Vyper `0.3.1 <= version < 0.3.10` can produce the same synthetic tail reference shape that Sourcify already uses for Vyper `>= 0.3.10`.
- Derive legacy immutable tail length from Vyper compiler IR instead of reconstructing source-level type sizes in Sourcify.
- Keep verification on one immutable path: `extractImmutablesTransformation` receives one `ImmutableReferences` object and applies the existing Vyper insert transformation only after runtime tail sanity checks pass.
- Apply those Vyper tail checks uniformly to legacy and modern Vyper immutables.

## Why

Vyper added `immutable(...)` in `0.3.1`, but it did not add the newer initcode/runtime layout metadata, including immutable section size, until `0.3.10` via [vyperlang/vyper#3584](https://github.com/vyperlang/vyper/pull/3584).

For affected legacy contracts, the deployed runtime can be:

```text
recompiled_runtime || immutable_tail
```

The old Vyper runtime metadata trailer is still inside `recompiled_runtime`, and the immutable payload is appended after it. Because pre-`0.3.10` metadata does not tell Sourcify how large that payload should be, these contracts fall through to plain bytecode comparison and fail with a deployed-vs-recompiled mismatch.

Vyper `>= 0.3.10` immutables were already supported through CBOR auxdata decoding. This PR keeps that modern path and adds legacy reference inference for `0.3.1` through `0.3.9`.

Concrete failing Vyper `0.3.7` examples from the observed bytecode-mismatch set:

- `0x0164df8d03e9e337497b3ce49d7736696054b92b`
- `0x19198c82f57f4613ef3b7fea2d268b44a4fc33a9`
- `0x1d43e85ff803938cc8f9d13b8c194a27bb59f7ef`
- `0x1d47ccdd400e56ec3517ac3f14a01601e4192ae6`
- `0x20c8602f5df730f93e298a0492777412935f37aa`
- `0x2106c2d7d321e434c1e37697a22575b497c32272`

For example, `0x0164df8d03e9e337497b3ce49d7736696054b92b` recompiles to a `248` byte runtime with Vyper `0.3.7`, while the deployed runtime is `280` bytes. The extra `32` bytes are the appended immutable value:

```text
0x000000000000000000000000216ce6e49e2e713e41383ba4c5d84a0d36189640
```

The local corpus also has exact `0.3.1` sources with active `immutable(...)` declarations, so this PR keeps the Vyper feature floor instead of dropping `0.3.1` support.

## Chosen Approach

Compilation now produces immutable references for both Vyper eras:

1. For `>= 0.3.10`, Sourcify keeps decoding `immutableSize` from Vyper creation-bytecode CBOR auxdata.
2. For `0.3.2 <= version < 0.3.10`, Vyper Standard JSON emits structured IR. The deploy node contains the compiler-resolved immutable size at `deploy[2]`; contracts without immutable data use `0`.
3. For `0.3.1`, Vyper Standard JSON emits old LLL text. The compiler-generated constructor return has the stable shape:

```text
[return, <memory_start>, [add, <immutable_tail_bytes>, _lllsz]]
```

4. Sourcify accepts a legacy immutable size only when exactly one positive, `32`-byte-aligned size signal is found.
5. `VyperCompilation.immutableReferences` returns one synthetic reference keyed by `"0"`, with `start` equal to the compiler runtime length and `length` equal to the compiler-derived immutable tail size.
6. Verification uses that normal reference object and appends the observed on-chain immutable bytes before bytecode comparison.

Using IR avoids hand-maintaining Vyper type-size logic in Sourcify. It also handles compiler-resolved constants in immutable array bounds, structs, arrays, and other supported immutable layouts because Vyper has already lowered the final immutable section size.

## Safety Conditions

The IR-derived legacy size must be positive, word-aligned, and unambiguous. Then, during verification, all Vyper immutable references are accepted only when:

- The deployed runtime is strictly longer than the populated recompiled runtime.
- The deployed runtime starts with the populated recompiled runtime.
- The appended byte length exactly equals the total compiler-derived immutable reference length.
- The references describe a contiguous tail starting at the end of the recompiled runtime.

If any check fails, Sourcify records no immutable transformation and keeps the existing bytecode comparison behavior.

This also addresses false-positive risk. A no-immutable structured IR signal (`deploy[2] = 0`) is ignored. Even if a future compiler shape accidentally produced a positive false signal, an already matching runtime has no appended tail, so the verifier records no phantom immutable. A prefix drift or wrong tail length also records no transformation, and the final bytecode comparison remains the correctness backstop.

## Limitations

- This handles append-only legacy Vyper immutable tails. It does not normalize unrelated legacy Vyper codegen instability, such as function/helper ordering differences in some `0.3.7` outputs. See [vyperlang/vyper#3369](https://github.com/vyperlang/vyper/issues/3369) for one known source of ordering instability.
- The immutable transformation accepts deployed immutable bytes as observed runtime data, matching Sourcify's existing Vyper runtime-side semantics. It does not prove constructor assignment semantics.
- The `0.3.1` path necessarily parses text LLL because that compiler version does not expose structured IR through Standard JSON. The parser is intentionally narrow and fails closed on ambiguity.

## Checks

- Focused Vyper immutable tests: `19 passing`
- `Transformations.spec.ts`: `17 passing`
- Prettier check on touched files
- ESLint on touched files
- `lerna run build --scope=@ethereum-sourcify/lib-sourcify --include-dependencies`
