### PR TITLE
docs: point CLAUDE.md at the committed database schema dump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,21 @@ npm run monitor:start
 - Uses dbmate for migrations and schema management
 - Supports both full and partial verification matches
 
+**The authoritative schema is the committed dump at [`services/database/sourcify-database.sql`](services/database/sourcify-database.sql).** Read it to answer schema questions instead of querying a live database. dbmate regenerates it on `npm run migrate:up`, and it must be committed alongside any new migration (see [`services/database/README.md`](services/database/README.md)).
+
+How the tables join:
+
+- `sourcify_matches.verified_contract_id` → `verified_contracts.id` (Sourcify-specific match info: `creation_match`/`runtime_match` quality, `chain_id`, and the contract's `metadata`)
+- `verified_contracts.compilation_id` → `compiled_contracts.id`, and `verified_contracts.deployment_id` → `contract_deployments.id`
+- `compiled_contracts_sources` (`compilation_id`, `path`, `source_hash`) is the source set stored for a compilation; join `source_hash` → `sources.source_hash` for the actual content
+- `code` holds bytecode, referenced via `creation_code_hash`/`runtime_code_hash` by both `compiled_contracts` (compiled) and `contracts` (onchain); reach the latter through `contract_deployments.contract_id` → `contracts.id`
+
+Notable columns when analysing verifications:
+
+- `compiled_contracts.compiler_settings` (jsonb) — the standard-JSON `settings`, e.g. `compiler_settings->'optimizer'->>'enabled'`
+- `sourcify_matches.metadata` (json) — the contract metadata; `metadata->'sources'` lists only the sources the target actually uses, so it differs from `compiled_contracts_sources` when the submitted input carried extra files. Nullable, so filter out NULLs before comparing source sets.
+- `compiled_contracts.language` — `solidity` | `vyper` | `yul` | `fe`
+
 ### Storage Services
 
 The server supports multiple storage backends:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,12 +119,6 @@ How the tables join:
 - `compiled_contracts_sources` (`compilation_id`, `path`, `source_hash`) is the source set stored for a compilation; join `source_hash` → `sources.source_hash` for the actual content
 - `code` holds bytecode, referenced via `creation_code_hash`/`runtime_code_hash` by both `compiled_contracts` (compiled) and `contracts` (onchain); reach the latter through `contract_deployments.contract_id` → `contracts.id`
 
-Notable columns when analysing verifications:
-
-- `compiled_contracts.compiler_settings` (jsonb) — the standard-JSON `settings`, e.g. `compiler_settings->'optimizer'->>'enabled'`
-- `sourcify_matches.metadata` (json) — the contract metadata; `metadata->'sources'` lists only the sources the target actually uses, so it differs from `compiled_contracts_sources` when the submitted input carried extra files. Nullable, so filter out NULLs before comparing source sets.
-- `compiled_contracts.language` — `solidity` | `vyper` | `yul` | `fe`
-
 ### Storage Services
 
 The server supports multiple storage backends:


### PR DESCRIPTION
## Summary

CLAUDE.md listed the key database tables but never said where the schema itself lives. The result is that schema questions get answered by probing a live database rather than reading the dump that is already committed at `services/database/sourcify-database.sql`.

This adds, under **Database Architecture**:

- A pointer to `services/database/sourcify-database.sql` as the authoritative schema, and the note that dbmate regenerates it on `migrate:up` and it must be committed with any new migration.
- The join paths between the core tables (`sourcify_matches` → `verified_contracts` → `compiled_contracts` / `contract_deployments`, plus `compiled_contracts_sources` → `sources` and the `code` table).

## Why

`services/database/README.md` already documents the dump, but nothing in CLAUDE.md points there, so it is easy to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
