### PR TITLE
fix(bytecode-utils): expose Vyper auxdata style helper

### DIFF
--- a/packages/bytecode-utils/README.md
+++ b/packages/bytecode-utils/README.md
@@ -13,9 +13,10 @@ yarn add @ethereum-sourcify/bytecode-utils
 ### Solidity Contracts
 
 ```ts
-import { decode, AuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
+import { decode, AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 
-const bytecodeRaw = "0x60806040526004361061003f5760003560e01...7265206c656e677468a2646970667358221220dceca8706b29e917dacf25fceef95acac8d90d765ac926663ce4096195952b6164736f6c634300060b0033"
+const bytecodeRaw =
+  '0x60806040526004361061003f5760003560e01...7265206c656e677468a2646970667358221220dceca8706b29e917dacf25fceef95acac8d90d765ac926663ce4096195952b6164736f6c634300060b0033';
 
 // For Solidity contracts
 decode(bytecodeRaw, AuxdataStyle.SOLIDITY);
@@ -36,12 +37,11 @@ decode(bytecodeRaw, AuxdataStyle.SOLIDITY);
 ### Vyper Contracts
 
 ```ts
-import { decode, AuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
+import { decode, getAuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
 
-const vyperBytecodeRaw = "0x..."; // Your Vyper contract bytecode
+const vyperBytecodeRaw = '0x...'; // Your Vyper contract bytecode
 
-// For Vyper contracts
-decode(vyperBytecodeRaw, AuxdataStyle.VYPER);
+decode(vyperBytecodeRaw, getAuxdataStyle('Vyper', '0.4.1'));
 ```
 
 **Result example**
@@ -60,7 +60,8 @@ decode(vyperBytecodeRaw, AuxdataStyle.VYPER);
 
 Different Vyper compiler versions use different auxdata formats:
 
-- **Before v0.3.5**: Auxdata only contains version information in cbor, without length data after it
-- **v0.3.5 to v0.3.9**: Auxdata includes version and length information in cbor
-- **v0.3.10 to v0.4.0**: Auxdata is stored as a cbor array with version object as last element
-- **v0.4.1 and later**: Auxdata cbor array includes integrity check as first element
+- `<0.3.4`: no CBOR auxdata
+- `0.3.4`: CBOR map `{"vyper": [0, 3, 4]}` with no length footer
+- `0.3.5-0.3.9`: CBOR map `{"vyper": [...]}` plus length footer
+- `0.3.10-0.4.0`: CBOR array `[runtimeSize, dataSizes, immutableSize, {"vyper": [...]}]`
+- `>=0.4.1`: CBOR array `[integrity, runtimeSize, dataSizes, immutableSize, {"vyper": [...]}]`

--- a/packages/bytecode-utils/README.md
+++ b/packages/bytecode-utils/README.md
@@ -13,10 +13,9 @@ yarn add @ethereum-sourcify/bytecode-utils
 ### Solidity Contracts
 
 ```ts
-import { decode, AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
+import { decode, AuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
 
-const bytecodeRaw =
-  '0x60806040526004361061003f5760003560e01...7265206c656e677468a2646970667358221220dceca8706b29e917dacf25fceef95acac8d90d765ac926663ce4096195952b6164736f6c634300060b0033';
+const bytecodeRaw = "0x60806040526004361061003f5760003560e01...7265206c656e677468a2646970667358221220dceca8706b29e917dacf25fceef95acac8d90d765ac926663ce4096195952b6164736f6c634300060b0033"
 
 // For Solidity contracts
 decode(bytecodeRaw, AuxdataStyle.SOLIDITY);
@@ -37,11 +36,12 @@ decode(bytecodeRaw, AuxdataStyle.SOLIDITY);
 ### Vyper Contracts
 
 ```ts
-import { decode, getAuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
+import { decode, getAuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
 
-const vyperBytecodeRaw = '0x...'; // Your Vyper contract bytecode
+const vyperBytecodeRaw = "0x..."; // Your Vyper contract bytecode
 
-decode(vyperBytecodeRaw, getAuxdataStyle('Vyper', '0.4.1'));
+// For Vyper contracts
+decode(vyperBytecodeRaw, getAuxdataStyle("Vyper", "0.4.1"));
 ```
 
 **Result example**

--- a/packages/bytecode-utils/src/lib/bytecode.ts
+++ b/packages/bytecode-utils/src/lib/bytecode.ts
@@ -36,6 +36,55 @@ export enum AuxdataStyle {
   FE = 'fe',
 }
 
+export const getVyperAuxdataStyle = (
+  compilerVersion: string,
+):
+  | AuxdataStyle.VYPER_LT_0_3_4
+  | AuxdataStyle.VYPER_LT_0_3_5
+  | AuxdataStyle.VYPER_LT_0_3_10
+  | AuxdataStyle.VYPER => {
+  const coercedVersion = semver.coerce(compilerVersion);
+  if (!coercedVersion) {
+    throw Error(`Invalid Vyper compiler version: ${compilerVersion}`);
+  }
+
+  const version = coercedVersion.version;
+  // Vyper versions < 0.3.4 emit no CBOR auxdata at all.
+  if (semver.lt(version, '0.3.4')) {
+    return AuxdataStyle.VYPER_LT_0_3_4;
+  }
+  // Only 0.3.4 uses the fixed-length 22-byte CBOR format.
+  if (semver.lt(version, '0.3.5')) {
+    return AuxdataStyle.VYPER_LT_0_3_5;
+  }
+  if (semver.lt(version, '0.3.10')) {
+    return AuxdataStyle.VYPER_LT_0_3_10;
+  }
+  return AuxdataStyle.VYPER;
+};
+
+export const getAuxdataStyle = (
+  language: string,
+  compilerVersion?: string,
+): AuxdataStyle => {
+  switch (language.toLowerCase()) {
+    case 'solidity':
+    case 'yul':
+      return AuxdataStyle.SOLIDITY;
+    case 'vyper':
+      if (!compilerVersion) {
+        throw Error(
+          'Vyper compiler version is required to determine auxdata style',
+        );
+      }
+      return getVyperAuxdataStyle(compilerVersion);
+    case 'fe':
+      return AuxdataStyle.FE;
+    default:
+      throw Error(`Unsupported language for auxdata style: ${language}`);
+  }
+};
+
 /**
  * Decode contract's bytecode
  * @param bytecode - hex of the bytecode with 0x prefix

--- a/packages/bytecode-utils/test/bytecode.spec.ts
+++ b/packages/bytecode-utils/test/bytecode.spec.ts
@@ -2,7 +2,13 @@ import chai from 'chai';
 import { readFileSync } from 'fs';
 import path from 'path';
 
-import { AuxdataStyle, decode, splitAuxdata } from '../src/lib/bytecode';
+import {
+  AuxdataStyle,
+  decode,
+  getAuxdataStyle,
+  getVyperAuxdataStyle,
+  splitAuxdata,
+} from '../src/lib/bytecode';
 
 type Error = {
   message: string;
@@ -144,6 +150,31 @@ describe('bytecode utils', function () {
       .to.deep.equal({
         vyperVersion: '0.3.4',
       });
+  });
+
+  it('selects Vyper auxdata style from compiler version history', () => {
+    chai
+      .expect(getVyperAuxdataStyle('0.3.3'))
+      .to.equal(AuxdataStyle.VYPER_LT_0_3_4);
+    chai
+      .expect(getVyperAuxdataStyle('0.3.4'))
+      .to.equal(AuxdataStyle.VYPER_LT_0_3_5);
+    chai
+      .expect(getVyperAuxdataStyle('0.3.8+commit.036f1536'))
+      .to.equal(AuxdataStyle.VYPER_LT_0_3_10);
+    chai
+      .expect(getVyperAuxdataStyle('vyper:0.3.10'))
+      .to.equal(AuxdataStyle.VYPER);
+    chai.expect(getVyperAuxdataStyle('v0.4.1rc1')).to.equal(AuxdataStyle.VYPER);
+  });
+
+  it('selects auxdata style from language and compiler version', () => {
+    chai.expect(getAuxdataStyle('Solidity')).to.equal(AuxdataStyle.SOLIDITY);
+    chai.expect(getAuxdataStyle('Yul')).to.equal(AuxdataStyle.SOLIDITY);
+    chai.expect(getAuxdataStyle('Fe')).to.equal(AuxdataStyle.FE);
+    chai
+      .expect(getAuxdataStyle('Vyper', '0.3.4'))
+      .to.equal(AuxdataStyle.VYPER_LT_0_3_5);
   });
 
   it('split Vyper bytecode (>= 0.4.1) into execution bytecode and auxdata', () => {

--- a/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/VyperCompilation.ts
@@ -3,6 +3,7 @@ import { AbstractCompilation } from './AbstractCompilation';
 import {
   AuxdataStyle,
   decode,
+  getVyperAuxdataStyle,
   splitAuxdata,
   type VyperDecodedObject,
 } from '@ethereum-sourcify/bytecode-utils';
@@ -65,18 +66,7 @@ export function returnAuxdataStyle(
   | AuxdataStyle.VYPER_LT_0_3_5
   | AuxdataStyle.VYPER_LT_0_3_10
   | AuxdataStyle.VYPER {
-  // Vyper versions < 0.3.4 emit no CBOR auxdata at all
-  if (semver.lt(compilerVersion, '0.3.4')) {
-    return AuxdataStyle.VYPER_LT_0_3_4;
-  }
-  // Only 0.3.4 uses the fixed-length 22-byte CBOR format
-  if (semver.lt(compilerVersion, '0.3.5')) {
-    return AuxdataStyle.VYPER_LT_0_3_5;
-  }
-  if (semver.lt(compilerVersion, '0.3.10')) {
-    return AuxdataStyle.VYPER_LT_0_3_10;
-  }
-  return AuxdataStyle.VYPER;
+  return getVyperAuxdataStyle(compilerVersion);
 }
 
 export function returnImmutableReferences(


### PR DESCRIPTION
## Summary

This adds a shared helper for selecting the correct bytecode auxdata decoder style from `language` and `compilerVersion`, with Vyper-specific version handling centralized in `@ethereum-sourcify/bytecode-utils`.

## Root Cause

Frontend or tooling callers can currently import `decode()` and `AuxdataStyle`, but they have to know Sourcify's Vyper auxdata history themselves. If a Vyper auxdata value is decoded with `AuxdataStyle.SOLIDITY`, Vyper `>=0.3.10` can fail because the trailing length footer uses different semantics, and older Vyper versions can render as generic raw CBOR instead of a normalized `vyperVersion`.

## Changes

- Add `getVyperAuxdataStyle(compilerVersion)` for Vyper's known auxdata ranges:
  - `<0.3.4`: no CBOR auxdata
  - `0.3.4`: CBOR map without a length footer
  - `0.3.5-0.3.9`: CBOR map with a length footer
  - `0.3.10-0.4.0`: CBOR layout array
  - `>=0.4.1`: CBOR layout array with integrity hash
- Add `getAuxdataStyle(language, compilerVersion)` for UI/tooling callers.
- Reuse the shared helper from `lib-sourcify`'s Vyper compilation path.
- Update bytecode-utils docs and tests for the version boundaries.

## Validation

- `npm test --workspace @ethereum-sourcify/bytecode-utils`
- `npm run check --workspace @ethereum-sourcify/bytecode-utils`
- `npm run check --workspace @ethereum-sourcify/lib-sourcify`
- `npm run build --workspace @ethereum-sourcify/bytecode-utils`
- `npm run build --workspace @ethereum-sourcify/compilers-types`
- `npm run build --workspace @ethereum-sourcify/lib-sourcify`
