### PR TITLE
fix(server): disable chains without usable RPCs instead of throwing

### DIFF
--- a/services/server/src/sourcify-chains.ts
+++ b/services/server/src/sourcify-chains.ts
@@ -285,15 +285,17 @@ export async function initializeSourcifyChains(opts: {
 
     const chainId = parseInt(chainIdStr);
     const rpcs = buildCustomRpcs(extension.rpc || []);
-    if (rpcs.length === 0 && extension.supported) {
-      throw new Error(
-        `Supported chain ${chainId} (${extension.sourcifyName}) has no usable RPCs configured`,
+    let supported = extension.supported;
+    if (rpcs.length === 0 && supported) {
+      logger.error(
+        `Supported chain ${chainId} (${extension.sourcifyName}) has no usable RPCs configured, disabling it`,
       );
+      supported = false;
     }
     sourcifyChainsMap[chainIdStr] = new SourcifyChain({
       name: extension.sourcifyName,
       chainId,
-      supported: extension.supported,
+      supported,
       hidden: extension.hidden ?? false,
       rpcs,
       etherscanApi: extension.etherscanApi,


### PR DESCRIPTION
## Summary

A supported chain configured with no usable RPCs previously threw in `initializeSourcifyChains`, which crashed the entire server startup. A single misconfigured chain would take down the whole server.

This changes the behavior to log an error and mark the chain as unsupported (`supported = false`), so the remaining chains still load and the server starts.

## Notes

Passing `supported: false` is safe with the `SourcifyChain` constructor: it returns early for unsupported chains before the empty-RPC guard, so a disabled chain with no RPCs constructs cleanly without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)