### PR TITLE
Fix OIDC trusted npm publishing by upgrading npm in CircleCI docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,11 @@ jobs:
     steps:
       - checkout
       - run:
+        name: Upgrade npm for OIDC trusted publishing
+        command: |
+          npm install -g npm@^11.5.1
+          npm --version
+      - run:
           name: install dependencies
           command: npm install
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,44 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -104,6 +142,44 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -136,23 +212,36 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.6.tgz",
-      "integrity": "sha512-RMCrCteiUwYTEv2G9zfP/BEuKHv57665vVieJyp9cf8VgilWxP/KrWVtMdfdDlIH8nFhvu3rIMc29z3ebGEZ1w==",
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -185,17 +274,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.21.tgz",
-      "integrity": "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==",
+      "version": "3.974.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
+      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.26",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.24.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -203,16 +292,29 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.47.tgz",
-      "integrity": "sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==",
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
+      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -220,17 +322,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.49.tgz",
-      "integrity": "sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
+      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -238,23 +340,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.54",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.54.tgz",
-      "integrity": "sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
+      "integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/credential-provider-env": "^3.972.47",
-        "@aws-sdk/credential-provider-http": "^3.972.49",
-        "@aws-sdk/credential-provider-login": "^3.972.53",
-        "@aws-sdk/credential-provider-process": "^3.972.47",
-        "@aws-sdk/credential-provider-sso": "^3.972.53",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.53",
-        "@aws-sdk/nested-clients": "^3.997.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -262,16 +364,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.53.tgz",
-      "integrity": "sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
+      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/nested-clients": "^3.997.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -279,21 +381,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.56.tgz",
-      "integrity": "sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.48.tgz",
+      "integrity": "sha512-QIbtJP0olSLZ2ImEu636pP+7JJbPfaL3xSJIFXhu472CWuondCc4bGOa8OeyhOFet8z4H1D/ZFKXc39FboWwYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.47",
-        "@aws-sdk/credential-provider-http": "^3.972.49",
-        "@aws-sdk/credential-provider-ini": "^3.972.54",
-        "@aws-sdk/credential-provider-process": "^3.972.47",
-        "@aws-sdk/credential-provider-sso": "^3.972.53",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.53",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -301,15 +403,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.47.tgz",
-      "integrity": "sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
+      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -317,17 +419,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.53.tgz",
-      "integrity": "sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
+      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/nested-clients": "^3.997.21",
-        "@aws-sdk/token-providers": "3.1069.0",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -335,16 +437,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.53.tgz",
-      "integrity": "sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
+      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/nested-clients": "^3.997.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -352,12 +454,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.25.tgz",
-      "integrity": "sha512-zcRjdhS46gQ+omEKod2Q83A+42dQlFgQP9GfsK2XcDCli8kzA3q1QH+hDpIZUDbKaXmkTSn0JG3WP5yds5j38g==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.17.tgz",
+      "integrity": "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.52",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -365,12 +470,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.21.tgz",
-      "integrity": "sha512-LmmKxy26I++tBdJVTGnghGFff2xrv+vryfKfbxoRb1la50DY77N1ePclYdDat8/tO6nRXA2EFXUBjY72jfHEcw==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.14.tgz",
+      "integrity": "sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.52",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -378,12 +485,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.31.tgz",
-      "integrity": "sha512-Yzj6NRYVZdBaCp7o1BwHGyeDBfixdeToLIAMprshIITEdl9wKVSiidVOfeaiH8FyeC1hBmBfDZFvs/aH1Y3xpw==",
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.23.tgz",
+      "integrity": "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.6",
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/crc64-nvme": "^3.972.9",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -391,12 +505,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.18.tgz",
-      "integrity": "sha512-pnAGLICTuUV+79LC5rEtCapqSBzNU8LUMgNP5mdfFsfQXxDcwyTEP1mcVwz3id18QOcB6jSqHbqd0MJZodyN+A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.52",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -404,16 +519,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.52.tgz",
-      "integrity": "sha512-rerjP08onRqkBh0AcCqip6GkKvESapmLoTgi1xysZ4C6a1xMrIMtTBcEbUb6EY71oeajnigeUD4KwZjtIO+aWQ==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.44.tgz",
+      "integrity": "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -421,12 +536,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.18.tgz",
-      "integrity": "sha512-Emeqtr7HJbVmkcMeiz86nxVbekdEYRMKkKuYKqSSE3M5GMOkG1eKacgQn3LS/iZ3m0mzApGN/6LRnyomgHjpKA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.52",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -434,20 +550,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.21.tgz",
-      "integrity": "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==",
+      "version": "3.997.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
+      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -455,14 +571,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "version": "3.996.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
+      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -470,16 +586,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1069.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1069.0.tgz",
-      "integrity": "sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==",
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
+      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.21",
-        "@aws-sdk/nested-clients": "^3.997.21",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -487,12 +603,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -510,12 +626,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
-      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.14.2",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -3509,9 +3625,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -3634,9 +3750,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-errors": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.15.tgz",
-      "integrity": "sha512-h3r32RzpmWEcB2bz6aqZKlKOP8tzyvHLkPFleFFqwVvjO5AUfSoMUxm8OjaTuNgPF35mXPYRISh+kNCwmsKVOA==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.14.tgz",
+      "integrity": "sha512-IlBQlJZmKLaGjhr8NX8wI1vjhOaquTxj+Boq0oOMGAVVkpvtaDtLsFu2tBTIjnP8TgazwR4uNFHsNlsDvsd76A==",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/hardhat-utils": "^4.1.3"
@@ -5238,13 +5354,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.0.tgz",
-      "integrity": "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5252,13 +5368,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.0.tgz",
-      "integrity": "sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5266,39 +5382,27 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.0.tgz",
-      "integrity": "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz",
-      "integrity": "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5306,13 +5410,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.0.tgz",
-      "integrity": "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5320,41 +5424,15 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@so-ric/colorspace": {
@@ -6231,18 +6309,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/append-field": {
       "version": "1.0.0",
@@ -10833,9 +10899,9 @@
       }
     },
     "node_modules/hardhat/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -17431,19 +17497,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
