### PR TITLE
feat: add Whitechain Sepolia testnet (chain ID 1874)

### DIFF
--- a/services/server/src/sourcify-chains.json
+++ b/services/server/src/sourcify-chains.json
@@ -1,0 +1,17 @@
+{
+  "1874": {
+    "sourcifyName": "Whitechain Sepolia Testnet",
+    "supported": true,
+    "fetchContractCreationTxUsing": {
+      "blockscoutApi": {
+        "url": "https://explorer.testnet.whitechain.io/"
+      }
+    },
+    "rpc": [
+      {
+        "type": "BaseRPC",
+        "url": "https://rpc.testnet.whitechain.io"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `services/server/src/sourcify-chains.json` with Whitechain Sepolia (chain ID 1874)
- Public RPC: `https://rpc.testnet.whitechain.io`
- Blockscout API: `https://explorer.testnet.whitechain.io/` for contract creation tx lookup

## Chain details

| Parameter | Value |
|---|---|
| Chain ID | `1874` (0x752) |
| Network name | Whitechain Sepolia |
| L1 | Ethereum Sepolia (11155111) |
| Gas token | WBT (18 decimals) |
| Block time | 1s |
| RPC | `https://rpc.testnet.whitechain.io` |
| Explorer | `https://explorer.testnet.whitechain.io` |

## Notes

The local `sourcify-chains.json` takes priority over remote GCS fetch per `sourcify-chains.ts` logic. File name follows the actual code convention (not `-default` suffix).

Verified locally:
- Build passes (`npx lerna run build`)
- `dist/sourcify-chains.json` correctly copied via `prebuild`
- RPC `eth_chainId` returns `0x752`
- Blockscout `/api/v2/stats` returns live chain data