### PR TITLE
fix(lib-sourcify): throw specific error when compiler does not output deployedBytecode

### DIFF
--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -108,6 +108,19 @@ export abstract class AbstractCompilation {
     // We call contractCompilerOutput() before logging because it can throw an error
     const compilationTargetContract = this.contractCompilerOutput;
 
+    // Some compilers don't output the deployedBytecode, e.g. Yul contracts compiled
+    // with solc <0.6.9 or without a deployed subobject, or Solidity <0.1.3.
+    // The rest of the verification flow relies on it being present, so fail here.
+    if (!compilationTargetContract.evm.deployedBytecode) {
+      logWarn('Runtime bytecode not found in compiler output', {
+        path: this.compilationTarget.path,
+        name: this.compilationTarget.name,
+      });
+      throw new CompilationError({
+        code: 'runtime_bytecode_not_found_in_compiler_output',
+      });
+    }
+
     const compilationEndTime = Date.now();
     this.compilationTime = compilationEndTime - compilationStartTime;
     logSilly('Compilation output', { compilerOutput: this.compilerOutput });
@@ -159,10 +172,9 @@ export abstract class AbstractCompilation {
   }
 
   get runtimeBytecode() {
-    // Solidity versions prior to 0.1.3 do not include the deployedBytecode in the compiler output,
-    // instead of handling the runtime bytecode type as optional, we set it to an empty string if it's not present
-    // otherwise the verification process would need to handle the runtime bytecode as optional
-    // and this would add unnecessary complexity to the verification process
+    // The deployedBytecode presence is enforced in compileAndReturnCompilationTarget.
+    // Its object can still be empty, e.g. for abstract contracts, in which case
+    // verification fails with `compiled_bytecode_is_zero`.
     return `0x${this.contractCompilerOutput.evm.deployedBytecode.object || ''}`;
   }
 

--- a/packages/lib-sourcify/src/Compilation/CompilationTypes.ts
+++ b/packages/lib-sourcify/src/Compilation/CompilationTypes.ts
@@ -41,6 +41,7 @@ export type CompilationErrorCode =
   | 'invalid_compiler_version'
   | 'unsupported_compiler_version'
   | 'contract_not_found_in_compiler_output'
+  | 'runtime_bytecode_not_found_in_compiler_output'
   | 'compiler_error'
   | 'no_compiler_output'
   | 'metadata_not_set'

--- a/packages/lib-sourcify/src/SourcifyLibError.ts
+++ b/packages/lib-sourcify/src/SourcifyLibError.ts
@@ -101,6 +101,8 @@ export function getErrorMessageFromCode(params: SourcifyLibErrorParameters) {
       return 'Compiler output is undefined.';
     case 'contract_not_found_in_compiler_output':
       return 'Contract not found in compiler output.';
+    case 'runtime_bytecode_not_found_in_compiler_output':
+      return 'The compiler did not output the runtime bytecode (evm.deployedBytecode) for the contract. This happens e.g. for Yul contracts compiled with solc <0.6.9 or without a deployed subobject, or Solidity contracts compiled with solc <0.1.3.';
     case 'metadata_not_set':
       return 'No metadata on compilation object.';
     case 'creation_bytecode_cbor_auxdata_not_set':

--- a/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/VyperCompilation.spec.ts
@@ -341,7 +341,7 @@ describe('VyperCompilation', () => {
       'utf8',
     );
 
-    // Mock vyperCompiler to return output without auxdata
+    // Mock vyperCompiler to return an empty creation bytecode, which makes splitAuxdata throw
     const mockCompiler = {
       compile: async () => ({
         contracts: {
@@ -349,6 +349,9 @@ describe('VyperCompilation', () => {
             [contractName]: {
               evm: {
                 bytecode: {
+                  object: '',
+                },
+                deployedBytecode: {
                   object: '0x123456',
                 },
               },
@@ -410,6 +413,9 @@ describe('VyperCompilation', () => {
             [contractName]: {
               evm: {
                 bytecode: {
+                  object: '0x123456',
+                },
+                deployedBytecode: {
                   object: '0x123456',
                 },
               },

--- a/packages/lib-sourcify/test/Compilation/YulCompilation.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/YulCompilation.spec.ts
@@ -56,4 +56,39 @@ describe('YulCompilation', () => {
       'Contract not found in compiler output.',
     );
   });
+
+  // solc <0.6.9 does not output evm.deployedBytecode for Yul contracts.
+  // See https://github.com/argotorg/sourcify/issues/2887
+  it('should throw when the compiler does not output deployedBytecode', async () => {
+    const jsonInputPath = path.join(
+      __dirname,
+      '..',
+      'sources',
+      'Yul',
+      'deterministic-deployment-proxy',
+      'jsonInput.json',
+    );
+    const jsonInput: SolidityJsonInput = JSON.parse(
+      fs.readFileSync(jsonInputPath, 'utf8'),
+    );
+
+    const compilation = new YulCompilation(
+      solc,
+      '0.5.8+commit.23d335f2',
+      jsonInput,
+      {
+        name: 'Proxy',
+        path: 'deterministic-deployment-proxy.yul',
+      },
+    );
+
+    await expect(compilation.compile(true))
+      .to.eventually.be.rejectedWith(
+        'The compiler did not output the runtime bytecode',
+      )
+      .and.have.property(
+        'code',
+        'runtime_bytecode_not_found_in_compiler_output',
+      );
+  });
 });

--- a/packages/lib-sourcify/test/sources/Yul/deterministic-deployment-proxy/jsonInput.json
+++ b/packages/lib-sourcify/test/sources/Yul/deterministic-deployment-proxy/jsonInput.json
@@ -1,0 +1,21 @@
+{
+  "language": "Yul",
+  "sources": {
+    "deterministic-deployment-proxy.yul": {
+      "content": "object \"Proxy\" {\n\t// deployment code\n\tcode {\n\t\tlet size := datasize(\"runtime\")\n\t\tdatacopy(0, dataoffset(\"runtime\"), size)\n\t\treturn(0, size)\n\t}\n\tobject \"runtime\" {\n\t\t// deployed code\n\t\tcode {\n\t\t\tcalldatacopy(0, 32, sub(calldatasize(), 32))\n\t\t\tlet result := create2(callvalue(), 0, sub(calldatasize(), 32), calldataload(0))\n\t\t\tif iszero(result) { revert(0, 0) }\n\t\t\tmstore(0, result)\n\t\t\treturn(12, 20)\n\t\t}\n\t}\n}\n"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true,
+      "details": {
+        "yul": true
+      }
+    },
+    "outputSelection": {
+      "*": {
+        "*": ["*"]
+      }
+    }
+  }
+}

--- a/services/server/test/integration/apiv2/verification/verify.json.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.json.spec.ts
@@ -341,6 +341,83 @@ describe("POST /v2/verify/:chainId/:address", function () {
     });
   });
 
+  it("should store a job error if the compiler does not output the runtime bytecode", async () => {
+    const { resolveWorkers } = makeWorkersWait();
+
+    // Yul contracts compiled with solc <0.6.9 have no evm.deployedBytecode in the compiler output
+    // See https://github.com/argotorg/sourcify/issues/2887
+    const yulFileName = "deterministic-deployment-proxy.yul";
+    const yulContent = `object "Proxy" {
+  code {
+    let size := datasize("runtime")
+    datacopy(0, dataoffset("runtime"), size)
+    return(0, size)
+  }
+  object "runtime" {
+    code {
+      calldatacopy(0, 32, sub(calldatasize(), 32))
+      let result := create2(callvalue(), 0, sub(calldatasize(), 32), calldataload(0))
+      if iszero(result) { revert(0, 0) }
+      mstore(0, result)
+      return(12, 20)
+    }
+  }
+}
+`;
+
+    const verifyRes = await chai
+      .request(serverFixture.server.app)
+      .post(
+        `/v2/verify/${chainFixture.chainId}/${chainFixture.defaultContractAddress}`,
+      )
+      .send({
+        stdJsonInput: {
+          language: "Yul",
+          sources: {
+            [yulFileName]: {
+              content: yulContent,
+            },
+          },
+          settings: {
+            optimizer: { enabled: true, details: { yul: true } },
+            outputSelection: {
+              "*": { "*": ["*"] },
+            },
+          },
+        },
+        compilerVersion: "0.5.8+commit.23d335f2",
+        contractIdentifier: `${yulFileName}:Proxy`,
+        creationTransactionHash: chainFixture.defaultContractCreatorTx,
+      });
+
+    chai.expect(verifyRes.status).to.equal(202);
+
+    await resolveWorkers();
+
+    const jobRes = await chai
+      .request(serverFixture.server.app)
+      .get(`/v2/verify/${verifyRes.body.verificationId}`);
+
+    chai.expect(jobRes.status).to.equal(200);
+    chai.expect(jobRes.body).to.include({
+      isJobCompleted: true,
+    });
+    chai.expect(jobRes.body.error).to.exist;
+    chai
+      .expect(jobRes.body.error.customCode)
+      .to.equal("runtime_bytecode_not_found_in_compiler_output");
+    chai
+      .expect(jobRes.body.error.message)
+      .to.include("did not output the runtime bytecode");
+    chai.expect(jobRes.body.contract).to.deep.equal({
+      match: null,
+      creationMatch: null,
+      runtimeMatch: null,
+      chainId: chainFixture.chainId,
+      address: chainFixture.defaultContractAddress,
+    });
+  });
+
   it("should return a 429 if the contract is being verified at the moment already", async () => {
     await testAlreadyBeingVerified(
       serverFixture,


### PR DESCRIPTION
Verifying a Yul contract compiled with solc <0.6.9 (e.g. the deterministic deployment proxy, [#2887](https://github.com/argotorg/sourcify/issues/2887)) failed with `internal_error`: those compiler versions don't output `evm.deployedBytecode` for Yul, and the `runtimeBytecode` getter crashed with a TypeError that escaped as an unexpected error.

Compilations whose output has no `evm.deployedBytecode` now fail with a new `runtime_bytecode_not_found_in_compiler_output` error. The check lives in `AbstractCompilation.compileAndReturnCompilationTarget`, so every language's compile() enforces it, and the rest of the verification flow can keep relying on the field being present. Contracts with a present-but-empty runtime bytecode (abstract contracts) still fail with `compiled_bytecode_is_zero` as before.