### PR TITLE
fix: upgrade npm for OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Upgrade npm for OIDC trusted publishing
+          command: |
+            npm install -g npm@^11.5.1
+      - run:
           name: install dependencies
           command: npm install
       - run:


### PR DESCRIPTION
Npm trusted publish failed because OIDC trusted publishing is not supported by npm 10.9.4: https://app.circleci.com/pipelines/github/argotorg/sourcify/11263/workflows/86c14e3e-e514-45ed-a580-9c3acde47089/jobs/66830