-      "dependencies": {
-        "anynum": "^1.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -18738,7 +18801,7 @@
     },
     "packages/bytecode-utils": {
       "name": "@ethereum-sourcify/bytecode-utils",
-      "version": "1.6.0",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "5.8.0",
@@ -18777,14 +18840,14 @@
     },
     "packages/compilers": {
       "name": "@ethereum-sourcify/compilers",
-      "version": "1.1.4",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "semver": "7.8.1",
         "solc": "0.8.35"
       },
       "devDependencies": {
-        "@ethereum-sourcify/compilers-types": "^1.3.0",
+        "@ethereum-sourcify/compilers-types": "^1.2.0",
         "@types/chai": "4.3.20",
         "@types/mocha": "10.0.10",
         "@types/node": "22.19.19",
@@ -18800,7 +18863,7 @@
     },
     "packages/compilers-types": {
       "name": "@ethereum-sourcify/compilers-types",
-      "version": "1.3.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "5.9.3"
@@ -18818,10 +18881,10 @@
     },
     "packages/lib-sourcify": {
       "name": "@ethereum-sourcify/lib-sourcify",
-      "version": "3.6.0",
+      "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
-        "@ethereum-sourcify/bytecode-utils": "^1.6.0",
+        "@ethereum-sourcify/bytecode-utils": "^1.5.3",
         "@ethereumjs/blockchain": "7.3.0",
         "@ethereumjs/common": "4.4.0",
         "@ethereumjs/evm": "3.1.1",
@@ -18837,8 +18900,8 @@
         "semver": "7.8.1"
       },
       "devDependencies": {
-        "@ethereum-sourcify/compilers": "^1.1.4",
-        "@ethereum-sourcify/compilers-types": "^1.3.0",
+        "@ethereum-sourcify/compilers": "^1.1.3",
+        "@ethereum-sourcify/compilers-types": "^1.2.0",
         "@ethereum-sourcify/test-helpers": "^1.0.1",
         "@types/chai": "4.3.20",
         "@types/chai-as-promised": "7.1.8",
@@ -18913,7 +18976,7 @@
     },
     "services/4byte": {
       "name": "sourcify-4byte",
-      "version": "1.1.14",
+      "version": "1.1.13",
       "dependencies": {
         "chalk": "4.1.2",
         "cors": "2.8.6",
@@ -18956,7 +19019,7 @@
     },
     "services/database": {
       "name": "sourcify-database",
-      "version": "2.13.2",
+      "version": "2.13.1",
       "license": "MIT",
       "dependencies": {
         "commander": "12.1.0",
@@ -18969,11 +19032,11 @@
     },
     "services/monitor": {
       "name": "sourcify-monitor",
-      "version": "1.5.8",
+      "version": "1.5.7",
       "license": "MIT",
       "dependencies": {
-        "@ethereum-sourcify/bytecode-utils": "^1.6.0",
-        "@ethereum-sourcify/lib-sourcify": "^3.6.0",
+        "@ethereum-sourcify/bytecode-utils": "^1.5.3",
+        "@ethereum-sourcify/lib-sourcify": "^3.5.3",
         "chalk": "4.1.2",
         "commander": "12.1.0",
         "dotenv": "16.6.1",
@@ -19006,13 +19069,13 @@
     },
     "services/server": {
       "name": "sourcify-server",
-      "version": "3.17.0",
+      "version": "3.16.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1058.0",
-        "@ethereum-sourcify/bytecode-utils": "^1.6.0",
-        "@ethereum-sourcify/compilers": "^1.1.4",
-        "@ethereum-sourcify/lib-sourcify": "^3.6.0",
+        "@ethereum-sourcify/bytecode-utils": "^1.5.3",
+        "@ethereum-sourcify/compilers": "^1.1.3",
+        "@ethereum-sourcify/lib-sourcify": "^3.5.3",
         "@google-cloud/cloud-sql-connector": "1.11.0",
         "@shazow/whatsabi": "0.26.0",
         "@solidity-parser/parser": "0.20.2",

--- a/packages/bytecode-utils/CHANGELOG.md
+++ b/packages/bytecode-utils/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## @ethereum-sourcify/bytecode-utils@1.6.0 - 2026-06-16
-
-- Expose Vyper auxdata style helper (#2830)
-
 ## @ethereum-sourcify/bytecode-utils@1.5.3 - 2026-05-27
 
 - Update dependencies

--- a/packages/bytecode-utils/package.json
+++ b/packages/bytecode-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereum-sourcify/bytecode-utils",
-  "version": "1.6.0",
+  "version": "1.5.3",
   "description": "Decode the CBOR encoded data at the end of an Ethereum contract's bytecode.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/packages/compilers-types/CHANGELOG.md
+++ b/packages/compilers-types/CHANGELOG.md
@@ -1,6 +1,4 @@
-## @ethereum-sourcify/compilers-types@1.3.0 - 2026-06-16
 
-- fix(lib-sourcify): support legacy Vyper immutable tails (#2817)
 
 ## @ethereum-sourcify/compilers-types@1.2.0 - 2026-04-14
 

--- a/packages/compilers-types/package.json
+++ b/packages/compilers-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereum-sourcify/compilers-types",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "description": "TypeScript types for Sourcify compilers",
   "main": "build/main/index.js",
   "module": "build/module/index.js",

--- a/packages/compilers/CHANGELOG.md
+++ b/packages/compilers/CHANGELOG.md
@@ -1,7 +1,3 @@
-## @ethereum-sourcify/compilers@1.1.4 - 2026-06-16
-
-- Escape non-ASCII Vyper standard-json stdin (#2816)
-
 ## @ethereum-sourcify/compilers@1.1.3 - 2026-05-27
 
 - Update dependencies

--- a/packages/compilers/package.json
+++ b/packages/compilers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereum-sourcify/compilers",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "Wrapper around multiple compilers to download the right version and invoke the compilation with a common interface.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -49,7 +49,7 @@
     "solc": "0.8.35"
   },
   "devDependencies": {
-    "@ethereum-sourcify/compilers-types": "^1.3.0",
+    "@ethereum-sourcify/compilers-types": "^1.2.0",
     "@types/chai": "4.3.20",
     "@types/mocha": "10.0.10",
     "@types/node": "22.19.19",

--- a/packages/lib-sourcify/CHANGELOG.md
+++ b/packages/lib-sourcify/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## @ethereum-sourcify/lib-sourcify@3.6.0 - 2026-06-16
-
-- fix(lib-sourcify): support legacy Vyper immutable tails (#2817)
-- Reduce standard JSON input to the fields we store (#2823)
-
 ## @ethereum-sourcify/lib-sourcify@3.5.3 - 2026-05-27
 
 - clear deployer and blockNumber when creationTransactionHash validation fails (#2803)

--- a/packages/lib-sourcify/package.json
+++ b/packages/lib-sourcify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereum-sourcify/lib-sourcify",
-  "version": "3.6.0",
+  "version": "3.5.3",
   "description": "Library for Sourcify's contract verification methods, contract validation, types, and interfaces.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -34,7 +34,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@ethereum-sourcify/bytecode-utils": "^1.6.0",
+    "@ethereum-sourcify/bytecode-utils": "^1.5.3",
     "@ethereumjs/blockchain": "7.3.0",
     "@ethereumjs/common": "4.4.0",
     "@ethereumjs/evm": "3.1.1",
@@ -50,8 +50,8 @@
     "semver": "7.8.1"
   },
   "devDependencies": {
-    "@ethereum-sourcify/compilers": "^1.1.4",
-    "@ethereum-sourcify/compilers-types": "^1.3.0",
+    "@ethereum-sourcify/compilers": "^1.1.3",
+    "@ethereum-sourcify/compilers-types": "^1.2.0",
     "@ethereum-sourcify/test-helpers": "^1.0.1",
     "@types/chai": "4.3.20",
     "@types/chai-as-promised": "7.1.8",

--- a/services/4byte/CHANGELOG.md
+++ b/services/4byte/CHANGELOG.md
@@ -1,7 +1,3 @@
-## sourcify-4byte@1.1.14 - 2026-06-16
-
-- Update dependencies
-
 ## sourcify-4byte@1.1.13 - 2026-05-27
 
 - Update dependencies

--- a/services/4byte/package.json
+++ b/services/4byte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcify-4byte",
-  "version": "1.1.14",
+  "version": "1.1.13",
   "private": true,
   "description": "Standalone service exposing Sourcify signature database endpoints",
   "main": "dist/cli.js",

--- a/services/database/CHANGELOG.md
+++ b/services/database/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog for `sourcify-database`
 
-## sourcify-database@2.13.2 - 2026-06-16
-
-- Update dependencies
-
 ## sourcify-database@2.13.1 - 2026-05-27
 
 - Fix hanging contracts endpoint (#2807)

--- a/services/database/package.json
+++ b/services/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcify-database",
-  "version": "2.13.2",
+  "version": "2.13.1",
   "private": true,
   "description": "The Sourcify database",
   "main": "index.js",

--- a/services/monitor/CHANGELOG.md
+++ b/services/monitor/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## sourcify-monitor@1.5.8 - 2026-06-16
-
-- Update dependencies
-
 ## sourcify-monitor@1.5.7 - 2026-05-27
 
 - Update dependencies

--- a/services/monitor/package.json
+++ b/services/monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcify-monitor",
-  "version": "1.5.8",
+  "version": "1.5.7",
   "private": true,
   "description": "A monitoring service to listen to chains and send detected new contracts to a Sourcify server",
   "main": "index.js",
@@ -37,8 +37,8 @@
   },
   "homepage": "https://github.com/argotorg/sourcify#readme",
   "dependencies": {
-    "@ethereum-sourcify/bytecode-utils": "^1.6.0",
-    "@ethereum-sourcify/lib-sourcify": "^3.6.0",
+    "@ethereum-sourcify/bytecode-utils": "^1.5.3",
+    "@ethereum-sourcify/lib-sourcify": "^3.5.3",
     "chalk": "4.1.2",
     "commander": "12.1.0",
     "dotenv": "16.6.1",

--- a/services/server/CHANGELOG.md
+++ b/services/server/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## sourcify-server@3.17.0 - 2026-06-16
-
-- fix(server): don't send global ETHERSCAN_API_KEY to custom Etherscan explorers (#2824)
-- Reduce standard JSON input to the fields we store (#2823)
-- Update dependencies
-
 ## sourcify-server@3.16.1 - 2026-05-27
 
 - Fix hanging contracts endpoint (#2807)

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcify-server",
-  "version": "3.17.0",
+  "version": "3.16.1",
   "description": "Solidity metadata-based re-compilation and source verification tool",
   "main": "dist/server/server.js",
   "types": "dist/server/server.d.ts",
@@ -47,9 +47,9 @@
   "homepage": "https://github.com/argotorg/sourcify#readme",
   "dependencies": {
     "@aws-sdk/client-s3": "3.1058.0",
-    "@ethereum-sourcify/bytecode-utils": "^1.6.0",
-    "@ethereum-sourcify/compilers": "^1.1.4",
-    "@ethereum-sourcify/lib-sourcify": "^3.6.0",
+    "@ethereum-sourcify/bytecode-utils": "^1.5.3",
+    "@ethereum-sourcify/compilers": "^1.1.3",
+    "@ethereum-sourcify/lib-sourcify": "^3.5.3",
     "@google-cloud/cloud-sql-connector": "1.11.0",
     "@shazow/whatsabi": "0.26.0",
     "@solidity-parser/parser": "0.20.2",


### PR DESCRIPTION
Npm trusted publish failed because OIDC trusted publishing is not supported by npm 10.9.4: https://app.circleci.com/pipelines/github/argotorg/sourcify/11263/workflows/86c14e3e-e514-45ed-a580-9c3acde47089/jobs/66830