### PR TITLE
fix(lib-sourcify): don't store sources unused by the compilation target

### DIFF
--- a/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/AbstractCompilation.ts
@@ -30,6 +30,32 @@ function cleanCompilerVersion(version: string): string {
   return version.replace(/^[^\d]*/, '');
 }
 
+/**
+ * Returns the compilation target's contract from a compiler output.
+ * Use this instead of indexing `contracts` directly: in solcjs, for solidity
+ * versions prior to 0.4.9, the contracts are stored without the source path as a key.
+ */
+export function findContractInCompilerOutput(
+  compilerOutput: SolidityOutput | VyperOutput | FeOutput,
+  compilationTarget: CompilationTarget,
+): SolidityOutputContract | VyperOutputContract | FeOutputContract {
+  const contract =
+    compilerOutput.contracts?.['']?.[compilationTarget.name] ??
+    compilerOutput.contracts?.[compilationTarget.path]?.[
+      compilationTarget.name
+    ];
+  if (!contract) {
+    logWarn('Contract not found in compiler output', {
+      path: compilationTarget.path,
+      name: compilationTarget.name,
+    });
+    throw new CompilationError({
+      code: 'contract_not_found_in_compiler_output',
+    });
+  }
+  return contract;
+}
+
 export abstract class AbstractCompilation {
   /**
    * Constructor parameters
@@ -141,28 +167,10 @@ export abstract class AbstractCompilation {
       logWarn('Compiler output is undefined');
       throw new CompilationError({ code: 'no_compiler_output' });
     }
-    // In solcjs, for solidity versions prior to 0.4.9, the contracts are stored without the source path as a key
-    if (this.compilerOutput.contracts['']?.[this.compilationTarget.name]) {
-      return this.compilerOutput.contracts[''][this.compilationTarget.name];
-    }
-    if (
-      !this.compilerOutput.contracts ||
-      !this.compilerOutput.contracts[this.compilationTarget.path] ||
-      !this.compilerOutput.contracts[this.compilationTarget.path][
-        this.compilationTarget.name
-      ]
-    ) {
-      logWarn('Contract not found in compiler output', {
-        path: this.compilationTarget.path,
-        name: this.compilationTarget.name,
-      });
-      throw new CompilationError({
-        code: 'contract_not_found_in_compiler_output',
-      });
-    }
-    return this.compilerOutput.contracts[this.compilationTarget.path][
-      this.compilationTarget.name
-    ];
+    return findContractInCompilerOutput(
+      this.compilerOutput,
+      this.compilationTarget,
+    );
   }
 
   get creationBytecode() {

--- a/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/PreRunCompilation.ts
@@ -1,5 +1,8 @@
 import { AuxdataStyle } from '@ethereum-sourcify/bytecode-utils';
-import { AbstractCompilation } from './AbstractCompilation';
+import {
+  AbstractCompilation,
+  findContractInCompilerOutput,
+} from './AbstractCompilation';
 import type {
   ImmutableReferences,
   LinkReferences,
@@ -49,9 +52,10 @@ export class PreRunCompilation extends AbstractCompilation {
     switch (this.language) {
       case 'Solidity': {
         this.auxdataStyle = AuxdataStyle.SOLIDITY;
-        const contractOutput = jsonOutput.contracts[
-          this.compilationTarget.path
-        ][this.compilationTarget.name] as SolidityOutputContract;
+        const contractOutput = findContractInCompilerOutput(
+          jsonOutput,
+          this.compilationTarget,
+        ) as SolidityOutputContract;
         if (contractOutput.metadata) {
           this._metadata = JSON.parse(contractOutput.metadata.trim());
         }

--- a/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
+++ b/packages/lib-sourcify/src/Compilation/SolidityCompilation.ts
@@ -1,6 +1,9 @@
 import { AuxdataStyle, splitAuxdata } from '@ethereum-sourcify/bytecode-utils';
 import semver from 'semver';
-import { AbstractCompilation } from './AbstractCompilation';
+import {
+  AbstractCompilation,
+  findContractInCompilerOutput,
+} from './AbstractCompilation';
 import type {
   ImmutableReferences,
   SolidityJsonInput,
@@ -241,10 +244,10 @@ export class SolidityCompilation extends AbstractCompilation {
         solcJsonInput: this.jsonInput,
         forceEmscripten,
       });
-      const editedContract =
-        editedContractCompilerOutput.contracts[this.compilationTarget.path][
-          this.compilationTarget.name
-        ];
+      const editedContract = findContractInCompilerOutput(
+        editedContractCompilerOutput,
+        this.compilationTarget,
+      ) as SolidityOutputContract;
 
       const editedContractAuxdatasFromCompilerOutput =
         findAuxdatasInLegacyAssembly(editedContract.evm.legacyAssembly);

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -867,8 +867,7 @@ export class Verification {
             bytecode: {
               sourceMap: (
                 contractCompilerOutput as
-                  | SolidityOutputContract
-                  | VyperOutputContract
+                  SolidityOutputContract | VyperOutputContract
               )?.evm?.bytecode?.sourceMap,
               linkReferences: (contractCompilerOutput as SolidityOutputContract)
                 ?.evm?.bytecode?.linkReferences,

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -1,4 +1,5 @@
 import type { AbstractCompilation } from '../Compilation/AbstractCompilation';
+import { findContractInCompilerOutput } from '../Compilation/AbstractCompilation';
 import { logDebug, logInfo, logWarn } from '../logger';
 import type { SourcifyChain } from '../SourcifyChain/SourcifyChain';
 import { lt } from 'semver';
@@ -425,10 +426,10 @@ export class Verification {
           checkJsonInput,
           forceEmscripten,
         );
-        const checkContract =
-          checkOutput.contracts[compilation.compilationTarget.path][
-            compilation.compilationTarget.name
-          ];
+        const checkContract = findContractInCompilerOutput(
+          checkOutput,
+          compilation.compilationTarget,
+        ) as SolidityOutputContract;
         if (
           `0x${checkContract.evm.bytecode.object}` !==
             compilation.creationBytecode ||

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -358,9 +358,9 @@ export class Verification {
   /**
    * Removes input sources that are not listed in the target's metadata.
    * Only runs after a successful match, so failed verifications never pay
-   * for it. With the optimizer enabled, unused sources can change the
-   * bytecode (extra file input bug), so in that case they are only removed
-   * after checking that the bytecode stays the same without them.
+   * for it. When the compiler settings make the extra file input bug possible,
+   * unused sources can change the bytecode, so in that case they are only
+   * removed after checking that the bytecode stays the same without them.
    * See https://github.com/argotorg/sourcify/issues/2363
    */
   private async removeUnusedSources(forceEmscripten: boolean): Promise<void> {
@@ -386,10 +386,20 @@ export class Verification {
       return;
     }
     // A check compilation is only needed when the unused sources could have
-    // affected the bytecode (extra file input bug), which can only happen
-    // with the optimizer enabled. With the optimizer disabled, the unused
-    // sources are removed without recompiling.
-    if (compilation.jsonInput.settings.optimizer?.enabled) {
+    // affected the bytecode (extra file input bug), which requires the
+    // optimizer to be enabled. From 0.8.22 on we additionally require a custom
+    // Yul optimizer step sequence: unrelated sources shift the names solc
+    // generates in the Yul IR, and only a hand-picked sequence skips the passes
+    // that would otherwise normalize that difference away.
+    // See https://github.com/argotorg/solidity/issues/15686#issuecomment-5103812547
+    const settings = compilation.jsonInput.settings;
+    const usesCustomYulOptimizerSteps =
+      settings.optimizer?.details?.yulDetails?.optimizerSteps !== undefined;
+    const mayHitExtraFileInputBug =
+      settings.optimizer?.enabled &&
+      (semver.lt(compilation.compilerVersion, '0.8.22') ||
+        usesCustomYulOptimizerSteps);
+    if (mayHitExtraFileInputBug) {
       try {
         // Compile without the unused sources, only outputting the bytecodes
         const checkJsonInput: SolidityJsonInput = {

--- a/packages/lib-sourcify/src/Verification/Verification.ts
+++ b/packages/lib-sourcify/src/Verification/Verification.ts
@@ -38,9 +38,11 @@ import type {
   SolidityOutputContract,
   FeOutputContract,
   SoliditySettings,
+  SolidityJsonInput,
   Metadata,
 } from '@ethereum-sourcify/compilers-types';
 import { SolidityMetadataContract } from '../Validation/SolidityMetadataContract';
+import { SolidityCompilation } from '../Compilation/SolidityCompilation';
 import type { VyperCompilation } from '../Compilation/VyperCompilation';
 
 function auxdataLacksMetadataOrIntegrityHash(
@@ -295,6 +297,10 @@ export class Verification {
     }
 
     if (this.creationMatch !== null || this.runtimeMatch !== null) {
+      // Remove unused sources so they don't get stored with the verified contract
+      // See https://github.com/argotorg/sourcify/issues/2363
+      await this.removeUnusedSources(forceEmscripten);
+
       logInfo('Verified contract', {
         address: this.address,
         chainId: this.sourcifyChain.chainId,
@@ -347,6 +353,108 @@ export class Verification {
     } catch (e: any) {
       // If we fail to find perfect metadata, we proceed with the verification
     }
+  }
+
+  /**
+   * Removes input sources that are not listed in the target's metadata.
+   * Only runs after a successful match, so failed verifications never pay
+   * for it. With the optimizer enabled, unused sources can change the
+   * bytecode (extra file input bug), so in that case they are only removed
+   * after checking that the bytecode stays the same without them.
+   * See https://github.com/argotorg/sourcify/issues/2363
+   */
+  private async removeUnusedSources(forceEmscripten: boolean): Promise<void> {
+    const compilation = this.compilation;
+    if (
+      !(compilation instanceof SolidityCompilation) ||
+      compilation.language !== 'Solidity'
+    ) {
+      return;
+    }
+
+    const metadataSources = compilation.metadata?.sources;
+    if (!metadataSources) {
+      return;
+    }
+
+    const inputSources = compilation.jsonInput.sources;
+    const unusedPaths = Object.keys(inputSources).filter(
+      (path) => !(path in metadataSources),
+    );
+    // Most verifications have no unused sources and stop here
+    if (unusedPaths.length === 0) {
+      return;
+    }
+    // A check compilation is only needed when the unused sources could have
+    // affected the bytecode (extra file input bug), which can only happen
+    // with the optimizer enabled. With the optimizer disabled, the unused
+    // sources are removed without recompiling.
+    if (compilation.jsonInput.settings.optimizer?.enabled) {
+      try {
+        // Compile without the unused sources, only outputting the bytecodes
+        const checkJsonInput: SolidityJsonInput = {
+          ...compilation.jsonInput,
+          sources: Object.keys(metadataSources).reduce(
+            (sources, path) => {
+              sources[path] = inputSources[path];
+              return sources;
+            },
+            {} as SolidityJsonInput['sources'],
+          ),
+          settings: {
+            ...compilation.jsonInput.settings,
+            outputSelection: {
+              '*': {
+                '*': ['evm.bytecode.object', 'evm.deployedBytecode.object'],
+              },
+            },
+          },
+        };
+        const checkOutput = await compilation.compiler.compile(
+          compilation.compilerVersion,
+          checkJsonInput,
+          forceEmscripten,
+        );
+        const checkContract =
+          checkOutput.contracts[compilation.compilationTarget.path][
+            compilation.compilationTarget.name
+          ];
+        if (
+          `0x${checkContract.evm.bytecode.object}` !==
+            compilation.creationBytecode ||
+          `0x${checkContract.evm.deployedBytecode?.object}` !==
+            compilation.runtimeBytecode
+        ) {
+          logInfo(
+            'Unused sources affect the bytecode (extra file input bug), keeping all sources',
+            {
+              address: this.address,
+              chainId: this.sourcifyChain.chainId,
+              unusedPaths,
+            },
+          );
+          return;
+        }
+      } catch (e: any) {
+        logWarn('Error checking unused sources, keeping all sources', {
+          address: this.address,
+          chainId: this.sourcifyChain.chainId,
+          unusedPaths,
+          error: e.message,
+        });
+        return;
+      }
+    }
+
+    for (const path of unusedPaths) {
+      delete compilation.jsonInput.sources[path];
+      delete compilation.compilerOutput?.sources?.[path];
+    }
+    logInfo('Removed unused sources from the compilation', {
+      address: this.address,
+      chainId: this.sourcifyChain.chainId,
+      unusedPaths,
+    });
   }
 
   handleSolidityExtraFileInputBug(): SolidityBugType {
@@ -759,7 +867,8 @@ export class Verification {
             bytecode: {
               sourceMap: (
                 contractCompilerOutput as
-                  SolidityOutputContract | VyperOutputContract
+                  | SolidityOutputContract
+                  | VyperOutputContract
               )?.evm?.bytecode?.sourceMap,
               linkReferences: (contractCompilerOutput as SolidityOutputContract)
                 ?.evm?.bytecode?.linkReferences,

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -694,6 +694,64 @@ describe('Verification Class Tests', () => {
       );
     });
 
+    it('should remove unused sources for solc >=0.8.22 without a check compilation', async () => {
+      // CBORInTheMiddle is compiled with 0.8.26 and the optimizer enabled but
+      // solc's default Yul optimizer steps, so the extra file input bug cannot
+      // occur and the check compilation must be skipped
+      const contractFolderPath = path.join(
+        __dirname,
+        '..',
+        'sources',
+        'CBORInTheMiddle',
+      );
+      const unrelatedSourcePath = 'contracts/Unrelated.sol';
+      const { contractAddress } = await deployFromAbiAndBytecode(
+        signer,
+        contractFolderPath,
+      );
+
+      const compilation = await getCompilationFromMetadata(contractFolderPath);
+      const neededSourcePaths = Object.keys(compilation.jsonInput.sources);
+
+      // Add a source that is unrelated to the compilation target
+      compilation.jsonInput.sources[unrelatedSourcePath] = {
+        content:
+          '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract Unrelated { uint256 number; }\n',
+      };
+
+      // The check compilation is the only one that drops the unrelated source.
+      // Its sources must be recorded as the call happens because the input is
+      // mutated afterwards, and this contract also recompiles to locate its
+      // CBOR auxdata, so counting the calls is not enough.
+      const compiledSourcePaths: string[][] = [];
+      const originalCompile = compilation.compiler.compile.bind(
+        compilation.compiler,
+      );
+      sandbox
+        .stub(compilation.compiler, 'compile')
+        .callsFake(async (version, jsonInput, forceEmscripten) => {
+          compiledSourcePaths.push(Object.keys(jsonInput.sources));
+          return originalCompile(version, jsonInput, forceEmscripten);
+        });
+
+      const verification = new Verification(
+        compilation,
+        sourcifyChainHardhat,
+        contractAddress,
+      );
+      await verification.verify();
+
+      expect(verification.status.runtimeMatch).to.equal('perfect');
+      expect(Object.keys(verification.compilation.sources)).to.have.members(
+        neededSourcePaths,
+      );
+      expect(
+        compiledSourcePaths.every((paths) =>
+          paths.includes(unrelatedSourcePath),
+        ),
+      ).to.be.true;
+    });
+
     it('should NOT diagnose extra_file_input_bug when bytecodes have no CBOR metadata (pre-0.4.7)', async () => {
       // Pre-0.4.7 contracts have no CBOR metadata. splitAuxdata returns a single-element array
       // for such bytecodes, so the auxdata at index [1] is undefined.

--- a/packages/lib-sourcify/test/Verification/Verification.spec.ts
+++ b/packages/lib-sourcify/test/Verification/Verification.spec.ts
@@ -604,6 +604,94 @@ describe('Verification Class Tests', () => {
           creationMatch: null,
         },
       });
+
+      // All sources must be kept because they affect the bytecode
+      // due to the extra file input bug
+      expect(Object.keys(verification.compilation.sources)).to.have.members(
+        Object.keys(additionalSources),
+      );
+    });
+
+    it('should remove sources unused by the compilation target', async () => {
+      const contractFolderPath = path.join(
+        __dirname,
+        '..',
+        'sources',
+        'Storage',
+      );
+      const { contractAddress } = await deployFromAbiAndBytecode(
+        signer,
+        contractFolderPath,
+      );
+
+      const compilation = await getCompilationFromMetadata(contractFolderPath);
+      const neededSourcePaths = Object.keys(compilation.jsonInput.sources);
+
+      // Add a source that is unrelated to the compilation target
+      compilation.jsonInput.sources['contracts/Unrelated.sol'] = {
+        content:
+          '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.4;\ncontract Unrelated { uint256 number; }\n',
+      };
+
+      const compileSpy = sandbox.spy(compilation.compiler, 'compile');
+
+      const verification = new Verification(
+        compilation,
+        sourcifyChainHardhat,
+        contractAddress,
+      );
+      await verification.verify();
+
+      expectVerification(verification, {
+        status: {
+          runtimeMatch: 'perfect',
+          creationMatch: null,
+        },
+      });
+
+      // Only the sources listed in the metadata should be kept
+      expect(Object.keys(verification.compilation.sources)).to.have.members(
+        neededSourcePaths,
+      );
+      expect(
+        Object.keys(verification.export().compilation.sources),
+      ).to.have.members(neededSourcePaths);
+      // With the optimizer disabled there must be no check compilation
+      expect(compileSpy.callCount).to.equal(1);
+    });
+
+    it('should remove unused sources with the optimizer enabled after a check compilation', async () => {
+      const contractFolderPath = path.join(
+        __dirname,
+        '..',
+        'sources',
+        'CallProtectionForLibraries',
+      );
+      const { contractAddress } = await deployFromAbiAndBytecode(
+        signer,
+        contractFolderPath,
+      );
+
+      const compilation = await getCompilationFromMetadata(contractFolderPath);
+      const neededSourcePaths = Object.keys(compilation.jsonInput.sources);
+
+      // Add a source that is unrelated to the compilation target
+      compilation.jsonInput.sources['contracts/Unrelated.sol'] = {
+        content:
+          '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract Unrelated { uint256 number; }\n',
+      };
+
+      const verification = new Verification(
+        compilation,
+        sourcifyChainHardhat,
+        contractAddress,
+      );
+      await verification.verify();
+
+      expect(verification.status.runtimeMatch).to.equal('perfect');
+      expect(Object.keys(verification.compilation.sources)).to.have.members(
+        neededSourcePaths,
+      );
     });
 
     it('should NOT diagnose extra_file_input_bug when bytecodes have no CBOR metadata (pre-0.4.7)', async () => {

--- a/services/server/test/integration/apiv2/verification/verify.json.spec.ts
+++ b/services/server/test/integration/apiv2/verification/verify.json.spec.ts
@@ -70,6 +70,58 @@ describe("POST /v2/verify/:chainId/:address", function () {
     );
   });
 
+  it("should not store sources that are unused by the compilation target", async () => {
+    const { resolveWorkers } = makeWorkersWait();
+
+    const jsonInput = JSON.parse(
+      JSON.stringify(chainFixture.defaultContractJsonInput),
+    );
+    // Add a source that is unrelated to the compilation target
+    jsonInput.sources["contracts/Unrelated.sol"] = {
+      content:
+        "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.4;\ncontract Unrelated { uint256 number; }\n",
+    };
+
+    const verifyRes = await chai
+      .request(serverFixture.server.app)
+      .post(
+        `/v2/verify/${chainFixture.chainId}/${chainFixture.defaultContractAddress}`,
+      )
+      .send({
+        stdJsonInput: jsonInput,
+        compilerVersion:
+          chainFixture.defaultContractMetadataObject.compiler.version,
+        contractIdentifier: Object.entries(
+          chainFixture.defaultContractMetadataObject.settings.compilationTarget,
+        )[0].join(":"),
+        creationTransactionHash: chainFixture.defaultContractCreatorTx,
+      });
+
+    await assertJobVerification(
+      serverFixture,
+      verifyRes,
+      resolveWorkers,
+      chainFixture.chainId,
+      chainFixture.defaultContractAddress,
+      "exact_match",
+    );
+
+    // Only the sources listed in the metadata of the compilation target
+    // should be stored
+    const contractRes = await chai
+      .request(serverFixture.server.app)
+      .get(
+        `/v2/contract/${chainFixture.chainId}/${chainFixture.defaultContractAddress}?fields=sources`,
+      );
+
+    chai.expect(contractRes.status).to.equal(200);
+    chai
+      .expect(Object.keys(contractRes.body.sources))
+      .to.have.members(
+        Object.keys(chainFixture.defaultContractMetadataObject.sources),
+      );
+  });
+
   it("should verify a Vyper contract", async () => {
     const { resolveWorkers } = makeWorkersWait();
 


### PR DESCRIPTION
## Summary

Fixes #2363

Until now, all sources of a standard JSON input were stored with the verified contract, even sources completely unrelated to the deployed contract. Unrelated sources can hinder contract reviews and could be added maliciously on purpose.

After a successful match, `Verification` now removes the input sources that are not listed in the compilation target's metadata, so only the sources needed for the verification get stored. This covers all entry points (v2 std-json, v1 `/verify/solc-json`, Etherscan import) since they all go through `Verification.verify()`. No storage-layer changes are needed: the storage services already persist `VerificationExport.compilation.sources`.

## The extra file input bug case

As noted in the issue, unused sources cannot always be removed: with the optimizer enabled they can affect the bytecode (extra file input bug, e.g. argotorg/solidity#14494, argotorg/solidity#15686). In that case the sources are needed to reproduce the onchain bytecode and must all be kept.

Since the bug is undetectable when the user submits the full original input (the match simply succeeds), **a check compilation without the unused sources decides whether they are removable**. To keep the cost minimal, it only runs when all of these hold, and is paid once per contract at first verification:

- the verification succeeded (failed jobs never pay for it)
- the input contains unused sources **this gate is the most important one, this will avoid running the recompilation on most cases**
- the optimizer is enabled (the bug cannot occur otherwise)
- solc is below 0.8.22, or the input sets a custom Yul optimizer step sequence

### Why the version and custom-steps gate

Above 0.8.22 the bug only reproduces with a custom Yul optimizer step sequence. That isn't a coincidence: solc names the functions in its intermediate output using a counter that runs across every file in the input, so adding unrelated files renames them. A cleanup pass later shortens those names and makes different choices depending on what it started with. Normally none of this survives, because the optimizer rewrites the code thoroughly enough to erase it — a near-empty sequence like `"u"` skips exactly those passes, so the renaming makes it through to the bytecode.

This was checked against argotorg/solidity#15686 on solc 0.8.36, which still reproduces there but only with `settings.optimizer.details.yulDetails.optimizerSteps` set ([details](https://github.com/argotorg/solidity/issues/15686#issuecomment-5103812547)).

Measured against production traffic, unused sources appear in ~4.2% of recent matches and the optimizer is on for ~53%, so the old gate fired on ~2.7% of verifications. With this gate, modern std-json submissions using default optimizer steps no longer pay for the second compilation at all.

The check compilation itself is cheaper than the main one: it compiles only the reduced source set and outputs only `evm.bytecode.object` and `evm.deployedBytecode.object`.
