### PR TITLE
Reduce standard JSON input to the fields we store

### DIFF
--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -781,12 +781,8 @@ export class Verification {
         creationBytecodeCborAuxdata,
         immutableReferences: immutableReferences,
         metadata,
-        jsonInput: {
-          settings,
-          ...(Object.keys(additionalInput).length > 0
-            ? { additionalInput }
-            : {}),
-        },
+        jsonInput: { settings },
+        ...(Object.keys(additionalInput).length > 0 ? { additionalInput } : {}),
         compilationTime: this.compilation.compilationTime,
       },
     };

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -33,7 +33,6 @@ import type {
 } from './VerificationTypes';
 import { SolidityBugType, VerificationError } from './VerificationTypes';
 import type {
-  VyperJsonInput,
   VyperOutputContract,
   ImmutableReferences,
   SolidityOutputContract,
@@ -725,6 +724,13 @@ export class Verification {
       // pass
     }
 
+    // Surface every top-level standard JSON input field used for compilation other than
+    // language/sources/settings (e.g. Vyper's `storage_layout_overrides`) so consumers can
+    // persist them.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { language, sources, settings, ...additionalInput } =
+      this.compilation.jsonInput;
+
     return {
       address: this.address,
       chainId: this.chainId,
@@ -776,14 +782,9 @@ export class Verification {
         immutableReferences: immutableReferences,
         metadata,
         jsonInput: {
-          settings: this.compilation.jsonInput.settings,
-          ...((this.compilation.jsonInput as VyperJsonInput)
-            .storage_layout_overrides
-            ? {
-                storageLayoutOverrides: (
-                  this.compilation.jsonInput as VyperJsonInput
-                ).storage_layout_overrides,
-              }
+          settings,
+          ...(Object.keys(additionalInput).length > 0
+            ? { additionalInput }
             : {}),
         },
         compilationTime: this.compilation.compilationTime,

--- a/packages/lib-sourcify/src/Verification/VerificationTypes.ts
+++ b/packages/lib-sourcify/src/Verification/VerificationTypes.ts
@@ -134,10 +134,9 @@ export interface VerificationExport {
     metadata?: Metadata;
     jsonInput: {
       settings: SoliditySettings | VyperSettings | FeSettings;
-      // Top-level standard JSON input fields used for compilation other than language/sources/settings.
-      additionalInput?: {
-        storage_layout_overrides?: VyperJsonInput['storage_layout_overrides'];
-      };
+    };
+    additionalInput?: {
+      storage_layout_overrides?: VyperJsonInput['storage_layout_overrides'];
     };
     compilationTime?: number;
   };

--- a/packages/lib-sourcify/src/Verification/VerificationTypes.ts
+++ b/packages/lib-sourcify/src/Verification/VerificationTypes.ts
@@ -134,7 +134,10 @@ export interface VerificationExport {
     metadata?: Metadata;
     jsonInput: {
       settings: SoliditySettings | VyperSettings | FeSettings;
-      storageLayoutOverrides?: VyperJsonInput['storage_layout_overrides'];
+      // Top-level standard JSON input fields used for compilation other than language/sources/settings.
+      additionalInput?: {
+        storage_layout_overrides?: VyperJsonInput['storage_layout_overrides'];
+      };
     };
     compilationTime?: number;
   };

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -1626,7 +1626,7 @@ describe('Verification Class Tests', () => {
       });
 
       const exported = verification.export();
-      expect(exported.compilation.jsonInput.additionalInput).to.deep.equal({
+      expect(exported.compilation.additionalInput).to.deep.equal({
         storage_layout_overrides: storageLayoutOverrides,
       });
     });

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -1626,9 +1626,9 @@ describe('Verification Class Tests', () => {
       });
 
       const exported = verification.export();
-      expect(
-        exported.compilation.jsonInput.storageLayoutOverrides,
-      ).to.deep.equal(storageLayoutOverrides);
+      expect(exported.compilation.jsonInput.additionalInput).to.deep.equal({
+        storage_layout_overrides: storageLayoutOverrides,
+      });
     });
 
     it('should export Vyper storage layout and sourceMaps', async () => {

--- a/services/server/src/apiv2.yaml
+++ b/services/server/src/apiv2.yaml
@@ -387,6 +387,8 @@ components:
                   Full [standard JSON object](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description) to pass to the compiler. 
 
                   Must include the `language` field inside the stdJsonInput object. Currently supports Solidity, Vyper, and Fe.
+
+                  Only top-level fields that Sourcify stores are accepted: `language`, `sources`, `settings`, and `storage_layout_overrides` (Vyper).
               compilerVersion:
                 $ref: "#/components/schemas/CompilerVersion"
               contractIdentifier:

--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -9,7 +9,10 @@ import {
   InvalidParametersError,
 } from "./errors";
 import { getAddress } from "ethers";
-import { FIELDS_TO_STORED_PROPERTIES } from "../services/utils/database-util";
+import {
+  FIELDS_TO_STORED_PROPERTIES,
+  SUPPORTED_ADDITIONAL_INPUT_FIELDS,
+} from "../services/utils/database-util";
 import { reduceAccessorStringToProperty } from "../services/utils/util";
 import type { Services } from "../services/services";
 import type {
@@ -165,6 +168,31 @@ export function validateStandardJsonInput(
   if (Object.values(stdJsonInput.sources).some((source) => !source.content)) {
     throw new InvalidParametersError(
       "Standard JSON input must contain a content field for each source.",
+    );
+  }
+
+  // Reject any top-level field we don't store in the database. Fields we don't persist
+  // can still change the compiler output (e.g. Vyper's `interfaces`), which would make
+  // the contract impossible to recompile from stored data. We only accept the core
+  // fields plus the additional input fields the DB can store. This mirrors the DB
+  // `validate_additional_input` CHECK constraint and surfaces a clear 400 instead of a
+  // generic 500 from the constraint.
+  const allowedTopLevelFields = [
+    "language",
+    "sources",
+    "settings",
+    ...SUPPORTED_ADDITIONAL_INPUT_FIELDS,
+  ];
+  const unsupportedFields = Object.keys(stdJsonInput).filter(
+    (field) => !allowedTopLevelFields.includes(field),
+  );
+  if (unsupportedFields.length > 0) {
+    throw new InvalidParametersError(
+      `Standard JSON input contains unsupported top-level field(s): ${unsupportedFields.join(
+        ", ",
+      )}. Only the following top-level fields are supported: ${allowedTopLevelFields.join(
+        ", ",
+      )}.`,
     );
   }
 

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -497,6 +497,15 @@ type proxyResolutionSubfields = keyof Partial<
   VerifiedContractApiObject["proxyResolution"]
 >;
 
+// Top-level standard JSON input fields (besides language/sources/settings) that the
+// database can store in the `compiled_contracts.additional_input` column. The API
+// rejects any other top-level field for better UX, while the DB CHECK constraint
+// `validate_additional_input` remains the authoritative backstop. Keep this list in
+// sync with that constraint (services/database/database-specs/migrations).
+export const SUPPORTED_ADDITIONAL_INPUT_FIELDS = [
+  "storage_layout_overrides",
+] as const;
+
 // used for API v2 GET contract endpoint
 export const FIELDS_TO_STORED_PROPERTIES: Record<
   keyof Omit<
@@ -888,13 +897,8 @@ export async function getDatabaseColumnsFromVerification(
       compilation_artifacts: compilationArtifacts,
       creation_code_artifacts: creationCodeArtifacts,
       runtime_code_artifacts: runtimeCodeArtifacts,
-      additional_input: verification.compilation.jsonInput
-        .storageLayoutOverrides
-        ? {
-            storage_layout_overrides:
-              verification.compilation.jsonInput.storageLayoutOverrides,
-          }
-        : null,
+      additional_input:
+        verification.compilation.jsonInput.additionalInput ?? null,
     },
     sourcesInformation,
     verifiedContract: {

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -509,15 +509,6 @@ type proxyResolutionSubfields = keyof Partial<
   VerifiedContractApiObject["proxyResolution"]
 >;
 
-// Top-level standard JSON input fields (besides language/sources/settings) that the
-// database can store in the `compiled_contracts.additional_input` column. The API
-// rejects any other top-level field for better UX, while the DB CHECK constraint
-// `validate_additional_input` remains the authoritative backstop. Keep this list in
-// sync with that constraint (services/database/database-specs/migrations).
-export const SUPPORTED_ADDITIONAL_INPUT_FIELDS = [
-  "storage_layout_overrides",
-] as const;
-
 // used for API v2 GET contract endpoint
 export const FIELDS_TO_STORED_PROPERTIES: Record<
   keyof Omit<

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -900,8 +900,7 @@ export async function getDatabaseColumnsFromVerification(
       compilation_artifacts: compilationArtifacts,
       creation_code_artifacts: creationCodeArtifacts,
       runtime_code_artifacts: runtimeCodeArtifacts,
-      additional_input:
-        verification.compilation.jsonInput.additionalInput ?? null,
+      additional_input: verification.compilation.additionalInput ?? null,
     },
     sourcesInformation,
     verifiedContract: {

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -46,6 +46,18 @@ import { keccak256 } from "ethers";
 import { SignatureType } from "./signature-util";
 import type { EtherscanVerifyApiIdentifiers } from "../storageServices/EtherscanVerifyApiService";
 
+// Top-level standard JSON input fields (besides language/sources/settings) that the
+// database can store in the `compiled_contracts.additional_input` column. The API
+// rejects any other top-level field for better UX, while the DB CHECK constraint
+// `validate_additional_input` remains the authoritative backstop. Keep this list in
+// sync with that constraint (services/database/database-specs/migrations).
+export const SUPPORTED_ADDITIONAL_INPUT_FIELDS = [
+  "storage_layout_overrides",
+] as const;
+
+type SupportedAdditionalInputField =
+  (typeof SUPPORTED_ADDITIONAL_INPUT_FIELDS)[number];
+
 export type JobErrorData = Omit<SourcifyLibErrorData, "chainId" | "address">;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -103,9 +115,9 @@ export namespace Tables {
       immutableReferences: Nullable<ImmutableReferences>;
       cborAuxdata: Nullable<CompiledContractCborAuxdata>;
     };
-    additional_input: Nullable<{
-      storage_layout_overrides?: VyperJsonInput["storage_layout_overrides"];
-    }>;
+    additional_input: Nullable<
+      Partial<Pick<VyperJsonInput, SupportedAdditionalInputField>>
+    >;
   }
 
   export interface VerifiedContract {

--- a/services/server/test/integration/apiv2/verification/verify.json.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.json.spec.ts
@@ -461,6 +461,37 @@ describe("POST /v2/verify/:chainId/:address", function () {
     chai.expect(verifyRes.body).to.have.property("message");
   });
 
+  it("should return a 400 if the standard json input contains an unsupported top-level field", async () => {
+    const jsonInput = JSON.parse(
+      JSON.stringify(chainFixture.defaultContractJsonInput),
+    );
+    // `interfaces` is a Vyper top-level field that Sourcify does not store. Such fields
+    // can change the compiler output and would make the contract impossible to recompile
+    // from stored data, so they must be rejected at the API.
+    jsonInput.interfaces = { "IFoo.json": { abi: [] } };
+
+    const verifyRes = await chai
+      .request(serverFixture.server.app)
+      .post(
+        `/v2/verify/${chainFixture.chainId}/${chainFixture.defaultContractAddress}`,
+      )
+      .send({
+        stdJsonInput: jsonInput,
+        compilerVersion:
+          chainFixture.defaultContractMetadataObject.compiler.version,
+        contractIdentifier: Object.entries(
+          chainFixture.defaultContractMetadataObject.settings.compilationTarget,
+        )[0].join(":"),
+        creationTransactionHash: chainFixture.defaultContractCreatorTx,
+      });
+
+    chai.expect(verifyRes.status).to.equal(400);
+    chai.expect(verifyRes.body.customCode).to.equal("invalid_parameter");
+    chai.expect(verifyRes.body.message).to.include("interfaces");
+    chai.expect(verifyRes.body).to.have.property("errorId");
+    chai.expect(verifyRes.body).to.have.property("message");
+  });
+
   it("should return 400 when contract identifier is missing", async () => {
     const verifyRes = await chai
       .request(serverFixture.server.app)

--- a/services/server/test/integration/apiv2/verification/verify.json.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.json.spec.ts
@@ -465,10 +465,10 @@ describe("POST /v2/verify/:chainId/:address", function () {
     const jsonInput = JSON.parse(
       JSON.stringify(chainFixture.defaultContractJsonInput),
     );
-    // `interfaces` is a Vyper top-level field that Sourcify does not store. Such fields
-    // can change the compiler output and would make the contract impossible to recompile
-    // from stored data, so they must be rejected at the API.
-    jsonInput.interfaces = { "IFoo.json": { abi: [] } };
+    // Any top-level field Sourcify does not store can change the compiler output and would
+    // make the contract impossible to recompile from stored data, so it must be rejected at
+    // the API.
+    jsonInput.someUnsupportedField = { foo: "bar" };
 
     const verifyRes = await chai
       .request(serverFixture.server.app)
@@ -487,7 +487,7 @@ describe("POST /v2/verify/:chainId/:address", function () {
 
     chai.expect(verifyRes.status).to.equal(400);
     chai.expect(verifyRes.body.customCode).to.equal("invalid_parameter");
-    chai.expect(verifyRes.body.message).to.include("interfaces");
+    chai.expect(verifyRes.body.message).to.include("someUnsupportedField");
     chai.expect(verifyRes.body).to.have.property("errorId");
     chai.expect(verifyRes.body).to.have.property("message");
   });


### PR DESCRIPTION
See #2751

## Summary
- **lib-sourcify**: the `Verification` export now forwards *all* top-level standard JSON input fields other than `language`/`sources`/`settings` via `additionalInput` (previously it kept only `storage_layout_overrides`). Nothing used for compilation is silently dropped, which matters for the library's other consumers too.
- **server**: the `/v2/verify` API now rejects any unsupported top-level input field (anything outside `language`/`sources`/`settings` + `storage_layout_overrides`) with a clear `400`, instead of failing later with a generic `500` from the DB constraint.

## Why
Unsupported fields such as Vyper's `interfaces` (#2750) change the compiler output but aren't persisted, making the contract impossible to recompile from the database. The API allowlist mirrors the DB `validate_additional_input` CHECK constraint, which stays as the authoritative backstop — so no migration is needed.