### PR TITLE
fix(lib-sourcify): compare creation-tx contractAddress case-insensitively

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -850,9 +850,7 @@ export class SourcifyChain {
       // Compare case-insensitively: the receipt's contractAddress is checksummed
       // on some RPCs, while the caller may pass a lowercase address, and a pure
       // `!==` would spuriously reject a genuine match.
-      if (
-        txReceipt.contractAddress.toLowerCase() !== address.toLowerCase()
-      ) {
+      if (txReceipt.contractAddress.toLowerCase() !== address.toLowerCase()) {
         // we need to check if this contract creation tx actually yields the same contract address https://github.com/argotorg/sourcify/issues/887
         throw new Error(
           `Address of the contract being verified ${address} doesn't match the address ${txReceipt.contractAddress} created by this transaction ${transactionHash}`,

--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChain.ts
@@ -847,7 +847,12 @@ export class SourcifyChain {
     let creationBytecode;
     // Non null txreceipt.contractAddress means that the contract was created with an EOA
     if (txReceipt.contractAddress !== null) {
-      if (txReceipt.contractAddress !== address) {
+      // Compare case-insensitively: the receipt's contractAddress is checksummed
+      // on some RPCs, while the caller may pass a lowercase address, and a pure
+      // `!==` would spuriously reject a genuine match.
+      if (
+        txReceipt.contractAddress.toLowerCase() !== address.toLowerCase()
+      ) {
         // we need to check if this contract creation tx actually yields the same contract address https://github.com/argotorg/sourcify/issues/887
         throw new Error(
           `Address of the contract being verified ${address} doesn't match the address ${txReceipt.contractAddress} created by this transaction ${transactionHash}`,


### PR DESCRIPTION
## Summary

`SourcifyChain.getContractCreationBytecodeAndReceipt` compared the creation-tx receipt's `contractAddress` against the address being verified with a strict, case-sensitive `!==`:

```ts
if (txReceipt.contractAddress !== address) {
  throw new Error(`Address of the contract being verified ${address} doesn't match ...`);
}
```

Some RPCs return a **checksummed** `contractAddress` in the receipt. When the caller passes a **lowercase** address, this strict compare throws `"... doesn't match the address ..."` even though it's the same contract — silently aborting creation-bytecode matching (the runtime match still succeeds, but `creationMatch` stays `null`).

The fix normalizes both sides to lowercase before comparing.

## Why / how it surfaced

Found while building end-to-end zksolc/EraVM verification tests against Abstract mainnet: Abstract's RPC returns a checksummed `contractAddress`, so a lowercase input address made every direct-deploy contract fail creation matching. Production is currently shielded only because the server checksums addresses before verifying, but relying on the caller's casing is fragile — any consumer passing a lowercase address hits this.

## Notes

Behavior is unchanged when the addresses genuinely differ (still throws) and when casing already matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)