### PR TITLE
feat(monitor): submit contracts via Sourcify API v2

### DIFF
--- a/services/monitor/README.md
+++ b/services/monitor/README.md
@@ -66,12 +66,6 @@ The structure of the file is as such:
   },
   // Sourcify instances to verify the contracts on. Can be multiple
   sourcifyServerURLs: ["https://sourcify.dev/server/", "http://localhost:5555/"],
-  sourcifyRequestOptions: {
-    // Maximum number of retry attempts for contract verification requests after encountering an error
-    maxRetries: 3,
-    // Delay in milliseconds between each retry attempt for verification requests to Sourcify
-    retryDelay: 30000,
-  },
   defaultChainConfig: {
     // Block to start monitoring from. If undefined, it will start from the latest block by asking the RPC `eth_blockNumber`
     startBlock: undefined,

--- a/services/monitor/src/ChainMonitor.ts
+++ b/services/monitor/src/ChainMonitor.ts
@@ -9,11 +9,7 @@ import {
 } from "@ethereum-sourcify/bytecode-utils";
 import type { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import logger from "./logger";
-import type {
-  KnownDecentralizedStorageFetchers,
-  MonitorConfig,
-  SourcifyRequestOptions,
-} from "./types";
+import type { KnownDecentralizedStorageFetchers, MonitorConfig } from "./types";
 import PendingContract from "./PendingContract";
 import type { Logger } from "winston";
 import type SimilarityVerificationClient from "./SimilarityVerificationClient";
@@ -31,7 +27,6 @@ export default class ChainMonitor extends EventEmitter {
   public sourcifyChain: SourcifyChain;
   private sourceFetchers: KnownDecentralizedStorageFetchers;
   private sourcifyServerURLs: string[];
-  private sourcifyRequestOptions: SourcifyRequestOptions;
   private similarityVerificationClient: SimilarityVerificationClient;
 
   private chainLogger: Logger;
@@ -65,7 +60,6 @@ export default class ChainMonitor extends EventEmitter {
     });
 
     this.sourcifyServerURLs = monitorConfig.sourcifyServerURLs;
-    this.sourcifyRequestOptions = monitorConfig.sourcifyRequestOptions;
     this.monitorFactories = monitorConfig.monitorFactories || false;
 
     const chainConfig = {
@@ -398,48 +392,14 @@ export default class ChainMonitor extends EventEmitter {
       });
 
       this.sourcifyServerURLs.forEach(async (url) => {
-        // Setup retry mechanism
-        let sourcifyRequestAttempt = 0;
-        while (
-          sourcifyRequestAttempt < this.sourcifyRequestOptions.maxRetries
-        ) {
-          try {
-            await pendingContract.sendToSourcifyServer(url, creatorTxHash);
-            break;
-          } catch (error: any) {
-            this.chainLogger.error(
-              "Error sending contract to Sourcify server",
-              {
-                url,
-                error,
-                address,
-                sourcifyRequestAttempt,
-              },
-            );
-
-            // If request fails increment number of attempts
-            sourcifyRequestAttempt++;
-
-            if (
-              sourcifyRequestAttempt < this.sourcifyRequestOptions.maxRetries
-            ) {
-              // If number of attempts is less than maxRetries, wait and retry
-              await new Promise((resolve) =>
-                setTimeout(resolve, this.sourcifyRequestOptions.retryDelay),
-              );
-            } else {
-              // If number of attempts >= maxRetries throw Error
-              this.chainLogger.error(
-                "Failed to send contract to Sourcify server after multiple attempts.",
-                {
-                  url,
-                  error,
-                  address,
-                  sourcifyRequestAttempt,
-                },
-              );
-            }
-          }
+        try {
+          await pendingContract.sendToSourcifyServer(url, creatorTxHash);
+        } catch (error: any) {
+          this.chainLogger.error("Error sending contract to Sourcify server", {
+            url,
+            error,
+            address,
+          });
         }
       });
     } catch (error: any) {

--- a/services/monitor/src/PendingContract.ts
+++ b/services/monitor/src/PendingContract.ts
@@ -165,7 +165,6 @@ export default class PendingContract {
       );
     }
 
-    // The contract is already verified on this server, nothing to do or retry.
     if (response.status === 409) {
       this.contractLogger.info(
         "[PendingContract.sendToSourcifyServer] Contract already verified",

--- a/services/monitor/src/PendingContract.ts
+++ b/services/monitor/src/PendingContract.ts
@@ -144,26 +144,21 @@ export default class PendingContract {
     const baseURL = sourcifyServerURL.replace(/\/+$/, "");
     const verifyURL = `${baseURL}/v2/verify/metadata/${this.chainId}/${this.address}`;
 
-    let response: Response;
-    try {
-      // Send to Sourcify server.
-      response = await fetch(verifyURL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "User-Agent": "sourcify-monitor",
-        },
-        body: JSON.stringify({
-          sources: formattedSources,
-          metadata: this.metadata,
-          creationTransactionHash: creatorTxHash,
-        }),
-      });
-    } catch (error: any) {
-      throw new Error(
-        `Error sending contract ${this.address} to Sourcify server ${verifyURL} - network error: ${error.message}`,
-      );
-    }
+    // Send to Sourcify server. Let network errors (e.g. ECONNRESET) propagate
+    // as-is so their cause/code/stack are preserved when logged. The url and
+    // address context is logged alongside the error by the caller.
+    const response = await fetch(verifyURL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "sourcify-monitor",
+      },
+      body: JSON.stringify({
+        sources: formattedSources,
+        metadata: this.metadata,
+        creationTransactionHash: creatorTxHash,
+      }),
+    });
 
     if (response.status === 409) {
       this.contractLogger.info(
@@ -179,7 +174,7 @@ export default class PendingContract {
 
     if (!response.ok) {
       throw new Error(
-        `Error sending contract ${this.address} to Sourcify server ${verifyURL} - response status not ok: ${response.status} ${response.statusText} ${await response.text()}`,
+        `Sourcify server returned a non-ok status: ${response.status} ${response.statusText} ${await response.text()}`,
       );
     }
 

--- a/services/monitor/src/PendingContract.ts
+++ b/services/monitor/src/PendingContract.ts
@@ -141,46 +141,60 @@ export default class PendingContract {
       formattedSources[sourceUnitName] = source.content;
     }
 
+    const baseURL = sourcifyServerURL.replace(/\/+$/, "");
+    const verifyURL = `${baseURL}/v2/verify/metadata/${this.chainId}/${this.address}`;
+
     let response: Response;
     try {
       // Send to Sourcify server.
-      response = await fetch(sourcifyServerURL, {
+      response = await fetch(verifyURL, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "User-Agent": "sourcify-monitor",
         },
         body: JSON.stringify({
-          chainId: this.chainId.toString(),
-          address: this.address,
-          files: {
-            ...formattedSources,
-            "metadata.json": JSON.stringify(this.metadata),
-          },
-          creatorTxHash,
+          sources: formattedSources,
+          metadata: this.metadata,
+          creationTransactionHash: creatorTxHash,
         }),
       });
-
-      if (!response.ok) {
-        throw new Error(
-          `Error sending contract ${this.address} to Sourcify server ${sourcifyServerURL} - response status not ok: ${response.statusText} ${await response.text()}`,
-        );
-      }
     } catch (error: any) {
       throw new Error(
-        `Error sending contract ${this.address} to Sourcify server ${sourcifyServerURL} - network error: ${error.message}`,
+        `Error sending contract ${this.address} to Sourcify server ${verifyURL} - network error: ${error.message}`,
       );
     }
 
+    // The contract is already verified on this server, nothing to do or retry.
+    if (response.status === 409) {
+      this.contractLogger.info(
+        "[PendingContract.sendToSourcifyServer] Contract already verified",
+        {
+          address: this.address,
+          chainId: this.chainId,
+          sourcifyServerURL: baseURL,
+        },
+      );
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Error sending contract ${this.address} to Sourcify server ${verifyURL} - response status not ok: ${response.status} ${response.statusText} ${await response.text()}`,
+      );
+    }
+
+    const responseBody = await response.json();
     this.contractLogger.info(
-      "[PendingContract.sendToSourcifyServer] Contract sent",
+      "[PendingContract.sendToSourcifyServer] Contract verification job submitted",
       {
         address: this.address,
         chainId: this.chainId,
-        sourcifyServerURL,
+        sourcifyServerURL: baseURL,
+        verificationId: responseBody?.verificationId,
       },
     );
-    return await response.json();
+    return responseBody;
   };
 
   private movePendingToFetchedSources = (sourceUnitName: string) => {

--- a/services/monitor/src/defaultConfig.js
+++ b/services/monitor/src/defaultConfig.js
@@ -9,10 +9,6 @@ const defaultConfig = {
     },
   },
   sourcifyServerURLs: ["https://sourcify.dev/server/"],
-  sourcifyRequestOptions: {
-    maxRetries: 3,
-    retryDelay: 30000,
-  },
   similarityVerification: {
     requestDelay: 15000,
   },

--- a/services/monitor/src/types.ts
+++ b/services/monitor/src/types.ts
@@ -41,15 +41,9 @@ export type DefatultChainMonitorConfig = {
   traceDelay: number;
 };
 
-export type SourcifyRequestOptions = {
-  maxRetries: number;
-  retryDelay: number;
-};
-
 export type MonitorConfig = {
   decentralizedStorages: DecentralizedStorageConfigMap;
   sourcifyServerURLs: string[];
-  sourcifyRequestOptions: SourcifyRequestOptions;
   defaultChainConfig: DefatultChainMonitorConfig;
   similarityVerification: SimilarityVerificationConfig;
   monitorFactories?: boolean; // gets overwritten by .env if set

--- a/services/monitor/test/Monitor.spec.ts
+++ b/services/monitor/test/Monitor.spec.ts
@@ -24,8 +24,6 @@ const HARDHAT_PORT = 8546;
 // Configured in hardhat.config.js
 const HARDHAT_BLOCK_TIME_IN_SEC = 3;
 const MOCK_SOURCIFY_SERVER = "http://mocksourcifyserver.dev/server/";
-const MOCK_SOURCIFY_SERVER_RETURNING_ERRORS =
-  "http://mocksourcifyserver-returning-errors.dev/server/";
 const MOCK_SIMILARITY_SERVER = "http://mocksimilarity.dev/server/";
 const localChain = {
   chainId: 1337,
@@ -241,105 +239,6 @@ describe("Monitor", function () {
         ).to.be.true;
         resolve();
       });
-    });
-  });
-
-  it("should use retry mechanism for failed Sourcify request", (done) => {
-    const maxRetries = 2;
-    monitor = new Monitor([localChain], {
-      sourcifyServerURLs: [MOCK_SOURCIFY_SERVER_RETURNING_ERRORS],
-      sourcifyRequestOptions: {
-        maxRetries,
-        retryDelay: 1000,
-      },
-      chainConfigs: {
-        [localChain.chainId]: {
-          startBlock: 0,
-          blockInterval: HARDHAT_BLOCK_TIME_IN_SEC * 1000,
-        },
-      },
-    });
-
-    deployFromAbiAndBytecode(
-      signer,
-      storageContractArtifact.abi,
-      storageContractArtifact.bytecode,
-      [],
-    ).then(() => {
-      let sourcifyMockTimesCalled = 0;
-      const { origin, pathname } = new URL(
-        MOCK_SOURCIFY_SERVER_RETURNING_ERRORS,
-      );
-      const verifyPathRegex = new RegExp(
-        `^${pathname.replace(/\/+$/, "")}/v2/verify/metadata/`,
-      );
-      nock(origin)
-        .post(verifyPathRegex)
-        .times(maxRetries)
-        .reply(function () {
-          sourcifyMockTimesCalled++;
-          if (sourcifyMockTimesCalled === maxRetries) {
-            done();
-          }
-          return [500];
-        });
-      monitor.start();
-    });
-  });
-
-  it("should not retry when the contract is already verified (409)", (done) => {
-    const maxRetries = 3;
-    const retryDelay = 500;
-    monitor = new Monitor([localChain], {
-      sourcifyServerURLs: [MOCK_SOURCIFY_SERVER],
-      sourcifyRequestOptions: {
-        maxRetries,
-        retryDelay,
-      },
-      chainConfigs: {
-        [localChain.chainId]: {
-          startBlock: 0,
-          blockInterval: HARDHAT_BLOCK_TIME_IN_SEC * 1000,
-        },
-      },
-    });
-
-    deployFromAbiAndBytecode(
-      signer,
-      storageContractArtifact.abi,
-      storageContractArtifact.bytecode,
-      [],
-    ).then(() => {
-      let sourcifyMockTimesCalled = 0;
-      const { origin, pathname } = new URL(MOCK_SOURCIFY_SERVER);
-      const verifyPathRegex = new RegExp(
-        `^${pathname.replace(/\/+$/, "")}/v2/verify/metadata/`,
-      );
-      nock(origin)
-        .persist()
-        .post(verifyPathRegex)
-        .reply(() => {
-          sourcifyMockTimesCalled++;
-          if (sourcifyMockTimesCalled === 1) {
-            // A 409 (already verified) is a terminal state and must not be
-            // retried. Wait past the retry window, then assert the server was
-            // only called once.
-            setTimeout(
-              () => {
-                nock.cleanAll();
-                try {
-                  expect(sourcifyMockTimesCalled).to.equal(1);
-                  done();
-                } catch (err) {
-                  done(err);
-                }
-              },
-              retryDelay * (maxRetries + 1),
-            );
-          }
-          return [409, { customCode: "already_verified" }];
-        });
-      monitor.start();
     });
   });
 

--- a/services/monitor/test/Monitor.spec.ts
+++ b/services/monitor/test/Monitor.spec.ts
@@ -267,8 +267,14 @@ describe("Monitor", function () {
       [],
     ).then(() => {
       let sourcifyMockTimesCalled = 0;
-      nock(MOCK_SOURCIFY_SERVER_RETURNING_ERRORS)
-        .post("/")
+      const { origin, pathname } = new URL(
+        MOCK_SOURCIFY_SERVER_RETURNING_ERRORS,
+      );
+      const verifyPathRegex = new RegExp(
+        `^${pathname.replace(/\/+$/, "")}/v2/verify/metadata/`,
+      );
+      nock(origin)
+        .post(verifyPathRegex)
         .times(maxRetries)
         .reply(function () {
           sourcifyMockTimesCalled++;
@@ -276,6 +282,62 @@ describe("Monitor", function () {
             done();
           }
           return [500];
+        });
+      monitor.start();
+    });
+  });
+
+  it("should not retry when the contract is already verified (409)", (done) => {
+    const maxRetries = 3;
+    const retryDelay = 500;
+    monitor = new Monitor([localChain], {
+      sourcifyServerURLs: [MOCK_SOURCIFY_SERVER],
+      sourcifyRequestOptions: {
+        maxRetries,
+        retryDelay,
+      },
+      chainConfigs: {
+        [localChain.chainId]: {
+          startBlock: 0,
+          blockInterval: HARDHAT_BLOCK_TIME_IN_SEC * 1000,
+        },
+      },
+    });
+
+    deployFromAbiAndBytecode(
+      signer,
+      storageContractArtifact.abi,
+      storageContractArtifact.bytecode,
+      [],
+    ).then(() => {
+      let sourcifyMockTimesCalled = 0;
+      const { origin, pathname } = new URL(MOCK_SOURCIFY_SERVER);
+      const verifyPathRegex = new RegExp(
+        `^${pathname.replace(/\/+$/, "")}/v2/verify/metadata/`,
+      );
+      nock(origin)
+        .persist()
+        .post(verifyPathRegex)
+        .reply(() => {
+          sourcifyMockTimesCalled++;
+          if (sourcifyMockTimesCalled === 1) {
+            // A 409 (already verified) is a terminal state and must not be
+            // retried. Wait past the retry window, then assert the server was
+            // only called once.
+            setTimeout(
+              () => {
+                nock.cleanAll();
+                try {
+                  expect(sourcifyMockTimesCalled).to.equal(1);
+                  done();
+                } catch (err) {
+                  done(err);
+                }
+              },
+              retryDelay * (maxRetries + 1),
+            );
+          }
+          return [409, { customCode: "already_verified" }];
         });
       monitor.start();
     });

--- a/services/monitor/test/PendingContract.spec.ts
+++ b/services/monitor/test/PendingContract.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import nock from "nock";
+import type { Metadata } from "@ethereum-sourcify/lib-sourcify";
+import PendingContract from "../src/PendingContract";
+import { FileHash } from "../src/util";
+
+const SERVER_URL = "http://localhost:5555/";
+const SERVER_ORIGIN = "http://localhost:5555";
+const CHAIN_ID = 1;
+const ADDRESS = "0x1234567890123456789012345678901234567890";
+const CREATION_TX_HASH =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+const verifyPath = `/v2/verify/metadata/${CHAIN_ID}/${ADDRESS}`;
+
+const metadata = {
+  language: "Solidity",
+  compiler: { version: "0.8.19+commit.7dd6d404" },
+} as unknown as Metadata;
+
+function buildPendingContract(): PendingContract {
+  const pendingContract = new PendingContract(
+    new FileHash("ipfs", "QmTest"),
+    ADDRESS,
+    CHAIN_ID,
+    {},
+  );
+  pendingContract.metadata = metadata;
+  pendingContract.fetchedSources = {
+    "contracts/Storage.sol": {
+      keccak256:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      content: "// SPDX-License-Identifier: MIT\ncontract Storage {}",
+    },
+  };
+  return pendingContract;
+}
+
+describe("PendingContract.sendToSourcifyServer", function () {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("submits to the v2 metadata endpoint and returns the verification job", async () => {
+    const pendingContract = buildPendingContract();
+    let capturedBody: any;
+    const scope = nock(SERVER_ORIGIN)
+      .post(verifyPath, (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(202, { verificationId: "job-1" });
+
+    const result = await pendingContract.sendToSourcifyServer(
+      SERVER_URL,
+      CREATION_TX_HASH,
+    );
+
+    expect(scope.isDone()).to.equal(true);
+    expect(result).to.deep.equal({ verificationId: "job-1" });
+    expect(capturedBody.sources).to.have.property("contracts/Storage.sol");
+    expect(capturedBody.metadata).to.deep.equal(metadata);
+    expect(capturedBody.creationTransactionHash).to.equal(CREATION_TX_HASH);
+  });
+
+  it("treats a 409 (already verified) as terminal and resolves without throwing", async () => {
+    const pendingContract = buildPendingContract();
+    const scope = nock(SERVER_ORIGIN)
+      .post(verifyPath)
+      .reply(409, { customCode: "already_verified" });
+
+    const result = await pendingContract.sendToSourcifyServer(
+      SERVER_URL,
+      CREATION_TX_HASH,
+    );
+
+    expect(scope.isDone()).to.equal(true);
+    expect(result).to.equal(undefined);
+  });
+
+  it("throws with the status and body when the server returns a non-ok status", async () => {
+    const pendingContract = buildPendingContract();
+    nock(SERVER_ORIGIN).post(verifyPath).reply(500);
+
+    let error: any;
+    try {
+      await pendingContract.sendToSourcifyServer(SERVER_URL, CREATION_TX_HASH);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.be.an("error");
+  });
+
+  it("throws if a fetched source has no content", async () => {
+    const pendingContract = buildPendingContract();
+    pendingContract.fetchedSources = {
+      "contracts/Storage.sol": {
+        keccak256:
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+      },
+    };
+
+    let error: any;
+    try {
+      await pendingContract.sendToSourcifyServer(SERVER_URL, CREATION_TX_HASH);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.be.an("error");
+    expect(error.message).to.include("Unexpectedly empty source content");
+  });
+});

--- a/services/monitor/test/helpers.ts
+++ b/services/monitor/test/helpers.ts
@@ -22,23 +22,24 @@ export async function deployFromAbiAndBytecode(
 /**
  * Returns a nock scope that later can be checked with isDone() if it was called.
  *
- * I.e. check if a request to serverUrl was made with the expected chainId and address.
+ * I.e. check if a request to serverUrl was made with the expected chainId and
+ * address, and a body containing `sources` and `metadata`.
  */
 export function nockInterceptorForVerification(
   serverUrl: string,
   expectedChainId: number,
   expectedAddress: string,
 ) {
-  return nock(serverUrl)
-    .post("/")
-    .reply(function (uri, requestBody) {
-      const body = requestBody as {
-        address: string;
-        chainId: string;
-      };
-      expect(body.chainId).to.equal(expectedChainId.toString());
-      expect(body.address).to.equal(expectedAddress);
-      const { address, chainId } = body;
-      return [200, { address, chainId, status: "perfect" }];
+  const { origin, pathname } = new URL(serverUrl);
+  const basePath = pathname.replace(/\/+$/, "");
+  const verifyPath = `${basePath}/v2/verify/metadata/${expectedChainId}/${expectedAddress}`;
+  return nock(origin)
+    .post(verifyPath, (body) => {
+      expect(body).to.have.property("sources");
+      expect(body).to.have.property("metadata");
+      return true;
+    })
+    .reply(202, {
+      verificationId: "00000000-0000-0000-0000-000000000000",
     });
 }


### PR DESCRIPTION
See #2837

## Summary

Upgrades the Sourcify Monitor's contract submission from the v1 API to the v2 API: `PendingContract.sendToSourcifyServer` now POSTs to `/v2/verify/metadata/{chainId}/{address}` with the v2 metadata payload (`sources`, `metadata`, `creationTransactionHash`) instead of the v1 `{ chainId, address, files, creatorTxHash }` body.

## Notes

- v2 verification is asynchronous: the endpoint returns `202` with a `verificationId` (logged) and processes the job in the background, so the monitor submits and does not poll for the result.
- A `409 already_verified` response is treated as a benign terminal state — logged at info level and skipped, rather than surfaced as an error.
- Removes the retry mechanism (`sourcifyRequestOptions` / `maxRetries` / `retryDelay`) entirely: it was added in #1561 to work around ECONNRESET on the old synchronous v1 verify requests, and v2's fast `202` submission removes that long-lived-connection failure mode, so a failed submission is now simply logged and skipped.
- Network errors from `fetch` are no longer re-wrapped, preserving the original error's type/code/stack when logged, and the non-ok-status error message was trimmed to drop context the caller already logs.
- The existing monitor test now exercises the v2 endpoint; the retry test was removed along with the retry mechanism.