### PR TITLE
fix(server): don't send global ETHERSCAN_API_KEY to custom Etherscan explorers

### DIFF
--- a/services/server/src/openapi.yaml
+++ b/services/server/src/openapi.yaml
@@ -144,6 +144,10 @@ paths:
                       type: boolean
                       description: Whether Etherscan API is available for this chain
                       example: true
+                    etherscanApiUrl:
+                      type: string
+                      description: Custom Etherscan-compatible explorer API URL, if the chain uses one instead of the canonical api.etherscan.io. Omitted for canonical Etherscan chains.
+                      example: "https://block-explorer-api.testnet.battlechain.com"
                   required:
                     - name
                     - chainId

--- a/services/server/src/server/routes.ts
+++ b/services/server/src/server/routes.ts
@@ -77,6 +77,10 @@ router.get("/chains", (_req, res) => {
           .filter((r) => r !== null),
         supported,
         etherscanAPI: etherscanApi?.supported ?? false, // Needed in the UI
+        // Custom Etherscan-compatible explorer API URL, if the chain uses one
+        // instead of the canonical api.etherscan.io. The UI needs this to
+        // import contracts from the right explorer.
+        etherscanApiUrl: etherscanApi?.url,
       };
     },
   );

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -271,10 +271,15 @@ export const getCreatorTx = async (
     sourcifyChain.fetchContractCreationTxUsing?.etherscanApi &&
     sourcifyChain?.etherscanApi?.supported
   ) {
-    const apiKey =
-      process.env[sourcifyChain.etherscanApi.apiKeyEnvName || ""] ||
-      process.env.ETHERSCAN_API_KEY ||
-      "";
+    // Only fall back to the global ETHERSCAN_API_KEY for canonical etherscan.io
+    // chains. Custom Etherscan-compatible explorers (those with a `url`) must
+    // not receive it — that would leak our etherscan.io key to a third party.
+    const chainSpecificKey =
+      process.env[sourcifyChain.etherscanApi.apiKeyEnvName || ""];
+    const globalKey = sourcifyChain.etherscanApi.url
+      ? undefined
+      : process.env.ETHERSCAN_API_KEY;
+    const apiKey = chainSpecificKey || globalKey || "";
     const fetcher = getEtherscanApiContractCreatorFetcher(
       apiKey,
       sourcifyChain.chainId,

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -1,6 +1,7 @@
 import type { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import { StatusCodes } from "http-status-codes";
 import logger from "../../../common/logger";
+import { deriveEtherscanApiKey } from "./etherscan-util";
 
 const ETHERSCAN_API =
   "https://api.etherscan.io/v2/api?chainid=${CHAIN_ID}&module=contract&action=getcontractcreation&contractaddresses=${ADDRESS}&apikey=";
@@ -271,15 +272,7 @@ export const getCreatorTx = async (
     sourcifyChain.fetchContractCreationTxUsing?.etherscanApi &&
     sourcifyChain?.etherscanApi?.supported
   ) {
-    // Only fall back to the global ETHERSCAN_API_KEY for canonical etherscan.io
-    // chains. Custom Etherscan-compatible explorers (those with a `url`) must
-    // not receive it — that would leak our etherscan.io key to a third party.
-    const chainSpecificKey =
-      process.env[sourcifyChain.etherscanApi.apiKeyEnvName || ""];
-    const globalKey = sourcifyChain.etherscanApi.url
-      ? undefined
-      : process.env.ETHERSCAN_API_KEY;
-    const apiKey = chainSpecificKey || globalKey || "";
+    const apiKey = deriveEtherscanApiKey(sourcifyChain);
     const fetcher = getEtherscanApiContractCreatorFetcher(
       apiKey,
       sourcifyChain.chainId,

--- a/services/server/src/server/services/utils/etherscan-util.ts
+++ b/services/server/src/server/services/utils/etherscan-util.ts
@@ -75,12 +75,18 @@ export const fetchFromEtherscanOrThrowError = async (
         : new BadRequestError(errorMessage);
     }
 
-    // Derive API key precedence: user -> chain-specific env -> global -> ''
-    const apiKey =
-      userApiKey ||
-      process.env[sourcifyChain.etherscanApi.apiKeyEnvName || ""] ||
-      process.env.ETHERSCAN_API_KEY ||
-      "";
+    // Derive API key precedence: user -> chain-specific env -> global -> ''.
+    // The global ETHERSCAN_API_KEY is only used for canonical etherscan.io
+    // chains. For custom Etherscan-compatible explorers (those with a `url`),
+    // we never fall back to it — that would leak our etherscan.io key to a
+    // third-party server. Such explorers only get a key explicitly configured
+    // for them via their own apiKeyEnvName.
+    const chainSpecificKey =
+      process.env[sourcifyChain.etherscanApi.apiKeyEnvName || ""];
+    const globalKey = sourcifyChain.etherscanApi.url
+      ? undefined
+      : process.env.ETHERSCAN_API_KEY;
+    const apiKey = userApiKey || chainSpecificKey || globalKey || "";
 
     return await EtherscanUtils.fetchFromEtherscan(
       sourcifyChain.chainId,

--- a/services/server/src/server/services/utils/etherscan-util.ts
+++ b/services/server/src/server/services/utils/etherscan-util.ts
@@ -59,6 +59,23 @@ function mapLibError(err: any, throwV2Errors: boolean): never {
   throw err;
 }
 
+// Derive the Etherscan API key with precedence: user -> chain-specific env -> global -> ''.
+// The global ETHERSCAN_API_KEY is only used for canonical etherscan.io chains. For custom
+// Etherscan-compatible explorers (those with a `url`), we never fall back to it — that would
+// leak our etherscan.io key to a third-party server. Such explorers only get a key explicitly
+// configured for them via their own apiKeyEnvName.
+export const deriveEtherscanApiKey = (
+  sourcifyChain: SourcifyChain,
+  userApiKey?: string,
+): string => {
+  const chainSpecificKey =
+    process.env[sourcifyChain.etherscanApi?.apiKeyEnvName || ""];
+  const globalKey = sourcifyChain.etherscanApi?.url
+    ? undefined
+    : process.env.ETHERSCAN_API_KEY;
+  return userApiKey || chainSpecificKey || globalKey || "";
+};
+
 // Fetches contract data from Etherscan and maps any errors to appropriate server errors (v1 or v2)
 export const fetchFromEtherscanOrThrowError = async (
   sourcifyChain: SourcifyChain,
@@ -75,18 +92,7 @@ export const fetchFromEtherscanOrThrowError = async (
         : new BadRequestError(errorMessage);
     }
 
-    // Derive API key precedence: user -> chain-specific env -> global -> ''.
-    // The global ETHERSCAN_API_KEY is only used for canonical etherscan.io
-    // chains. For custom Etherscan-compatible explorers (those with a `url`),
-    // we never fall back to it — that would leak our etherscan.io key to a
-    // third-party server. Such explorers only get a key explicitly configured
-    // for them via their own apiKeyEnvName.
-    const chainSpecificKey =
-      process.env[sourcifyChain.etherscanApi.apiKeyEnvName || ""];
-    const globalKey = sourcifyChain.etherscanApi.url
-      ? undefined
-      : process.env.ETHERSCAN_API_KEY;
-    const apiKey = userApiKey || chainSpecificKey || globalKey || "";
+    const apiKey = deriveEtherscanApiKey(sourcifyChain, userApiKey);
 
     return await EtherscanUtils.fetchFromEtherscan(
       sourcifyChain.chainId,

--- a/services/server/test/integration/status-handlers.spec.ts
+++ b/services/server/test/integration/status-handlers.spec.ts
@@ -15,6 +15,15 @@ describe("Verify server status endpoint", function () {
   it("should check server's chains", async function () {
     const res = await chai.request(serverFixture.server.app).get("/chains");
     chai.expect(res.body.length).greaterThan(0);
+    // Every chain exposes etherscanAPI as a boolean, and when a chain uses a
+    // custom Etherscan-compatible explorer it exposes that explorer's API URL
+    // as a non-empty string (omitted for canonical etherscan.io chains).
+    for (const chain of res.body) {
+      chai.expect(chain.etherscanAPI).to.be.a("boolean");
+      if (chain.etherscanApiUrl !== undefined) {
+        chai.expect(chain.etherscanApiUrl).to.be.a("string").and.not.empty;
+      }
+    }
   });
 
   it("should return version information", async function () {

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -134,6 +134,66 @@ describe("contract creation util", function () {
       );
   });
 
+  describe("Etherscan API key handling for getCreatorTx", function () {
+    const ADDRESS = "0x0000000000000000000000000000000000000001";
+    const GLOBAL_KEY = "SECRET_GLOBAL_ETHERSCAN_KEY";
+    let prevGlobalKey: string | undefined;
+    let fetchStub: sinon.SinonStub;
+
+    beforeEach(function () {
+      prevGlobalKey = process.env.ETHERSCAN_API_KEY;
+      process.env.ETHERSCAN_API_KEY = GLOBAL_KEY;
+      fetchStub = sinon.stub(global, "fetch" as any).resolves({
+        status: 200,
+        json: async () => ({ result: [{ txHash: "0xabc" }] }),
+      } as any);
+    });
+
+    afterEach(function () {
+      fetchStub.restore();
+      if (prevGlobalKey === undefined) delete process.env.ETHERSCAN_API_KEY;
+      else process.env.ETHERSCAN_API_KEY = prevGlobalKey;
+    });
+
+    it("should NOT send the global ETHERSCAN_API_KEY to a custom Etherscan-compatible explorer (with url)", async function () {
+      const chain = new SourcifyChain({
+        name: "Custom Explorer Chain",
+        chainId: 999999,
+        supported: true,
+        rpcs: [{ rpc: "http://localhost/" }],
+        fetchContractCreationTxUsing: { etherscanApi: true },
+        etherscanApi: {
+          supported: true,
+          url: "https://block-explorer-api.testnet.battlechain.com",
+        },
+      });
+
+      await getCreatorTx(chain, ADDRESS);
+
+      chai.expect(fetchStub.calledOnce).to.equal(true);
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      chai.expect(calledUrl).to.not.include(GLOBAL_KEY);
+      chai.expect(calledUrl.endsWith("&apikey=")).to.equal(true);
+    });
+
+    it("should send the global ETHERSCAN_API_KEY to a canonical Etherscan chain (no url)", async function () {
+      const chain = new SourcifyChain({
+        name: "Canonical Etherscan Chain",
+        chainId: 1,
+        supported: true,
+        rpcs: [{ rpc: "http://localhost/" }],
+        fetchContractCreationTxUsing: { etherscanApi: true },
+        etherscanApi: { supported: true },
+      });
+
+      await getCreatorTx(chain, ADDRESS);
+
+      chai.expect(fetchStub.calledOnce).to.equal(true);
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      chai.expect(calledUrl).to.include(GLOBAL_KEY);
+    });
+  });
+
   // Test each fetchContractCreationTxUsing method
   // We can use the Mainnet to test all below as all support Mainnet
   const testCases: {


### PR DESCRIPTION
## Problem

A chain can opt into Etherscan support via a custom explorer URL (`etherscanApi.url`) — used for Etherscan-compatible explorers that aren't on etherscan.io (e.g. BattleChain's `https://block-explorer-api.testnet.battlechain.com`).

In both the source-import path (`etherscan-util.ts`) and the contract-creation-tx path (`contract-creation-util.ts`), the API key was resolved as:

```
process.env[etherscanApi.apiKeyEnvName || ""] || process.env.ETHERSCAN_API_KEY || ""
```

When such a chain has no chain-specific `apiKeyEnvName`, this falls back to the global `ETHERSCAN_API_KEY` and appends it as `&apikey=<key>` to a request sent to the chain's own explorer host. That leaks our etherscan.io API key to a third-party server.

Separately, the custom explorer URL was never surfaced in the `/chains` API response, so the verification UI (verify.sourcify.dev) had no way to know a chain uses a non-canonical explorer and would always import from `api.etherscan.io`.

## Fix

**1. Don't leak the global key to custom explorers.** The global `ETHERSCAN_API_KEY` fallback now applies only to canonical etherscan.io chains (those without a custom `url`). Custom Etherscan-compatible explorers only receive a key explicitly configured for them via their own `apiKeyEnvName`; otherwise no key is sent (`&apikey=`).

Behavior for existing etherscan.io chains is unchanged.

**2. Expose the custom explorer URL in `/chains`.** The serialized chain object now includes an optional `etherscanApiUrl` field (sourced from `etherscanApi.url`), omitted for canonical Etherscan chains. This lets the UI import contracts from the correct explorer. OpenAPI spec updated accordingly.

> UI counterpart: sourcifyeth/verify.sourcify.dev#47 reads this `etherscanApiUrl` field and passes it through `EtherscanUtils.fetchFromEtherscan(..., customBaseUrl)`.

## Tests

- `contract-creation-util.spec.ts` (mocked `fetch`):
  - custom-`url` chain → outbound URL does not contain the global key (ends with `&apikey=`)
  - canonical chain (no `url`) → outbound URL does contain the global key
- `status-handlers.spec.ts`: asserts the `/chains` response exposes `etherscanAPI` as a boolean and `etherscanApiUrl`, when present, as a non-empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)