### PR TITLE
Speed up delete-sourcify-match orphan checks and add verification_jobs FK index

### DIFF
--- a/scripts/delete-sourcify-match.ts
+++ b/scripts/delete-sourcify-match.ts
@@ -298,13 +298,15 @@ async function deleteCompiledContractSources(
   for (const row of sourcesResult) {
     const sourceHash = row.source_hash;
 
-    // Check if this source is referenced by other compiled_contracts_sources
+    // Check if this source is referenced by other compiled_contracts_sources.
+    // LIMIT 1 instead of COUNT(*): we only need existence, and counting all
+    // references of a widely shared source scans the whole index range.
     const otherSourceRefsResult = await client.query(
-      `SELECT COUNT(*) as count FROM compiled_contracts_sources WHERE source_hash = $1 AND compilation_id != $2`,
+      `SELECT 1 FROM compiled_contracts_sources WHERE source_hash = $1 AND compilation_id != $2 LIMIT 1`,
       [sourceHash, compilationId],
     );
 
-    const canDeleteSource = parseInt(otherSourceRefsResult[0].count) === 0;
+    const canDeleteSource = otherSourceRefsResult.length === 0;
 
     // Delete the compiled_contracts_sources entry
     await client.query(
@@ -335,19 +337,22 @@ async function deleteCompiledContractSignatures(
   );
 
   console.log(
-    `⏱️  Processing ${signaturesResult.length} signatures for compilation ${compilationId}. For many signatures this may take 10-20 minutes...`,
+    `⏱️  Processing ${signaturesResult.length} signatures for compilation ${compilationId}...`,
   );
 
   for (const row of signaturesResult) {
     const signatureHash = row.signature_hash_32;
 
-    // Check if this signature is referenced by other compiled_contracts_signatures
+    // Check if this signature is referenced by other compiled_contracts_signatures.
+    // LIMIT 1 instead of COUNT(*): common signatures (e.g. transfer) have
+    // millions of references and counting them takes ~80s each; an existence
+    // probe stops at the first match (~40ms).
     const otherSigRefsResult = await client.query(
-      `SELECT COUNT(*) as count FROM compiled_contracts_signatures WHERE signature_hash_32 = $1 AND compilation_id != $2`,
+      `SELECT 1 FROM compiled_contracts_signatures WHERE signature_hash_32 = $1 AND compilation_id != $2 LIMIT 1`,
       [signatureHash, compilationId],
     );
 
-    const canDeleteSignature = parseInt(otherSigRefsResult[0].count) === 0;
+    const canDeleteSignature = otherSigRefsResult.length === 0;
 
     // Delete the compiled_contracts_signatures entry
     await client.query(
@@ -374,23 +379,25 @@ async function deleteCodeIfOrphaned(
 ): Promise<void> {
   if (!codeHash) return;
 
-  // Check if this code is referenced by other compiled_contracts
+  // Check if this code is referenced by other compiled_contracts.
+  // LIMIT 1 instead of COUNT(*): popular bytecode (e.g. minimal proxies) has
+  // millions of references; an existence probe stops at the first match.
   const otherCompiledContractsResult = await client.query(
-    `SELECT COUNT(*) as count FROM compiled_contracts
-     WHERE creation_code_hash = $1 OR runtime_code_hash = $1`,
+    `SELECT 1 FROM compiled_contracts
+     WHERE creation_code_hash = $1 OR runtime_code_hash = $1 LIMIT 1`,
     [codeHash],
   );
 
   // Check if this code is referenced by other contracts
   const otherContractsResult = await client.query(
-    `SELECT COUNT(*) as count FROM contracts
-     WHERE creation_code_hash = $1 OR runtime_code_hash = $1`,
+    `SELECT 1 FROM contracts
+     WHERE creation_code_hash = $1 OR runtime_code_hash = $1 LIMIT 1`,
     [codeHash],
   );
 
   const canDeleteCode =
-    parseInt(otherCompiledContractsResult[0].count) === 0 &&
-    parseInt(otherContractsResult[0].count) === 0;
+    otherCompiledContractsResult.length === 0 &&
+    otherContractsResult.length === 0;
 
   if (canDeleteCode) {
     await client.query(`DELETE FROM code WHERE code_hash = $1`, [codeHash]);

--- a/services/database/migrations/20260715080000_add_verification_jobs_verified_contract_id_index.sql
+++ b/services/database/migrations/20260715080000_add_verification_jobs_verified_contract_id_index.sql
@@ -1,0 +1,18 @@
+-- migrate:up transaction:false
+
+-- Index on the verification_jobs.verified_contract_id FK column. Without it,
+-- every DELETE on verified_contracts triggers a sequential scan of
+-- verification_jobs for the RI check of
+-- verification_jobs_verified_contract_id_fk (one scan per deleted row),
+-- which makes contract deletions (scripts/delete-sourcify-match) take
+-- minutes instead of milliseconds.
+--
+-- CONCURRENTLY is required so production verifications can keep writing
+-- while the index builds. transaction:false is required because
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS verification_jobs_verified_contract_id_idx
+    ON verification_jobs USING btree (verified_contract_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS verification_jobs_verified_contract_id_idx;

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1689,6 +1689,13 @@ CREATE INDEX verification_jobs_chain_id_address_idx ON public.verification_jobs 
 
 
 --
+-- Name: verification_jobs_verified_contract_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX verification_jobs_verified_contract_id_idx ON public.verification_jobs USING btree (verified_contract_id);
+
+
+--
 -- Name: verified_contracts_compilation_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2210,4 +2217,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260309080000'),
     ('20260527081526'),
     ('20260527085036'),
-    ('20260527085037');
+    ('20260527085037'),
+    ('20260715080000');


### PR DESCRIPTION
## Summary

Deleting a single contract with `delete-sourcify-match` could take ~50 minutes. Two fixes bring it down to seconds:

- **New index on `verification_jobs.verified_contract_id`**: every row deleted from `verified_contracts` triggered a full seq scan of `verification_jobs` (74M rows) for the FK integrity check. Measured: 180ms → 0.085ms per check on a 2M-row table.
- **`COUNT(*)` → `LIMIT 1` existence probes** in the orphan checks (signatures, sources, code): counting all references of a common signature like `transfer(address,uint256)` (~3M rows) took ~80s; an existence probe takes ~40ms.
